### PR TITLE
Add KiwiSearching

### DIFF
--- a/src/main/java/org/kiwiproject/search/KiwiSearching.java
+++ b/src/main/java/org/kiwiproject/search/KiwiSearching.java
@@ -1,0 +1,212 @@
+package org.kiwiproject.search;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utilities related to searching and pagination. Supports both zero- and one-based page numbering but the
+ * default is one-based. Use the methods that accept
+ */
+@UtilityClass
+public class KiwiSearching {
+
+    /**
+     * Enum that represents either zero or one-based page numbering scheme.
+     */
+    public enum PageNumberingScheme {
+
+        /**
+         * Page numbers start at zero.
+         */
+        ZERO_BASED("pageNumber starts at 0", 0),
+
+        /**
+         * Page numbers start at one.
+         */
+        ONE_BASED("pageNumber starts at 1", 1);
+
+        /**
+         * @implNote Allow access through a traditional getter method or via a public field (which is perfectly
+         * fine since this is an immutable String.)
+         */
+        @Getter
+        public final String pageNumberError;
+
+        private final int minimumPageNumber;
+
+        PageNumberingScheme(String pageNumberError, int minimumPageNumber) {
+            this.pageNumberError = pageNumberError;
+            this.minimumPageNumber = minimumPageNumber;
+        }
+
+        /**
+         * Check the given page number for this scheme's minimum page number.
+         *
+         * @throws IllegalArgumentException if the given page number is not valid
+         */
+        public void checkPageNumber(int pageNumber) {
+            checkArgument(pageNumber >= minimumPageNumber, pageNumberError);
+        }
+    }
+
+    /**
+     * A rather opinionated value for the default page size.
+     */
+    public static final int DEFAULT_PAGE_SIZE = 25;
+
+    /**
+     * The rather opinionated value for default page size as a String, in order to support web framework annotations
+     * like JAX-RS's {@code javax.ws.rs.DefaultValue} that require a String.
+     *
+     * @implNote This <em>must</em> be a constant not an expression, otherwise trying to use it in an annotation like
+     * the JAX-RS {@code DefaultValue} will result in a compilation error due to the vagaries of Java annotations.
+     * For example, trying to do this:
+     * {@code DEFAULT_PAGE_SIZE_AS_STRING = String.valueOf(DEFAULT_PAGE_SIZE)}
+     * and then using in an annotation like this:
+     * {@code @DefaultValue(DEFAULT_PAGE_SIZE_AS_STRING)}
+     * will result in the following compiler error: "java: element value must be a constant expression"
+     */
+    public static final String DEFAULT_PAGE_SIZE_AS_STRING = "25";
+
+    public static final String PAGE_SIZE_ERROR = "pageSize must be at least 1";
+
+    /**
+     * Validate that the given page size is greater than zero.
+     */
+    public static void checkPageSize(int pageSize) {
+        checkArgument(pageSize > 0, PAGE_SIZE_ERROR);
+    }
+
+    /**
+     * Validate the given page number is greater than zero. <em>This uses one-based page numbering.</em>
+     *
+     * @param pageNumber the page number to check
+     * @throws IllegalArgumentException if the page number is not greater than zero
+     * @see #checkPageNumber(int, PageNumberingScheme)
+     * @see PageNumberingScheme#ONE_BASED
+     */
+    public static void checkPageNumber(int pageNumber) {
+        PageNumberingScheme.ONE_BASED.checkPageNumber(pageNumber);
+    }
+
+    /**
+     * Validate the given page number is equal to or greater than the minimum for the given {@link PageNumberingScheme}.
+     *
+     * @param pageNumber      the page number to check
+     * @param numberingScheme the page numbering scheme to use
+     * @throws IllegalArgumentException if the page number is invalid according to the numbering scheme
+     * @see PageNumberingScheme
+     */
+    public static void checkPageNumber(int pageNumber, PageNumberingScheme numberingScheme) {
+        checkArgumentNotNull(numberingScheme);
+        numberingScheme.checkPageNumber(pageNumber);
+    }
+
+    /**
+     * Calculate the <em>zero-based offset</em> for the given page number and size using page numbers starting
+     * at one, after first validating the page number and size. Useful for any data access library that requires a
+     * zero-based offset.
+     * <p>
+     * <em>This uses one-based page numbering.</em>
+     *
+     * @param pageNumber the page number (one-based)
+     * @param pageSize   the page size
+     * @return the zero-based offset, e.g. for use in SQL queries using OFFSET and LIMIT
+     * @throws IllegalArgumentException if the page number or size is invalid
+     * @see PageNumberingScheme#ONE_BASED
+     * @see #zeroBasedOffset(int, PageNumberingScheme, int)
+     */
+    public static int zeroBasedOffset(int pageNumber, int pageSize) {
+        return zeroBasedOffset(pageNumber, PageNumberingScheme.ONE_BASED, pageSize);
+    }
+
+    /**
+     * Calculate the <em>zero-based offset</em> for the given page number and size using the given page numbering
+     * scheme, after first validating the page number and size. Useful for any data access library that requires
+     * a zero-based offset.
+     *
+     * @param pageNumber      the page number
+     * @param numberingScheme the page numbering scheme to use
+     * @param pageSize        the page size
+     * @return the zero-based offset, e.g. for use in SQL queries using OFFSET and LIMIT
+     * @throws IllegalArgumentException if the page number or size is invalid
+     * @see PageNumberingScheme
+     */
+    public static int zeroBasedOffset(int pageNumber, PageNumberingScheme numberingScheme, int pageSize) {
+        checkPageNumber(pageNumber, numberingScheme);
+        checkPageSize(pageSize);
+        return (pageNumber - numberingScheme.minimumPageNumber) * pageSize;
+    }
+
+    /**
+     * Calculate the number of pages necessary to paginate the given number of results using the given page size.
+     *
+     * @param resultCount the total number of results to paginate
+     * @param pageSize    the size of each page
+     * @return the number of pages
+     * @throws IllegalArgumentException if the page size is invalid
+     */
+    public static int numberOfPages(long resultCount, int pageSize) {
+        checkPageSize(pageSize);
+        return (int) (resultCount / pageSize) + (resultCount % pageSize > 0 ? 1 : 0);
+    }
+
+    /**
+     * Calculate the number of results on the given page number for the given number of results and page size.
+     * <em>This uses one-based page numbering.</em>
+     *
+     * @param resultCount the total number of results to paginate
+     * @param pageSize    the size of each page
+     * @param pageNumber  the page number
+     * @return the number of results on the given page
+     * @throws IllegalArgumentException if page number or size is invalid
+     * @see PageNumberingScheme#ONE_BASED
+     * @see #numberOnPage(long, int, int, PageNumberingScheme)
+     */
+    public static int numberOnPage(long resultCount, int pageSize, int pageNumber) {
+        return numberOnPage(resultCount, pageSize, pageNumber, PageNumberingScheme.ONE_BASED);
+    }
+
+    /**
+     * Calculate the number of results on the given page number for the given number of results and page size, and
+     * using the given {@link PageNumberingScheme}.
+     *
+     * @param resultCount     the total number of results to paginate
+     * @param pageSize        the size of each page
+     * @param pageNumber      the page number
+     * @param numberingScheme the page numbering scheme to use
+     * @return the number of results on the given page
+     * @throws IllegalArgumentException if page number or size is invalid
+     * @see PageNumberingScheme
+     */
+    public static int numberOnPage(long resultCount,
+                                   int pageSize,
+                                   int pageNumber,
+                                   PageNumberingScheme numberingScheme) {
+
+        checkPageNumber(pageNumber, numberingScheme);
+        checkPageSize(pageSize);
+
+        if (resultCount == 0) {
+            return 0;
+        }
+
+        var numPages = numberOfPages(resultCount, pageSize);
+
+        var schemePageNumber = (numberingScheme == PageNumberingScheme.ONE_BASED) ? pageNumber : pageNumber + 1;
+
+        if (schemePageNumber > numPages) {
+            return 0;
+        }
+
+        if (schemePageNumber == numPages) {
+            long remainder = resultCount % pageSize;
+            return remainder == 0 ? pageSize : (int) remainder;
+        }
+
+        return pageSize;
+    }
+}

--- a/src/test/java/org/kiwiproject/search/KiwiSearchingTest.java
+++ b/src/test/java/org/kiwiproject/search/KiwiSearchingTest.java
@@ -1,0 +1,255 @@
+package org.kiwiproject.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.kiwiproject.search.KiwiSearching.PAGE_SIZE_ERROR;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.search.KiwiSearching.PageNumberingScheme;
+
+@DisplayName("KiwiSearching")
+@ExtendWith(SoftAssertionsExtension.class)
+class KiwiSearchingTest {
+
+    @Test
+    void shouldNotChangeDefaultPageSizeConstantsUnlessBothAreChanged() {
+        assertThat(KiwiSearching.DEFAULT_PAGE_SIZE_AS_STRING)
+                .isEqualTo(String.valueOf(KiwiSearching.DEFAULT_PAGE_SIZE));
+    }
+
+    @Nested
+    class CheckPageSize {
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 2, 10, Integer.MAX_VALUE})
+        void shouldNotThrowException_WhenValidPageSize(int pageSize) {
+            assertThatCode(() -> KiwiSearching.checkPageSize(pageSize))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {Integer.MIN_VALUE, -10, -1, 0})
+        void shouldThrowException_WhenInvalidPageSize(int pageSize) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiSearching.checkPageSize(pageSize))
+                    .withMessage(PAGE_SIZE_ERROR);
+        }
+    }
+
+    @Nested
+    class CheckPageNumber {
+
+        @Nested
+        class UsingOneBasedNumberingScheme {
+
+            @ParameterizedTest
+            @ValueSource(ints = {1, 2, 10, 100, Integer.MAX_VALUE})
+            void shouldNotThrowException_WhenValidPageNumber(int pageNumber) {
+                assertThatCode(() -> KiwiSearching.checkPageNumber(pageNumber))
+                        .doesNotThrowAnyException();
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {Integer.MIN_VALUE, -1000, -100, -1, 0})
+            void shouldThrowException_WhenInvalidPageNumber(int pageNumber) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.checkPageNumber(pageNumber))
+                        .withMessage("pageNumber starts at 1");
+            }
+        }
+
+        @Nested
+        class UsingZeroBasedNumberingScheme {
+
+            @ParameterizedTest
+            @ValueSource(ints = {0, 1, 2, 10, 100, Integer.MAX_VALUE})
+            void shouldNotThrowException_WhenValidPageNumber(int pageNumber) {
+                assertThatCode(() -> KiwiSearching.checkPageNumber(pageNumber, PageNumberingScheme.ZERO_BASED))
+                        .doesNotThrowAnyException();
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {Integer.MIN_VALUE, -1000, -100, -1})
+            void shouldThrowException_WhenInvalidPageNumber(int pageNumber) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.checkPageNumber(pageNumber, PageNumberingScheme.ZERO_BASED))
+                        .withMessage("pageNumber starts at 0");
+            }
+        }
+    }
+
+    @Nested
+    class ZeroBasedOffset {
+
+        @Nested
+        class UsingOneBasedNumberingScheme {
+
+            @Test
+            void shouldReturnExpectedZeroBasedOffset(SoftAssertions softly) {
+                softly.assertThat(KiwiSearching.zeroBasedOffset(1, 25)).isEqualTo(0);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(10, 25)).isEqualTo(9 * 25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(100, 25)).isEqualTo(99 * 25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(1_000, 25)).isEqualTo(999 * 25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(1_000, 20)).isEqualTo(999 * 20);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-10, -1, 0})
+            void shouldThrowException_WhenInvalidPageSize(int pageSize) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.zeroBasedOffset(1, pageSize));
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-100, -2, -1, 0})
+            void shouldThrowException_WhenInvalidPageNumber(int pageNumber) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.zeroBasedOffset(pageNumber, 10))
+                        .withMessage(PageNumberingScheme.ONE_BASED.getPageNumberError());
+            }
+        }
+
+        @Nested
+        class UsingZeroBasedNumberingScheme {
+
+            @Test
+            void shouldReturnExpectedZeroBasedOffset(SoftAssertions softly) {
+                softly.assertThat(KiwiSearching.zeroBasedOffset(0, PageNumberingScheme.ZERO_BASED, 25)).isEqualTo(0);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(1, PageNumberingScheme.ZERO_BASED, 25)).isEqualTo(25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(10, PageNumberingScheme.ZERO_BASED, 25)).isEqualTo(10 * 25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(100, PageNumberingScheme.ZERO_BASED, 25)).isEqualTo(100 * 25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(1_000, PageNumberingScheme.ZERO_BASED, 25)).isEqualTo(1_000 * 25);
+                softly.assertThat(KiwiSearching.zeroBasedOffset(1_000, PageNumberingScheme.ZERO_BASED, 20)).isEqualTo(1_000 * 20);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-10, -1, 0})
+            void shouldThrowException_WhenInvalidPageSize(int pageSize) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.zeroBasedOffset(1, PageNumberingScheme.ZERO_BASED, pageSize));
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-100, -2, -1})
+            void shouldThrowException_WhenInvalidPageNumber(int pageNumber) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.zeroBasedOffset(pageNumber, PageNumberingScheme.ZERO_BASED, 10))
+                        .withMessage(PageNumberingScheme.ZERO_BASED.getPageNumberError());
+            }
+        }
+    }
+
+    @Nested
+    class NumberOfPages {
+
+        @Test
+        void shouldReturnExpectedNumberOfPages(SoftAssertions softly) {
+            softly.assertThat(KiwiSearching.numberOfPages(0, 20)).isEqualTo(0);
+            softly.assertThat(KiwiSearching.numberOfPages(7, 20)).isEqualTo(1);
+            softly.assertThat(KiwiSearching.numberOfPages(10, 10)).isEqualTo(1);
+            softly.assertThat(KiwiSearching.numberOfPages(100, 20)).isEqualTo(5);
+            softly.assertThat(KiwiSearching.numberOfPages(101, 20)).isEqualTo(6);
+        }
+
+        @SuppressWarnings("ResultOfMethodCallIgnored")
+        @ParameterizedTest
+        @ValueSource(ints = {-10, -1, 0})
+        void shouldThrowException_WhenInvalidPageSize(int pageSize) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiSearching.numberOfPages(100, pageSize))
+                    .withMessage(PAGE_SIZE_ERROR);
+        }
+    }
+
+    @Nested
+    class NumberOnPage {
+
+        @Nested
+        class UsingOneBasedNumberingScheme {
+
+            @Test
+            void shouldReturnExpectedNumberOnPage(SoftAssertions softly) {
+                softly.assertThat(KiwiSearching.numberOnPage(0, 20, 1)).isEqualTo(0);
+
+                softly.assertThat(KiwiSearching.numberOnPage(7, 20, 1)).isEqualTo(7);
+                softly.assertThat(KiwiSearching.numberOnPage(7, 20, 2)).isEqualTo(0);
+
+                softly.assertThat(KiwiSearching.numberOnPage(19, 20, 1)).isEqualTo(19);
+                softly.assertThat(KiwiSearching.numberOnPage(20, 20, 1)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(21, 20, 1)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(21, 20, 2)).isEqualTo(1);
+
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 1)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 2)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 3)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 4)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 5)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 6)).isEqualTo(1);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-100, -2, -1, 0})
+            void shouldThrowException_WhenInvalidPageNumber(int pageNumber) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.numberOnPage(100, 20, pageNumber))
+                        .withMessage(PageNumberingScheme.ONE_BASED.pageNumberError);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-10, -1, 0})
+            void shouldThrowException_WhenInvalidPageSize(int pageSize) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.numberOnPage(100, pageSize, 1))
+                        .withMessage(PAGE_SIZE_ERROR);
+            }
+        }
+
+        @Nested
+        class UsingZeroBasedNumberingScheme {
+
+            @Test
+            void shouldReturnExpectedNumberOnPage(SoftAssertions softly) {
+                softly.assertThat(KiwiSearching.numberOnPage(0, 20, 0, PageNumberingScheme.ZERO_BASED)).isEqualTo(0);
+
+                softly.assertThat(KiwiSearching.numberOnPage(7, 20, 0, PageNumberingScheme.ZERO_BASED)).isEqualTo(7);
+                softly.assertThat(KiwiSearching.numberOnPage(7, 20, 1, PageNumberingScheme.ZERO_BASED)).isEqualTo(0);
+
+                softly.assertThat(KiwiSearching.numberOnPage(19, 20, 0, PageNumberingScheme.ZERO_BASED)).isEqualTo(19);
+                softly.assertThat(KiwiSearching.numberOnPage(20, 20, 0, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(21, 20, 0, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(21, 20, 1, PageNumberingScheme.ZERO_BASED)).isEqualTo(1);
+
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 0, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 1, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 2, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 3, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 4, PageNumberingScheme.ZERO_BASED)).isEqualTo(20);
+                softly.assertThat(KiwiSearching.numberOnPage(101, 20, 5, PageNumberingScheme.ZERO_BASED)).isEqualTo(1);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-100, -2, -1, 0})
+            void shouldThrowException_WhenInvalidPageNumber(int pageNumber) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.numberOnPage(100, 20, pageNumber))
+                        .withMessage(PageNumberingScheme.ONE_BASED.pageNumberError);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {-10, -1, 0})
+            void shouldThrowException_WhenInvalidPageSize(int pageSize) {
+                assertThatIllegalArgumentException()
+                        .isThrownBy(() -> KiwiSearching.numberOnPage(100, pageSize, 1))
+                        .withMessage(PAGE_SIZE_ERROR);
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Augment the original implementation which always assumes
  a one-based page numbering scheme
* Add the PageNumberingScheme enum inside KiwiSearching
  and add method overloads that accept a PageNumberingScheme
  argument to change the behavior
* The methods that do NOT accept a PageNumberingScheme are
  the original one-based methods so the original API stays
  intact.

Fixes #135