### PR TITLE
Improve how we determine appropriate flags for pgrep commands

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
+++ b/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
@@ -53,6 +53,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrep(String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public List<Long> pgrep(String commandLine) {
         return Processes.pgrep(commandLine);
@@ -60,6 +62,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrep(String, String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public List<Long> pgrep(String user, String commandLine) {
         return Processes.pgrep(user, commandLine);
@@ -67,6 +71,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrepWithSingleResult(String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public Optional<Long> pgrepWithSingleResult(String commandLine) {
         return Processes.pgrepWithSingleResult(commandLine);
@@ -74,6 +80,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrepWithSingleResult(String, String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public Optional<Long> pgrepWithSingleResult(String user, String commandLine) {
         return Processes.pgrepWithSingleResult(user, commandLine);
@@ -81,6 +89,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrepList(String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public List<String> pgrepList(String commandLine) {
         return Processes.pgrepList(commandLine);
@@ -88,6 +98,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrepList(String, String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public List<String> pgrepList(String user, String commandLine) {
         return Processes.pgrepList(user, commandLine);
@@ -95,6 +107,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrepParsedList(String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public List<Pair<Long, String>> pgrepParsedList(String commandLine) {
         return Processes.pgrepParsedList(commandLine);
@@ -102,6 +116,8 @@ public class ProcessHelper {
 
     /**
      * @see Processes#pgrepParsedList(String, String)
+     * @see Processes#wasPgrepFlagsCheckSuccessful()
+     * @see Processes#getPgrepFlags()
      */
     public List<Pair<Long, String>> pgrepParsedList(String user, String commandLine) {
         return Processes.pgrepParsedList(user, commandLine);

--- a/src/main/java/org/kiwiproject/base/process/Processes.java
+++ b/src/main/java/org/kiwiproject/base/process/Processes.java
@@ -119,11 +119,12 @@ public class Processes {
         }
     }
 
-    private static void logPgrepCheckInfo(String flags,
-                                          String pid,
-                                          List<String> stdOutLines,
-                                          List<String> stdErrLines,
-                                          String expectedCommand) {
+    @VisibleForTesting
+    static void logPgrepCheckInfo(String flags,
+                                  String pid,
+                                  List<String> stdOutLines,
+                                  List<String> stdErrLines,
+                                  String expectedCommand) {
         LOG.trace("Checking pgrep flags [{}] for command [{}] with pid {}", flags, expectedCommand, pid);
         LOG.trace("pid {} stdOut: {}", pid, stdOutLines);
         if (stdErrLines.isEmpty()) {
@@ -147,7 +148,8 @@ public class Processes {
         }
     }
 
-    private static void logPgrepFlagWarnings() {
+    @VisibleForTesting
+    static void logPgrepFlagWarnings() {
         LOG.warn("Neither -fa nor -fl flags produced PID and full command line, so pgrep commands will behave (or fail) in unexpected ways!");
         LOG.warn("If you see this warning, DO NOT use any of the pgrep-related methods in Processes or ProcessHelper and submit a bug report.");
         LOG.warn("Turn on TRACE-level logging to see standard output and error for pgrep commands");

--- a/src/main/java/org/kiwiproject/base/process/Processes.java
+++ b/src/main/java/org/kiwiproject/base/process/Processes.java
@@ -154,7 +154,7 @@ public class Processes {
             LOG.trace("Killing sleeper process ({}) used to determine pgrep flags", processId);
             kill(processId, KillSignal.SIGTERM, KillTimeoutAction.NO_OP);
         } catch (Exception e) {
-            LOG.warn("Error killing sleeper process ({}) used to determined pgrep flags", processId, e);
+            LOG.warn("Error killing sleeper process ({}) used to determine pgrep flags", processId, e);
         }
     }
 

--- a/src/test/java/org/kiwiproject/base/process/ProcessHelperTest.java
+++ b/src/test/java/org/kiwiproject/base/process/ProcessHelperTest.java
@@ -12,7 +12,10 @@ import static org.kiwiproject.collect.KiwiLists.third;
 import static org.kiwiproject.io.KiwiIO.emptyByteArrayInputStream;
 import static org.kiwiproject.io.KiwiIO.newByteArrayInputStreamOfLines;
 import static org.kiwiproject.io.KiwiIO.readLinesFromInputStreamOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.StandardSystemProperty;
@@ -65,6 +68,18 @@ public class ProcessHelperTest {
         Optional<Integer> exitCode = processes.waitForExit(process, 25, TimeUnit.MILLISECONDS);
 
         assertThat(exitCode).isEmpty();
+    }
+
+    @Test
+    void testWaitForExit_WhenInterruptedExceptionThrown() throws InterruptedException {
+        var process = mock(Process.class);
+        when(process.waitFor(anyLong(), any(TimeUnit.class))).thenThrow(new InterruptedException("sorry"));
+
+        var timeout = 2L;
+        var timeUnit = TimeUnit.SECONDS;
+        assertThat(processes.waitForExit(process, timeout, timeUnit)).isEmpty();
+
+        verify(process).waitFor(timeout, timeUnit);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
+++ b/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @DisplayName("Processes")
@@ -21,6 +22,18 @@ class ProcessesTest {
     @BeforeEach
     void setUp() {
         assumeTrue(SystemUtils.IS_OS_UNIX, "This test should only run on UNIX or UNIX-like systems");
+    }
+
+    @Test
+    void testGetPgrepFlags() {
+        assertThat(Processes.getPgrepFlags()).isIn(List.of("-fa", "-fl"));
+    }
+
+    @Test
+    void testWasPgrepCheckSuccessful() {
+        assertThat(Processes.wasPgrepFlagsCheckSuccessful())
+                .describedAs("We expect this to always be true...")
+                .isTrue();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
+++ b/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.base.process;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.when;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -34,6 +36,21 @@ class ProcessesTest {
         assertThat(Processes.wasPgrepFlagsCheckSuccessful())
                 .describedAs("We expect this to always be true...")
                 .isTrue();
+    }
+
+    @RepeatedTest(5)
+    void testLogPgrepFlagWarnings() {
+        assertThatCode(Processes::logPgrepFlagWarnings).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testLogPgrepCheckInfo() {
+        assertThatCode(() -> Processes.logPgrepCheckInfo(
+                "-fl",
+                "12345",
+                List.of(),
+                List.of("PEBKAC (problem exists between keyboard and chair)", "User error"),
+                "doit -foo -bar -baz")).doesNotThrowAnyException();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
+++ b/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,29 @@ class ProcessesTest {
         assertThat(Processes.wasPgrepFlagsCheckSuccessful())
                 .describedAs("We expect this to always be true...")
                 .isTrue();
+    }
+
+    @Nested
+    class ChoosePgrepFlags {
+
+        @Test
+        void shouldIndicateSuccess_WhenNonNullFlags() {
+            var flags = "-fl";
+            var result = Processes.choosePgrepFlags(flags);
+            assertThat(result.getLeft()).isEqualTo(flags);
+            assertThat(result.getRight()).isTrue();
+        }
+
+        @Test
+        void shouldIndicateUnsuccessful_WhenNullFlags() {
+            var result = Processes.choosePgrepFlags(null);
+            assertThat(result.getLeft())
+                    .describedAs("default should be -fa")
+                    .isEqualTo("-fa");
+            assertThat(result.getRight())
+                    .describedAs("should indicate not successful")
+                    .isFalse();
+        }
     }
 
     @RepeatedTest(5)


### PR DESCRIPTION
This improves how we determine which command line flags to
use when executing pgrep commands, specifically in order to
match and print the full command line, e.g. given a "sleep 123"
process with pid 4567 we want to use the pgrep flags so that
the command results in the format: [pid full-command], in this
example it would be "4567 sleep 123". We try the -fa flags first,
then -fl. If none match we log warnings but have chosen NOT to
throw an exception. We are also choosing to log any stderr at
WARN level but otherwise are not using it in the determination.
If there is stdErr, it's likely the check failed anyway.

Also added static wasPgrepFlagsCheckSuccessful() and
getPgrepFlags() to Processes to allow checking whether
the flags were successfully determined, and what those
flags actually are, respectively.

Fixes #38