### PR TITLE
Move LazyLogParameterSupplier to logging package

### DIFF
--- a/src/main/java/org/kiwiproject/logging/LazyLogParameterSupplier.java
+++ b/src/main/java/org/kiwiproject/logging/LazyLogParameterSupplier.java
@@ -1,4 +1,4 @@
-package org.kiwiproject.slf4j;
+package org.kiwiproject.logging;
 
 import static java.util.Objects.isNull;
 

--- a/src/test/java/org/kiwiproject/logging/LazyLogParameterSupplierTest.java
+++ b/src/test/java/org/kiwiproject/logging/LazyLogParameterSupplierTest.java
@@ -1,7 +1,7 @@
-package org.kiwiproject.slf4j;
+package org.kiwiproject.logging;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.slf4j.LazyLogParameterSupplier.lazy;
+import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
 
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -15,7 +15,7 @@
     NOTE: A logger for this test class *must* be present and at DEBUG level for the test to work (since it
     is testing logging and specifically whether the lazy supplier executes or not.
     -->
-    <logger name="org.kiwiproject.slf4j.LazyLogParameterSupplierTest" level="DEBUG"/>
+    <logger name="org.kiwiproject.logging.LazyLogParameterSupplierTest" level="DEBUG"/>
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
This was a mistake. It should never have gone in an
slf4j package.

Fixes #135