### PR TITLE
Start pom cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.kiwiproject</groupId>
     <artifactId>kiwi</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -15,10 +15,9 @@
         <guava.version>28.2-jre</guava.version>
         <commons-lang3.version>3.10</commons-lang3.version>
 
-        <!-- Versions for provided/optional dependencies -->
+        <!-- Versions for provided dependencies -->
         <commons-text.version>1.8</commons-text.version>
         <dropwizard.version>2.0.7</dropwizard.version>
-        <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
         <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
         <httpclient.version>4.5.12</httpclient.version>
         <jackson.version>2.10.3</jackson.version>
@@ -29,13 +28,14 @@
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
         <joda-time.version>2.10.5</joda-time.version>
-        <jsr250-api.version>1.0</jsr250-api.version>
-        <jsr305.version>3.0.2</jsr305.version>
         <logback-classic.version>1.2.3</logback-classic.version>
-        <spring-beans.version>5.2.5.RELEASE</spring-beans.version>
+        <spring.version>5.2.5.RELEASE</spring.version>
         <commons-io.version>2.6</commons-io.version>
-
         <lombok.version>1.18.12</lombok.version>
+
+        <!-- Versions for optional dependencies -->
+        <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
+        <jsr305.version>3.0.2</jsr305.version>
 
         <!-- Versions for test dependencies -->
         <mockito.version>3.3.0</mockito.version>
@@ -69,6 +69,18 @@
             <version>${guava.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.j2objc</groupId>
+                    <artifactId>j2objc-annotations</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
@@ -87,7 +99,20 @@
             <version>${slf4j-api.version}</version>
         </dependency>
 
-        <!-- provided & optional dependencies -->
+        <!-- provided dependencies -->
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons-text.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
 
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -166,18 +191,21 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <version>${jakarta.annotation-api.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>${joda-time.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -191,12 +219,14 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.el</artifactId>
             <version>${jakarta-el.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>${javassist.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -226,13 +256,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>${javax.ws.rs-api.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>${jakarta.xml.bind-api.version}</version>
@@ -247,26 +270,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- optional dependencies -->
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <version>${error_prone_annotations.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>${javax.annotation-api.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-            <version>${jsr250-api.version}</version>
-            <scope>provided</scope>
             <optional>true</optional>
         </dependency>
 
@@ -274,15 +289,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>${jsr305.version}</version>
-            <scope>provided</scope>
             <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>${spring-beans.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->
@@ -296,19 +303,6 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>${commons-text.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/org/kiwiproject/beans/BeanConverter.java
+++ b/src/main/java/org/kiwiproject/beans/BeanConverter.java
@@ -23,10 +23,12 @@ import java.util.stream.Stream;
 /**
  * Simple way to convert one bean to another.  This utility uses spring-beans to attempt the conversion at first.  If attempting to
  * convert maps, it will attempt to do simple copies of the key-value pairs.
- *
+ * <p>
  * Exclusion lists can be provided to ignore specific fields.
- *
+ * <p>
  * Also custom mappers can be provided per field for more control over how the fields are converted.
+ * <p>
+ * NOTE: This class requires spring-beans as a dependency.
  */
 @Slf4j
 public class BeanConverter<T> {
@@ -64,9 +66,9 @@ public class BeanConverter<T> {
     /**
      * This conversion method takes two parameters and copies properties from one object to another
      *
-     * @param input   the object to copy the properties from
-     * @param target  the object to copy the properties too (destination)
-     * @param <R>     the type of object being returned
+     * @param input  the object to copy the properties from
+     * @param target the object to copy the properties too (destination)
+     * @param <R>    the type of object being returned
      * @return the modified target object
      */
     @SuppressWarnings("unchecked")
@@ -181,7 +183,7 @@ public class BeanConverter<T> {
      * Adds a property mapper function for a specific property name
      *
      * @param propertyName the property name
-     * @param function the Function that will be triggered
+     * @param function     the Function that will be triggered
      * @return true if successfully added; false otherwise
      */
     public boolean addPropertyMapper(String propertyName, Function<T, ?> function) {

--- a/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.http.protocol.HttpContext;
 import org.kiwiproject.security.KeyAndTrustStoreConfigProvider;
 import org.kiwiproject.security.KeyStoreType;
 import org.kiwiproject.security.SSLContextProtocol;
@@ -26,7 +25,9 @@ import java.util.Optional;
 /**
  * Configuration for standard/common properties required for secure TLS connections.
  * <p>
- * As this is a configuration class that supports population from external configuration, it is mutable.
+ * As this is a configuration class that supports population from external configuration, it is mutable
+ * <p>
+ * NOTE: This requires dropwizard-client as a dependency.
  */
 @Getter
 @Setter
@@ -99,7 +100,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
      * HttpClient's {@link org.apache.http.conn.ssl.SSLConnectionSocketFactory} accepts {@code supportedProtocols}
      * in its constructors as arrays that are supposed to be null if you aren't specifying a specific list of them.
      * The HttpClient code does an explicit null check on the {@code supportedProtocols} in
-     * {@link org.apache.http.conn.ssl.SSLConnectionSocketFactory#createLayeredSocket(Socket, String, int, HttpContext)}.
+     * {@link org.apache.http.conn.ssl.SSLConnectionSocketFactory#createLayeredSocket(Socket, String, int, org.apache.http.protocol.HttpContext)}.
      * You will need to look at the source code, as the JavaDoc doesn't mention this tidbit, nor do the constructors
      * since they don't have any documentation regarding their arguments. If you don't like reading source code of the
      * open source tools you rely on, then please close this file, log out, and change careers.

--- a/src/main/java/org/kiwiproject/io/TimeBasedDirectoryCleaner.java
+++ b/src/main/java/org/kiwiproject/io/TimeBasedDirectoryCleaner.java
@@ -37,6 +37,8 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * A {@link Runnable} that cleans a given directory of files and/or directories that are older than a specified
  * retention threshold.
+ * <p>
+ * NOTE: This class relies on classes in commons-io, so you will need to add it as a dependency to your project!
  *
  * @implNote This is intended to be run in a single thread, e.g. using a {@link java.util.concurrent.ScheduledExecutorService}
  * with one thread. Results are undefined (and probably bad) if multiple threads execute the same instance of this
@@ -298,7 +300,7 @@ public class TimeBasedDirectoryCleaner implements Runnable {
      */
     @VisibleForTesting
     void logUnableToDelete(FileDeleteResult deleteResult) {
-       logDeleteError("Unable to delete " + deleteResult.absolutePath);
+        logDeleteError("Unable to delete " + deleteResult.absolutePath);
     }
 
     @VisibleForTesting

--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -11,10 +11,10 @@ import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiMaps.isNullOrEmpty;
 
 import com.google.common.base.Splitter;
-import io.dropwizard.util.Strings;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -88,7 +88,7 @@ public class KiwiUrls {
      */
     public static URL createUrlObject(String protocol, String hostname, int port, String path) {
         try {
-            var pathWithLeadingSlash = Strings.isNullOrEmpty(path) ? "" : prependLeadingSlash(path);
+            var pathWithLeadingSlash = StringUtils.isBlank(path) ? "" : prependLeadingSlash(path);
 
             return new URL(protocol, hostname, port, pathWithLeadingSlash);
         } catch (MalformedURLException e) {


### PR DESCRIPTION
* Update kiwi version to 0.0.3-SNAPSHOT
* Re-organized properties in pom according to usage
* Made some dependencies provided, others optional
* Removed a few deps that we don't need
  - javax.ws.rs-api (b/c the newer jakarta rs-api supersedes)
  - javax.annotation-api and jsr250-api, which are actually
    duplicates even though have different Maven coordinates
* Exclude some of guava's transitive deps that we don't need
* Moved commons-text up from test section into provided; even
  though it's only used in tests right now, I wanted to keep
  only pure testing frameworks/libraries in the test group

Other changes:

* Change KiwiUrls to use StringUtils from commons-lang3 instead
  of Dropwizard to avoid dropwizard dependency when using it
* Make note in TimeBasedDirectoryCleaner, TlsContextConfiguration,
  and BeanConverter about what dependencies are needed to use them

Relates to #101