### PR TITLE
Add PropertyMaskingSafePropertyWriter and KiwiJacksonSerializers

### DIFF
--- a/src/main/java/org/kiwiproject/json/KiwiJacksonSerializers.java
+++ b/src/main/java/org/kiwiproject/json/KiwiJacksonSerializers.java
@@ -1,0 +1,44 @@
+package org.kiwiproject.json;
+
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+
+/**
+ * Custom Jackson serializers.
+ * <p>
+ * Jackson databind must be available at runtime.
+ */
+@UtilityClass
+public class KiwiJacksonSerializers {
+
+    /**
+     * Build a new {@link SimpleModule} that will replace the values of specific fields with a "masked" value
+     * and will replace any exceptions with a message indicating the field could not be serialized.
+     *
+     * @param maskedFieldRegexps list containing regular expressions that define the properties to mask
+     * @return a new {@link SimpleModule}
+     */
+    public static SimpleModule buildPropertyMaskingSafeSerializerModule(List<String> maskedFieldRegexps) {
+        var modifier = new BeanSerializerModifier() {
+            @Override
+            public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
+                                                             BeanDescription beanDesc,
+                                                             List<BeanPropertyWriter> beanProperties) {
+                return beanProperties.stream()
+                        .map(beanPropertyWriter ->
+                                new PropertyMaskingSafePropertyWriter(beanPropertyWriter, maskedFieldRegexps))
+                        .collect(toList());
+            }
+        };
+
+        return new SimpleModule().setSerializerModifier(modifier);
+    }
+}

--- a/src/main/java/org/kiwiproject/json/PropertyMaskingSafePropertyWriter.java
+++ b/src/main/java/org/kiwiproject/json/PropertyMaskingSafePropertyWriter.java
@@ -1,0 +1,86 @@
+package org.kiwiproject.json;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Writes properties "safely" and masks sensitive properties such as passwords. This property writer will attempt
+ * to write out the value, but if an exception is thrown, it will instead write a pre-configured value in place
+ * of the actual value.
+ * <p>
+ * This writer also allows masking (hiding the true value) of certain fields based on their name by writing out
+ * asterisks instead of the true value.
+ * <p>
+ * NOTE: Generally this should be used only on String fields, because otherwise the type in the resulting JSON will be
+ * different than the source type. For example, if a class has a "secretNumber" of type "int" and it is masked, the
+ * resulting JSON contains a String instead of an int, which will likely cause problems if a downstream system reads
+ * the JSON expecting an int. For such cases, consider using {@link com.fasterxml.jackson.annotation.JsonView} instead.
+ */
+@Slf4j
+public class PropertyMaskingSafePropertyWriter extends BeanPropertyWriter {
+
+    private static final String DEFAULT_HIDDEN_TEXT_REPLACEMENT = "********";
+    private static final String DEFAULT_FAILED_TEXT_REPLACEMENT = "(unable to serialize field)";
+
+    private final List<Pattern> hiddenFieldPatterns;
+
+    /**
+     * Construct new instance wrapping the given {@link BeanPropertyWriter} and the given list of (String)
+     * regular expressions that define the properties which should be masked.
+     *
+     * @param base               the base or delegate {@link BeanPropertyWriter} to use
+     * @param maskedFieldRegexps list containing regular expressions that define the properties to mask
+     */
+    public PropertyMaskingSafePropertyWriter(BeanPropertyWriter base, List<String> maskedFieldRegexps) {
+        super(base);
+        this.hiddenFieldPatterns = convertToPatterns(maskedFieldRegexps);
+    }
+
+    private static List<Pattern> convertToPatterns(List<String> maskedFieldRegexps) {
+        return maskedFieldRegexps.stream()
+                .filter(Objects::nonNull)
+                .map(regex -> Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
+                .collect(toUnmodifiableList());
+    }
+
+    @Override
+    public void serializeAsField(Object bean, JsonGenerator gen, SerializerProvider prov) {
+        var propertyName = getName();
+        try {
+            LOG.trace("Using custom serializer for field: {}", propertyName);
+            if (matchesExclusionPatterns(propertyName)) {
+                writeReplacementText(gen, propertyName, DEFAULT_HIDDEN_TEXT_REPLACEMENT);
+            } else {
+                super.serializeAsField(bean, gen, prov);
+            }
+        } catch (Exception e) {
+            LOG.debug("Unable to serialize: {}, of {} instance, exception {}: {}",
+                    propertyName, bean.getClass().getName(), e.getClass().getName(), e.getMessage());
+            LOG.trace("Exception serializing field: {}", propertyName, e);
+            writeReplacementText(gen, propertyName, DEFAULT_FAILED_TEXT_REPLACEMENT);
+        }
+    }
+
+    private boolean matchesExclusionPatterns(String name) {
+        return hiddenFieldPatterns.stream().anyMatch(pattern -> pattern.matcher(name).find());
+    }
+
+    private static void writeReplacementText(JsonGenerator gen, String name, String text) {
+        LOG.trace("Setting field '{}' to: {}", name, text);
+        try {
+            gen.writeFieldName(name);
+            gen.writeString(text);
+        } catch (Exception e) {
+            LOG.error("Failed to serialize replacement value for field: {}", name, e);
+        }
+    }
+
+}

--- a/src/test/java/org/kiwiproject/json/PropertyMaskingSafePropertyWriterTest.java
+++ b/src/test/java/org/kiwiproject/json/PropertyMaskingSafePropertyWriterTest.java
@@ -1,0 +1,119 @@
+package org.kiwiproject.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+@DisplayName("PropertyMaskingSafePropertyWriter")
+class PropertyMaskingSafePropertyWriterTest {
+
+    @Test
+    void shouldMaskConfiguredPropertyValues() {
+        var jsonHelper = JsonHelper.newDropwizardJsonHelper();
+
+        jsonHelper.getObjectMapper()
+                .registerModule(KiwiJacksonSerializers.buildPropertyMaskingSafeSerializerModule(List.of(".*password.*")));
+
+        var properties = jsonHelper.convertToMap(new SampleUserObject());
+
+        assertThat(properties).containsOnly(
+                entry("email", "bob@example.com"),
+                entry("username", "bob"),
+                entry("password", "********"),
+                entry("passwordConfirmation", "********"),
+                entry("confirmationPassword", "********")
+        );
+    }
+
+    @Test
+    void shouldWriteWarningMessageInsteadOfThrowingExceptions() {
+        var jsonHelper = JsonHelper.newDropwizardJsonHelper();
+
+        jsonHelper.getObjectMapper()
+                .registerModule(KiwiJacksonSerializers.buildPropertyMaskingSafeSerializerModule(List.of()));
+
+        var properties = jsonHelper.convertToMap(new SampleExceptionThrowingObject());
+
+        assertThat(properties).containsOnly(
+                entry("normalProperty", "string-value"),
+                entry("badProperty", "(unable to serialize field)"),
+                entry("anotherProperty", 1)
+        );
+    }
+
+    @Test
+    void shouldWriteStringsToJsonInsteadOfSourceTypeWhenMasking() {
+        var jsonHelper = JsonHelper.newDropwizardJsonHelper();
+
+        jsonHelper.getObjectMapper()
+                .registerModule(KiwiJacksonSerializers.buildPropertyMaskingSafeSerializerModule(List.of(".*secret.*")));
+
+        var properties = jsonHelper.convertToMap(new SampleSecretAgent());
+
+        assertThat(properties).containsOnly(
+                entry("codeName", "007"),
+                entry("secretNumber", "********"),
+                entry("secretIdentities", "********")
+        );
+    }
+
+    @SuppressWarnings("unused")
+    static class SampleUserObject {
+
+        public String getEmail() {
+            return "bob@example.com";
+        }
+
+        public String getUsername() {
+            return "bob";
+        }
+
+        public String getPassword() {
+            return "secret";
+        }
+
+        public String getPasswordConfirmation() {
+            return "secret";
+        }
+
+        public String getConfirmationPassword() {
+            return "secret";
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class SampleExceptionThrowingObject {
+
+        public String getNormalProperty() {
+            return "string-value";
+        }
+
+        public Double getBadProperty() {
+            throw new IllegalStateException("bad object!");
+        }
+
+        public int getAnotherProperty() {
+            return 1;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class SampleSecretAgent {
+
+        public String getCodeName() {
+            return "007";
+        }
+
+        public int getSecretNumber() {
+            return 42;
+        }
+
+        public List<String> getSecretIdentities() {
+            return List.of("Bond", "James Bond");
+        }
+    }
+}


### PR DESCRIPTION
* Add PropertyMaskingSafePropertyWriter which masks specific fields
  when serializing JSON, and which also catches any exceptions
  during serialization and inserts replacement text instead
* Add KiwiJacksonSerializers which provides (at present) a single
  factory method to build a Jackson module that uses the
  PropertyMaskingSafePropertyWriter

Fixes #219
Fixed #220