### PR TITLE
Add minimal script for Maven central deployment

### DIFF
--- a/maven-central-deploy.sh
+++ b/maven-central-deploy.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Deploy maven artifact in current directory into Maven central repository
+# using maven-release-plugin goals
+
+read -r -p "Really deploy to maven central repository  (yes/no)? "
+
+if [[ "$REPLY" == "yes" ]]; then
+  mvn release:clean release:prepare release:perform -e | tee maven-central-deploy.log
+else
+  echo 'Exit without deploy'
+fi


### PR DESCRIPTION
* Copied the script from elucidation and added -r option
  to fix "read without -r will mangle backslashes" problem
  found by shellcheck (SC2162)

Fixes #221