### PR TITLE
Update Dropwizard version to 2.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <!-- Versions for provided dependencies -->
         <commons-io.version>2.6</commons-io.version>
         <commons-text.version>1.8</commons-text.version>
-        <dropwizard.version>2.0.7</dropwizard.version>
+        <dropwizard.version>2.0.8</dropwizard.version>
         <hibernate-validator.version>6.1.3.Final</hibernate-validator.version>
         <httpclient.version>4.5.12</httpclient.version>
         <jackson.version>2.10.3</jackson.version>
@@ -28,6 +28,7 @@
         <javassist.version>3.27.0-GA</javassist.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
         <javax.ws.rs-api.version>2.1.1</javax.ws.rs-api.version>
+        <jetty-server.version>9.4.28.v20200408</jetty-server.version>
         <joda-time.version>2.10.5</joda-time.version>
         <logback-classic.version>1.2.3</logback-classic.version>
         <lombok.version>1.18.12</lombok.version>
@@ -172,6 +173,10 @@
                     <artifactId>javassist</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>joda-time</groupId>
                     <artifactId>joda-time</artifactId>
                 </exclusion>
@@ -264,6 +269,13 @@
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>${javassist.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty-server.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Because of an enforcer violation, had to exclude jetty-server from
dropwizard-client, and add it as an explicit dependency.

Fixes #102

The convergence failure was due to dropwizard-core depending on metrics-jetty9 which
in turn depends on jetty-server version 9.4.27.v20200227, while all the others
depend on 9.4.28.v20200408. I wish Dropwizard used the enforcer plugin...

Dependency convergence error for org.eclipse.jetty:jetty-server:9.4.27.v20200227 paths to dependency are:
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-client:2.0.8
    +-io.dropwizard:dropwizard-core:2.0.8
      +-io.dropwizard.metrics:metrics-jetty9:4.1.6
        +-org.eclipse.jetty:jetty-server:9.4.27.v20200227

and
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-client:2.0.8
    +-io.dropwizard:dropwizard-core:2.0.8
      +-io.dropwizard:dropwizard-request-logging:2.0.8
        +-org.eclipse.jetty:jetty-server:9.4.28.v20200408
and
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-client:2.0.8
    +-io.dropwizard:dropwizard-core:2.0.8
      +-org.eclipse.jetty:jetty-security:9.4.28.v20200408
        +-org.eclipse.jetty:jetty-server:9.4.28.v20200408
and
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-client:2.0.8
    +-io.dropwizard:dropwizard-core:2.0.8
      +-org.eclipse.jetty:jetty-server:9.4.28.v20200408
and
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-client:2.0.8
    +-io.dropwizard:dropwizard-lifecycle:2.0.8
      +-org.eclipse.jetty:jetty-server:9.4.28.v20200408
and
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:2.0.8
    +-io.dropwizard:dropwizard-jetty:2.0.8
      +-org.eclipse.jetty:jetty-server:9.4.28.v20200408
and
+-org.kiwiproject:kiwi:0.0.4-SNAPSHOT
  +-io.dropwizard:dropwizard-testing:2.0.8
    +-org.eclipse.jetty:jetty-server:9.4.28.v20200408