### PR TITLE
Add TlsContextConfiguration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,10 +10,12 @@
     <packaging>jar</packaging>
 
     <properties>
+        <!-- Versions for required dependencies -->
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <guava.version>28.2-jre</guava.version>
         <commons-lang3.version>3.10</commons-lang3.version>
 
+        <!-- Versions for provided/optional dependencies -->
         <commons-text.version>1.8</commons-text.version>
         <dropwizard.version>2.0.7</dropwizard.version>
         <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
@@ -34,11 +36,13 @@
 
         <lombok.version>1.18.12</lombok.version>
 
+        <!-- Versions for test dependencies -->
         <mockito.version>3.3.0</mockito.version>
         <assertj.version>3.15.0</assertj.version>
         <awaitility.version>4.0.2</awaitility.version>
         <junit.jupiter.version>5.6.0</junit.jupiter.version>
 
+        <!-- Build properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -12,11 +12,32 @@
     <properties>
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <guava.version>28.2-jre</guava.version>
-        <commons-lang3.version>3.9</commons-lang3.version>
-        <junit.jupiter.version>5.6.0</junit.jupiter.version>
-        <assertj.version>3.15.0</assertj.version>
+        <commons-lang3.version>3.10</commons-lang3.version>
+
+        <commons-text.version>1.8</commons-text.version>
+        <dropwizard.version>2.0.7</dropwizard.version>
+        <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
+        <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
+        <httpclient.version>4.5.12</httpclient.version>
+        <jackson.version>2.10.3</jackson.version>
+        <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
+        <jakarta-el.version>3.0.3</jakarta-el.version>
+        <jakarta.xml.bind-api.version>2.3.3</jakarta.xml.bind-api.version>
+        <javassist.version>3.27.0-GA</javassist.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
+        <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
+        <joda-time.version>2.10.5</joda-time.version>
+        <jsr250-api.version>1.0</jsr250-api.version>
+        <jsr305.version>3.0.2</jsr305.version>
+        <logback-classic.version>1.2.3</logback-classic.version>
+        <spring-beans.version>5.2.5.RELEASE</spring-beans.version>
+
+        <lombok.version>1.18.12</lombok.version>
+
         <mockito.version>3.3.0</mockito.version>
+        <assertj.version>3.15.0</assertj.version>
         <awaitility.version>4.0.2</awaitility.version>
+        <junit.jupiter.version>5.6.0</junit.jupiter.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -24,10 +45,29 @@
 
     <dependencies>
 
+        <!--
+        NOTES:
+        1. Exclusions are due to version conflicts (found using Maven Enforcer plugin)
+        2. When there are version conflicts, we exclude that dependency, then add an explicit dependency.
+        3. The only required dependencies at the moment are guava and commons-lang3.
+        4. All other third party dependencies have 'provided' scope such that we won't always
+           bring in every single transitive dependency.
+        5. Because most third party dependencies are provided, you will need to add them to your
+           own project depending on which parts of Kiwi you're using.
+        -->
+
+        <!-- required dependencies -->
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -45,30 +85,160 @@
         <!-- provided & optional dependencies -->
 
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-client</artifactId>
+            <version>${dropwizard.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-jaxb-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.annotation</groupId>
+                    <artifactId>jakarta.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>jakarta.el</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.hibernate.validator</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.javassist</groupId>
+                    <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation-api.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda-time.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>${jakarta-el.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>${javassist.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml</groupId>
+                    <artifactId>classmate</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
+            <version>${javax.ws.rs-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.3</version>
+            <version>${jakarta.xml.bind-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
-            <version>2.3.4</version>
+            <version>${error_prone_annotations.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -76,7 +246,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
+            <version>${javax.annotation-api.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -84,7 +254,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>jsr250-api</artifactId>
-            <version>1.0</version>
+            <version>${jsr250-api.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -92,7 +262,7 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
+            <version>${jsr305.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -100,7 +270,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
-            <version>5.2.5.RELEASE</version>
+            <version>${spring-beans.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -109,7 +279,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>${logback-classic.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -122,8 +292,14 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.8</version>
+            <version>${commons-text.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -173,6 +349,23 @@
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <version>${dropwizard.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
@@ -1,0 +1,163 @@
+package org.kiwiproject.config;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import io.dropwizard.client.ssl.TlsConfiguration;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.http.protocol.HttpContext;
+import org.kiwiproject.security.KeyAndTrustStoreConfigProvider;
+import org.kiwiproject.security.KeyStoreType;
+import org.kiwiproject.security.SSLContextProtocol;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.net.Socket;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Configuration for standard/common properties required for secure TLS connections.
+ */
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)  // for Builder (b/c also need no-args constructor)
+@ToString(exclude = {"keyStorePassword", "trustStorePassword"})
+public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
+
+    /**
+     * The TLS/SSL protocol to use. Default is {@link SSLContextProtocol#TLS_1_2}.
+     *
+     * @see SSLContextProtocol
+     */
+    @NotBlank
+    @Builder.Default
+    private String protocol = SSLContextProtocol.TLS_1_2.value;
+
+    /**
+     * Absolute path to the key store.
+     */
+    private String keyStorePath;
+
+    /**
+     * Key store password.
+     */
+    private String keyStorePassword;
+
+    /**
+     * Key store type. Defaults to {@link KeyStoreType#JKS}.
+     *
+     * @see KeyStoreType
+     */
+    @NotBlank
+    @Builder.Default
+    private String keyStoreType = KeyStoreType.JKS.value;
+
+    /**
+     * Absolute path tot the trust store.
+     */
+    @NotBlank
+    private String trustStorePath;
+
+    /**
+     * Trust store password.
+     */
+    @NotNull
+    private String trustStorePassword;
+
+    /**
+     * Trust store type. Defaults to {@link KeyStoreType#JKS}.
+     *
+     * @see KeyStoreType
+     */
+    @NotBlank
+    @Builder.Default
+    private String trustStoreType = KeyStoreType.JKS.value;
+
+    /**
+     * Should host names be verified when establishing secure connections? Default is {@code true}.
+     */
+    @Builder.Default
+    private boolean verifyHostname = true;
+
+    /**
+     * List of supported protocols. It can be {@code null}. See the implementation note for why.
+     *
+     * @implNote Yes, this is null by default. This is due to the Dropwizard {@link TlsConfiguration} which has this
+     * same property null by default; I suspect this is ultimately due to the (unfortunate) way in which Apache
+     * HttpClient's {@link org.apache.http.conn.ssl.SSLConnectionSocketFactory} accepts {@code supportedProtocols}
+     * in its constructors as arrays that are supposed to be null if you aren't specifying a specific list of them.
+     * The HttpClient code does an explicit null check on the {@code supportedProtocols} in
+     * {@link org.apache.http.conn.ssl.SSLConnectionSocketFactory#createLayeredSocket(Socket, String, int, HttpContext)}.
+     * You will need to look at the source code, as the JavaDoc doesn't mention this tidbit, nor do the constructors
+     * since they don't have any documentation regarding their arguments. If you don't like reading source code of the
+     * open source tools you rely on, then please close this file, log out, and change careers.
+     */
+    private List<String> supportedProtocols;
+
+    /**
+     * Given a Dropwizard {@link TlsConfiguration}, create a new {@link TlsContextConfiguration}.
+     * <p>
+     * Even though {@link TlsContextConfiguration} does not permit null trust store properties (per the validation
+     * annotations), the {@link TlsConfiguration} does. If we encounter this sitation, we will be lenient; even though
+     * this could possibly cause downstream problems, we will jsut assume the caller knows what it is doing.
+     *
+     * @implNote Currently we do not support {@code supportedCiphers} or {@code certAlias}, which Dropwizard does.
+     */
+    public static TlsContextConfiguration fromDropwizardTlsConfiguration(TlsConfiguration tlsConfig) {
+        checkArgumentNotNull(tlsConfig, "TlsConfiguration cannot be null");
+
+        return TlsContextConfiguration.builder()
+                .protocol(tlsConfig.getProtocol())
+                .keyStorePath(absolutePathOrNull(tlsConfig.getKeyStorePath()))
+                .keyStorePassword(tlsConfig.getKeyStorePassword())
+                .keyStoreType(tlsConfig.getKeyStoreType())
+                .trustStorePath(absolutePathOrNull(tlsConfig.getTrustStorePath()))
+                .trustStorePassword(tlsConfig.getTrustStorePassword())
+                .trustStoreType(tlsConfig.getTrustStoreType())
+                .verifyHostname(tlsConfig.isVerifyHostname())
+                .supportedProtocols(tlsConfig.getSupportedProtocols())
+                .build();
+    }
+
+    private static String absolutePathOrNull(@Nullable File nullableFile) {
+        return Optional.ofNullable(nullableFile).map(File::getAbsolutePath).orElse(null);
+    }
+
+    /**
+     * Convert this {@link TlsContextConfiguration} into a Dropwizard {@link TlsConfiguration} object. Assumes that
+     * thia object is valid.
+     *
+     * @implNote Requires dropwizard-client as a dependency
+     */
+    public TlsConfiguration toDropwizardTlsConfiguration() {
+        var tlsConfig = new TlsConfiguration();
+
+        tlsConfig.setProtocol(protocol);
+
+        var keyStoreFile = Optional.ofNullable(keyStorePath).map(File::new).orElse(null);
+        tlsConfig.setKeyStorePath(keyStoreFile);
+        tlsConfig.setKeyStorePassword(keyStorePassword);
+        tlsConfig.setKeyStoreType(keyStoreType);
+
+        tlsConfig.setTrustStorePath(new File(trustStorePath));
+        tlsConfig.setTrustStorePassword(trustStorePassword);
+        tlsConfig.setTrustStoreType(trustStoreType);
+
+        tlsConfig.setVerifyHostname(verifyHostname);
+        tlsConfig.setSupportedProtocols(supportedProtocols);
+
+        return tlsConfig;
+    }
+
+    // TODO Add toSslContextConfiguration once SSLContextConfiguration is added.
+}

--- a/src/test/java/org/kiwiproject/config/TlsContextConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/config/TlsContextConfigurationTest.java
@@ -1,0 +1,382 @@
+package org.kiwiproject.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.kiwiproject.validation.ValidationTestHelper.assertNoViolations;
+import static org.kiwiproject.validation.ValidationTestHelper.assertOnePropertyViolation;
+import static org.kiwiproject.validation.ValidationTestHelper.newValidator;
+
+import io.dropwizard.client.ssl.TlsConfiguration;
+import io.dropwizard.testing.FixtureHelpers;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.security.KeyStoreType;
+import org.kiwiproject.security.SSLContextProtocol;
+import org.kiwiproject.security.SecureTestConstants;
+import org.yaml.snakeyaml.Yaml;
+
+import javax.validation.Validator;
+import java.io.File;
+import java.util.List;
+
+@DisplayName("TlsContextConfiguration")
+class TlsContextConfigurationTest {
+
+    private static final Validator VALIDATOR = newValidator();
+
+    @Nested
+    class NoArgsConstructor {
+
+        @Test
+        void shouldHaveDefaultValues() {
+            assertDefaultValues(new TlsContextConfiguration());
+        }
+    }
+
+    @Nested
+    class Builder {
+
+        @Test
+        void shouldHaveDefaultValues() {
+            assertDefaultValues(TlsContextConfiguration.builder().build());
+        }
+    }
+
+    @Nested
+    class ToString {
+
+        private TlsContextConfiguration config;
+
+        @BeforeEach
+        void setUp() {
+            config = loadTlsContextConfiguration("TlsContextConfigurationTest/full-tls-config.yml");
+        }
+
+        @Test
+        void shouldNotContainKeyStorePassword() {
+            var string = config.toString();
+            assertThat(string)
+                    .doesNotContain("keyStorePassword")
+                    .doesNotContain(config.getKeyStorePassword());
+        }
+
+        @Test
+        void shouldNotContainTrustKeyStorePassword() {
+            var string = config.toString();
+            assertThat(string)
+                    .doesNotContain("trustStorePassword")
+                    .doesNotContain(config.getTrustStorePassword());
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")  // must be public for Yaml to instantiate
+    @Getter
+    @Setter
+    public static class SampleAppConfig {
+        private TlsContextConfiguration tlsConfig;
+    }
+
+    @Nested
+    class FromYaml {
+
+        @Test
+        void shouldDeserializeMinimalConfig() {
+            var tlsConfig = loadTlsContextConfiguration("TlsContextConfigurationTest/minimal-tls-config.yml");
+
+            assertDefaultValues(tlsConfig);
+
+            assertThat(tlsConfig.getKeyStorePath()).isEqualTo("/path/to/keystore.jks");
+            assertThat(tlsConfig.getKeyStorePassword()).isEqualTo("ksPassWd");
+            assertThat(tlsConfig.getTrustStorePath()).isEqualTo("/path/to/truststore.jks");
+            assertThat(tlsConfig.getTrustStorePassword()).isEqualTo("tsPass100");
+        }
+
+        @Test
+        void shouldDeserializeMinimalWithNoKeyStorePropertiesConfig() {
+            var tlsConfig = loadTlsContextConfiguration("TlsContextConfigurationTest/minimal-no-key-props-tls-config.yml");
+
+            assertDefaultValues(tlsConfig);
+
+            assertThat(tlsConfig.getKeyStorePath()).isNull();
+            assertThat(tlsConfig.getKeyStorePassword()).isNull();
+        }
+
+        @Test
+        void shouldDeserializeFullConfig() {
+            var tlsConfig = loadTlsContextConfiguration("TlsContextConfigurationTest/full-tls-config.yml");
+
+            assertThat(tlsConfig.getProtocol()).isEqualTo("TLSv1.3");
+            assertThat(tlsConfig.getKeyStorePath()).isEqualTo("/path/to/keystore.pkcs12");
+            assertThat(tlsConfig.getKeyStorePassword()).isEqualTo("ksPassWd");
+            assertThat(tlsConfig.getKeyStoreType()).isEqualTo("PKCS12");
+            assertThat(tlsConfig.getTrustStorePath()).isEqualTo("/path/to/truststore.pkcs12");
+            assertThat(tlsConfig.getTrustStorePassword()).isEqualTo("tsPass100");
+            assertThat(tlsConfig.getTrustStoreType()).isEqualTo("PKCS12");
+            assertThat(tlsConfig.isVerifyHostname()).isFalse();
+            assertThat(tlsConfig.getSupportedProtocols()).containsOnly(
+                    SSLContextProtocol.TLS_1_2.value,
+                    SSLContextProtocol.TLS_1_3.value
+            );
+        }
+    }
+
+    private static void assertDefaultValues(TlsContextConfiguration config) {
+        assertThat(config.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value);
+        assertThat(config.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value);
+        assertThat(config.getTrustStoreType()).isEqualTo(KeyStoreType.JKS.value);
+        assertThat(config.isVerifyHostname()).isTrue();
+        assertThat(config.getSupportedProtocols()).isNull();
+    }
+
+    @Nested
+    class Validation {
+
+        private TlsContextConfiguration config;
+
+        @BeforeEach
+        void setUp() {
+            config = new TlsContextConfiguration();
+        }
+
+        @Nested
+        class ShouldPass {
+
+            @Test
+            void whenConfigurationIsValid() {
+                config.setTrustStorePath("/data/vault/etc/pki/ts/jks");
+                config.setTrustStorePassword("passwd67890");
+
+                assertNoViolations(VALIDATOR, config);
+            }
+        }
+
+        @Nested
+        class ShouldFail {
+
+            @Test
+            void whenProtocolIsBlank() {
+                config.setProtocol("");
+                assertOnePropertyViolation(VALIDATOR, config, "protocol");
+            }
+
+            @Test
+            void whenKeyStoreTypeIsBlank() {
+                config.setKeyStoreType("");
+                assertOnePropertyViolation(VALIDATOR, config, "keyStoreType");
+            }
+
+            @Test
+            void whenTrustStorePathIsBlank() {
+                config.setTrustStorePath("");
+                assertOnePropertyViolation(VALIDATOR, config, "trustStorePath");
+            }
+
+            @Test
+            void whenTrustStorePasswordIsNull() {
+                config.setTrustStorePassword(null);
+                assertOnePropertyViolation(VALIDATOR, config, "trustStorePassword");
+            }
+
+            @Test
+            void whenTrustStoreTypeIsBlank() {
+                config.setTrustStoreType("");
+                assertOnePropertyViolation(VALIDATOR, config, "trustStoreType");
+            }
+        }
+    }
+
+    @Nested
+    class ConversionMethods {
+
+        private TlsContextConfiguration config;
+        private String protocol;
+        private String path;
+        private String password;
+        private String type;
+
+        @BeforeEach
+        void setUp() {
+            protocol = SecureTestConstants.TLS_PROTOCOL;
+            path = SecureTestConstants.JKS_FILE_PATH;
+            password = SecureTestConstants.JKS_PASSWORD;
+            type = SecureTestConstants.STORE_TYPE;
+
+            config = TlsContextConfiguration.builder()
+                    .protocol(protocol)
+                    .keyStorePath(path)
+                    .keyStorePassword(password)
+                    .keyStoreType(type)
+                    .trustStorePath(path)
+                    .trustStorePassword(password)
+                    .trustStoreType(type)
+                    .verifyHostname(false)
+                    .build();
+        }
+
+        @Nested
+        class FromDropwizardTlsConfiguration {
+
+            private TlsConfiguration dwTlsConfig;
+
+            @BeforeEach
+            void setUp() {
+                dwTlsConfig = new TlsConfiguration();
+                dwTlsConfig.setProtocol("TLSv1.3");
+                dwTlsConfig.setKeyStorePath(new File("/pki/test.ks"));
+                dwTlsConfig.setKeyStorePassword("ks-pass");
+                dwTlsConfig.setKeyStoreType("PKCS12");
+                dwTlsConfig.setTrustStorePath(new File("/pki/test.ts"));
+                dwTlsConfig.setTrustStorePassword("ts-pass");
+                dwTlsConfig.setTrustStoreType("PKCS12");
+                dwTlsConfig.setVerifyHostname(false);
+                dwTlsConfig.setSupportedProtocols(List.of("TLSv1.3"));
+            }
+
+            @Test
+            void shouldNotAllowNullArguments() {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> TlsContextConfiguration.fromDropwizardTlsConfiguration(null))
+                        .withMessage("TlsConfiguration cannot be null");
+            }
+
+            @Test
+            void shouldReturnTlsContextConfiguration_FromDefaultDropwizardTlsConfiguration() {
+                dwTlsConfig = new TlsConfiguration();
+
+                var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
+
+                // The following also test assumptions about defaults of Dropwizard's TlsConfiguration, for example
+                // which are null. This isn't wonderful but at the same time we'll find out quickly what Dropwizard
+                // has changed.
+                assertThat(tlsContextConfig.getProtocol()).isNotNull().isEqualTo(dwTlsConfig.getProtocol());
+                assertThat(tlsContextConfig.getKeyStorePath()).isNull();
+                assertThat(tlsContextConfig.getKeyStorePassword()).isNull();
+                assertThat(tlsContextConfig.getKeyStoreType()).isNotNull().isEqualTo(dwTlsConfig.getKeyStoreType());
+                assertThat(tlsContextConfig.getTrustStorePath()).isNull();
+                assertThat(tlsContextConfig.getTrustStorePassword()).isNull();
+                assertThat(tlsContextConfig.getTrustStoreType()).isNotNull().isEqualTo(dwTlsConfig.getTrustStoreType());
+                assertThat(tlsContextConfig.isVerifyHostname()).isTrue();
+                assertThat(tlsContextConfig.getSupportedProtocols()).isNull();
+            }
+
+            @Test
+            void shouldReturnTlsContextConfiguration() {
+                var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
+
+                assertThat(tlsContextConfig.getProtocol()).isEqualTo("TLSv1.3");
+                assertThat(tlsContextConfig.getKeyStorePath()).isEqualTo("/pki/test.ks");
+                assertThat(tlsContextConfig.getKeyStorePassword()).isEqualTo("ks-pass");
+                assertThat(tlsContextConfig.getKeyStoreType()).isEqualTo("PKCS12");
+                assertThat(tlsContextConfig.getTrustStorePath()).isEqualTo("/pki/test.ts");
+                assertThat(tlsContextConfig.getTrustStorePassword()).isEqualTo("ts-pass");
+                assertThat(tlsContextConfig.getTrustStoreType()).isEqualTo("PKCS12");
+                assertThat(tlsContextConfig.isVerifyHostname()).isFalse();
+                assertThat(tlsContextConfig.getSupportedProtocols()).containsOnly("TLSv1.3");
+            }
+
+            @Test
+            void shouldHandleNullKeyStorePathAndPassword() {
+                dwTlsConfig.setKeyStorePath(null);
+                dwTlsConfig.setKeyStorePassword(null);
+
+                var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
+
+                assertThat(tlsContextConfig.getKeyStorePath()).isNull();
+                assertThat(tlsContextConfig.getKeyStorePassword()).isNull();
+            }
+
+            @Test
+            void shouldHandleNullTrustStorePathAndPassword() {
+                dwTlsConfig.setTrustStorePath(null);
+                dwTlsConfig.setTrustStorePassword(null);
+
+                var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
+
+                assertThat(tlsContextConfig.getTrustStorePath()).isNull();
+                assertThat(tlsContextConfig.getTrustStorePassword()).isNull();
+            }
+
+            @Test
+            void shouldHandleNullSupportedProtocols() {
+                dwTlsConfig.setSupportedProtocols(null);
+
+                var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
+
+                assertThat(tlsContextConfig.getSupportedProtocols()).isNull();
+            }
+        }
+
+        @Nested
+        class ToSslContext {
+
+            @Test
+            void shouldReturnSslContext() {
+                var sslContext = config.toSSLContext();
+
+                assertThat(sslContext).isNotNull();
+                assertThat(sslContext.getProtocol()).isEqualTo(config.getProtocol());
+            }
+        }
+
+        @Nested
+        class ToSslSocketFactory {
+
+            @Test
+            void shouldReturnSslSocketFactory() {
+                var sslSocketFactory = config.toSslSocketFactory();
+                assertThat(sslSocketFactory).isNotNull();
+            }
+        }
+
+        @Nested
+        class ToDropwizardTlsConfiguration {
+
+            @SuppressWarnings("ConstantConditions")  // b/c IntelliJ sees Dropwizard [key|trust]StorePath are @Nullable
+            @Test
+            void shouldReturnTlsConfiguration() {
+                var dwTlsConfig = config.toDropwizardTlsConfiguration();
+
+                assertThat(dwTlsConfig.getProtocol()).isEqualTo(protocol);
+                assertThat(dwTlsConfig.getKeyStorePath().getAbsolutePath()).isEqualTo(path);
+                assertThat(dwTlsConfig.getKeyStorePassword()).isEqualTo(password);
+                assertThat(dwTlsConfig.getKeyStoreType()).isEqualTo(type);
+                assertThat(dwTlsConfig.getTrustStorePath().getAbsolutePath()).isEqualTo(path);
+                assertThat(dwTlsConfig.getTrustStorePassword()).isEqualTo(password);
+                assertThat(dwTlsConfig.getTrustStoreType()).isEqualTo(type);
+                assertThat(dwTlsConfig.isVerifyHostname()).isFalse();
+            }
+
+            @SuppressWarnings("ConstantConditions")  // b/c IntelliJ sees Dropwizard [key|trust]StorePath are @Nullable
+            @Test
+            void shouldCorrectlyHandleWhenOnlyTrustStoreIsPresent() {
+                config = TlsContextConfiguration.builder()
+                        .trustStorePath("/data/pki/trust-store.pkcs12")
+                        .trustStorePassword("mySuperSecretTsPassword")
+                        .trustStoreType(KeyStoreType.PKCS12.value)
+                        .build();
+
+                var dwTlsConfig = config.toDropwizardTlsConfiguration();
+
+                assertThat(dwTlsConfig.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value);
+                assertThat(dwTlsConfig.getKeyStorePath()).isNull();
+                assertThat(dwTlsConfig.getKeyStorePassword()).isNull();
+                assertThat(dwTlsConfig.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value);
+                assertThat(dwTlsConfig.getTrustStorePath().getAbsolutePath()).isEqualTo("/data/pki/trust-store.pkcs12");
+                assertThat(dwTlsConfig.getTrustStorePassword()).isEqualTo("mySuperSecretTsPassword");
+                assertThat(dwTlsConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value);
+                assertThat(dwTlsConfig.isVerifyHostname()).isTrue();
+            }
+        }
+    }
+
+    private static TlsContextConfiguration loadTlsContextConfiguration(String filename) {
+        var yaml = new Yaml();
+        var yamlConfig = FixtureHelpers.fixture(filename);
+        var appConfig = yaml.loadAs(yamlConfig, SampleAppConfig.class);
+        return appConfig.getTlsConfig();
+    }
+}

--- a/src/test/java/org/kiwiproject/validation/ValidationTestHelper.java
+++ b/src/test/java/org/kiwiproject/validation/ValidationTestHelper.java
@@ -1,0 +1,69 @@
+package org.kiwiproject.validation;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import lombok.experimental.UtilityClass;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Arrays;
+
+@UtilityClass
+public class ValidationTestHelper {
+
+    public static final Validator DEFAULT_VALIDATOR = newValidator();
+
+    public static Validator newValidator() {
+        return Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    public static void assertNoViolations(Validator validator, Object object) {
+        var violations = validator.validate(object);
+        assertThat(violations).isEmpty();
+    }
+
+    public static void assertViolations(Validator validator, Object object, int numExpectedViolations) {
+        var violations = validator.validate(object);
+        assertThat(violations).hasSize(numExpectedViolations);
+    }
+
+    public static void assertOnePropertyViolation(Validator validator, Object object, String propertyName) {
+        assertPropertyViolations(validator, object, propertyName, 1);
+    }
+
+    public static void assertNoPropertyViolations(Validator validator, Object object, String propertyName) {
+        assertPropertyViolations(validator, object, propertyName, 0);
+    }
+
+    public static void assertPropertyViolations(Validator validator,
+                                                Object object,
+                                                String propertyName,
+                                                int numExpectedViolations) {
+        var violations = validator.validateProperty(object, propertyName);
+        assertThat(violations).hasSize(numExpectedViolations);
+    }
+
+    public static void assertPropertyViolations(Validator validator,
+                                                Object object,
+                                                String propertyName,
+                                                String... expectedMessages) {
+
+        var violations = validator.validateProperty(object, propertyName);
+
+        var actualMessages = violations.stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(toUnmodifiableList());
+
+        var missingMessages = Arrays.stream(expectedMessages)
+                .filter(value -> !actualMessages.contains(value))
+                .collect(toUnmodifiableList());
+
+        if (!missingMessages.isEmpty()) {
+            fail("Messages [%s] not found in actual messages %s",
+                    String.join(",", missingMessages), actualMessages);
+        }
+    }
+}

--- a/src/test/resources/TlsContextConfigurationTest/full-tls-config.yml
+++ b/src/test/resources/TlsContextConfigurationTest/full-tls-config.yml
@@ -1,0 +1,12 @@
+tlsConfig:
+  protocol: TLSv1.3
+  keyStorePath: /path/to/keystore.pkcs12
+  keyStorePassword: ksPassWd
+  keyStoreType: PKCS12
+  trustStorePath: /path/to/truststore.pkcs12
+  trustStorePassword: tsPass100
+  trustStoreType: PKCS12
+  verifyHostname: false
+  supportedProtocols:
+    - TLSv1.2
+    - TLSv1.3

--- a/src/test/resources/TlsContextConfigurationTest/minimal-no-key-props-tls-config.yml
+++ b/src/test/resources/TlsContextConfigurationTest/minimal-no-key-props-tls-config.yml
@@ -1,0 +1,3 @@
+tlsConfig:
+  trustStorePath: /path/to/truststore.jks
+  trustStorePassword: tsPass100

--- a/src/test/resources/TlsContextConfigurationTest/minimal-tls-config.yml
+++ b/src/test/resources/TlsContextConfigurationTest/minimal-tls-config.yml
@@ -1,0 +1,5 @@
+tlsConfig:
+  keyStorePath: /path/to/keystore.jks
+  keyStorePassword: ksPassWd
+  trustStorePath: /path/to/truststore.jks
+  trustStorePassword: tsPass100


### PR DESCRIPTION
* Add TlsContextConfiguration
* To get access to Dropwizard's TlsConfiguration added dropwizard-client dependency,
  which then caused all manner of havoc due to Maven Enforcer detecting version
  conflicts. As a result, did some initial re-organization in the POM, excluding
  things that were in conflict, then adding them explicitly. Also, extracted all
  (non-plugin) dependency versions to properties. We can do the plugins later.

Fixes #84