### PR TITLE
Add configurable replacement text in PropertyMaskingSafePropertyWriter

### DIFF
--- a/src/main/java/org/kiwiproject/json/KiwiJacksonSerializers.java
+++ b/src/main/java/org/kiwiproject/json/KiwiJacksonSerializers.java
@@ -22,11 +22,30 @@ public class KiwiJacksonSerializers {
     /**
      * Build a new {@link SimpleModule} that will replace the values of specific fields with a "masked" value
      * and will replace any exceptions with a message indicating the field could not be serialized.
+     * <p>
+     * Uses the default replacement text provided by {@link PropertyMaskingOptions}.
      *
      * @param maskedFieldRegexps list containing regular expressions that define the properties to mask
      * @return a new {@link SimpleModule}
      */
     public static SimpleModule buildPropertyMaskingSafeSerializerModule(List<String> maskedFieldRegexps) {
+        var options = PropertyMaskingOptions.builder()
+                .maskedFieldRegexps(maskedFieldRegexps)
+                .build();
+
+        return buildPropertyMaskingSafeSerializerModule(options);
+    }
+
+    /**
+     * Build a new {@link SimpleModule} that will replace the values of specific fields with a "masked" value
+     * and will replace any exceptions with a message indicating the field could not be serialized.
+     *
+     * @param options the specific masking and serialization error options to use
+     * @return a new {@link SimpleModule}
+     * @implNote Per the docs for {@link BeanSerializerModifier#changeProperties(SerializationConfig, BeanDescription, List)}
+     * the returned list is mutable.
+     */
+    public static SimpleModule buildPropertyMaskingSafeSerializerModule(PropertyMaskingOptions options) {
         var modifier = new BeanSerializerModifier() {
             @Override
             public List<BeanPropertyWriter> changeProperties(SerializationConfig config,
@@ -34,7 +53,7 @@ public class KiwiJacksonSerializers {
                                                              List<BeanPropertyWriter> beanProperties) {
                 return beanProperties.stream()
                         .map(beanPropertyWriter ->
-                                new PropertyMaskingSafePropertyWriter(beanPropertyWriter, maskedFieldRegexps))
+                                new PropertyMaskingSafePropertyWriter(beanPropertyWriter, options))
                         .collect(toList());
             }
         };

--- a/src/main/java/org/kiwiproject/json/PropertyMaskingOptions.java
+++ b/src/main/java/org/kiwiproject/json/PropertyMaskingOptions.java
@@ -1,0 +1,39 @@
+package org.kiwiproject.json;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Options for {@link PropertyMaskingSafePropertyWriter} and {@link KiwiJacksonSerializers}.
+ */
+@Builder
+@Getter
+public class PropertyMaskingOptions {
+
+    private static final String DEFAULT_MASK_TEXT_REPLACEMENT = "********";
+    private static final String DEFAULT_FAILED_TEXT_REPLACEMENT = "(unable to serialize field)";
+
+    /**
+     * Regular expressions that define that field names to be masked, e.g. {@code .*password.*} (note the comparisons
+     * will be case insensitive). Must not be {@code null}, but can be empty. Default is empty.
+     */
+    @NonNull
+    @Builder.Default
+    List<String> maskedFieldRegexps = new ArrayList<>();
+
+    /**
+     * The replacement text for masked field values. Can be {@code null}.
+     */
+    @Builder.Default
+    String maskedFieldReplacementText = DEFAULT_MASK_TEXT_REPLACEMENT;
+
+    /**
+     * The replacement text for serialization errors. Can be {@code null}.
+     */
+    @Builder.Default
+    String serializationErrorReplacementText = DEFAULT_FAILED_TEXT_REPLACEMENT;
+}

--- a/src/test/java/org/kiwiproject/json/PropertyMaskingOptionsTest.java
+++ b/src/test/java/org/kiwiproject/json/PropertyMaskingOptionsTest.java
@@ -1,0 +1,28 @@
+package org.kiwiproject.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("PropertyMaskingOptions")
+class PropertyMaskingOptionsTest {
+
+    @Test
+    void shouldNotAllowNullMaskedFieldRegexps() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> PropertyMaskingOptions.builder()
+                        .maskedFieldRegexps(null)
+                        .build());
+    }
+
+    @Test
+    void shouldHaveDefaultValues() {
+        var defaultOptions = PropertyMaskingOptions.builder().build();
+
+        assertThat(defaultOptions.getMaskedFieldRegexps()).isEmpty();
+        assertThat(defaultOptions.getMaskedFieldReplacementText()).isEqualTo("********");
+        assertThat(defaultOptions.getSerializationErrorReplacementText()).isEqualTo("(unable to serialize field)");
+    }
+}

--- a/src/test/java/org/kiwiproject/junit/jupiter/WhiteBoxTest.java
+++ b/src/test/java/org/kiwiproject/junit/jupiter/WhiteBoxTest.java
@@ -1,0 +1,21 @@
+package org.kiwiproject.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicator that a test is "white box", generally used to indicate a test is calling a non-public API.
+ * This is often useful when testing complex internal logic or exceptions thay are difficult or near impossible
+ * to simulate.
+ * <p>
+ * TODO Should we make this a public part of kiwi?
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Test
+public @interface WhiteBoxTest {
+}


### PR DESCRIPTION
* Add PropertyMaskingOptions configuration class
* Add new constructor accepting a PropertyMaskingOptions
  to PropertyMaskingSafePropertyWriter
* Add new factory method to KiwiJacksonSerializers that accepts
  a PropertyMaskingOptions argument
* Add @WhiteBoxTest test meta-annotation to make it more
  clear which tests are "white box" tests of non-public
  and/or internal methods

Fixes #229