### PR TITLE
Add SimpleRetries utility class

### DIFF
--- a/src/main/java/org/kiwiproject/retry/RetryLogger.java
+++ b/src/main/java/org/kiwiproject/retry/RetryLogger.java
@@ -1,0 +1,80 @@
+package org.kiwiproject.retry;
+
+import static org.postgresql.shaded.com.ongres.scram.common.util.Preconditions.checkArgument;
+
+import lombok.experimental.UtilityClass;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+/**
+ * Package-private helper class to log attempts at different SLF4J logging levels (since SLF4J 1.7.x does not
+ * provide any log methods that accept a {@link Level} object, we unfortunately have to resort to this instead).
+ *
+ * @see Logger SLFJ Logger
+ * @see Level SLF4J Level
+ */
+@UtilityClass
+class RetryLogger {
+
+    /**
+     * Log an attempt for the current attempt number. First attempts are <em>always</em> logged at TRACE level.
+     *
+     * @param logger         the Logger to use
+     * @param level          the Level to log at for retry attempts
+     * @param currentAttempt the current attempt number (starting at 1)
+     * @param message        the message or message template
+     * @param args           the optional arguments if the message is a template
+     */
+    static void logAttempt(Logger logger,
+                           Level level,
+                           long currentAttempt,
+                           String message,
+                           Object... args) {
+
+        checkArgument(currentAttempt > 0, "currentAttempt must be a positive integer");
+
+        // If this is the first attempt, just log the traffic at trace level regardless of the log level argument
+        if (currentAttempt == 1) {
+            logger.trace(message, args);
+            return;
+        }
+
+        // Otherwise, log it at the appropriate level
+        logAttempt(logger, level, message, args);
+    }
+
+    /**
+     * Log an attempt at the specified {@link Level}.
+     *
+     * @param logger  the Logger to use
+     * @param level   the Level to log at for retry attempts
+     * @param message the message or message template
+     * @param args    the optional arguments if the message is a template
+     */
+    static void logAttempt(Logger logger, Level level, String message, Object... args) {
+        switch (level) {
+            case DEBUG:
+                logger.debug(message, args);
+                break;
+
+            case INFO:
+                logger.info(message, args);
+                break;
+
+            case WARN:
+                logger.warn(message, args);
+                break;
+
+            case ERROR:
+                logger.error(message, args);
+                break;
+
+            case TRACE:
+            default:
+                // NOTE: Intentional fall-through from TRACE. Whenever move to JDK 14+ can use enhanced switch
+                //  when we won't need default since we'll be exhaustive on all Level values
+                logger.trace(message, args);
+                break;
+        }
+    }
+}

--- a/src/main/java/org/kiwiproject/retry/SimpleRetries.java
+++ b/src/main/java/org/kiwiproject/retry/SimpleRetries.java
@@ -1,0 +1,376 @@
+package org.kiwiproject.retry;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toList;
+import static org.slf4j.event.Level.TRACE;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.kiwiproject.base.DefaultEnvironment;
+import org.kiwiproject.base.KiwiEnvironment;
+import org.slf4j.event.Level;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntFunction;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+/**
+ * Static utilities for retrying an operation. The {@link Supplier} passed to each method must indicate success or
+ * failure. Success is indicated by returning a non-null value. Failure is indicated by returning {@code null} or
+ * by throwing an exception. Each time a failure occurs, another attempt will be made unless the maximum number
+ * of attempts has been reached.
+ */
+@SuppressWarnings("WeakerAccess")
+@UtilityClass
+@Slf4j
+public class SimpleRetries {
+
+    private static final KiwiEnvironment DEFAULT_KIWI_ENV = new DefaultEnvironment();
+
+    private static final String ATTEMPT_MSG_TEMPLATE = "Attempt {} of {} to obtain a(n) {} from supplier";
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return an Optional which either contains a value, or is empty if all attempts failed
+     */
+    public static <T> Optional<T> tryGetObject(int maxAttempts,
+                                               long retryDelay, TimeUnit retryDelayUnit,
+                                               Supplier<T> supplier) {
+        return tryGetObject(maxAttempts, retryDelay, retryDelayUnit, DEFAULT_KIWI_ENV, supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level
+     * using "object" as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param environment    the {@link KiwiEnvironment} to use when sleeping between attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return an Optional which either contains a value, or is empty if all attempts failed
+     */
+    public static <T> Optional<T> tryGetObject(int maxAttempts,
+                                               long retryDelay, TimeUnit retryDelayUnit,
+                                               KiwiEnvironment environment,
+                                               Supplier<T> supplier) {
+        return tryGetObject(maxAttempts, retryDelay, retryDelayUnit, environment, "object", TRACE, supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level
+     * using the given {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return an Optional which either contains a value, or is empty if all attempts failed
+     */
+    public static <T> Optional<T> tryGetObject(int maxAttempts,
+                                               long retryDelay, TimeUnit retryDelayUnit,
+                                               Class<T> type,
+                                               Supplier<T> supplier) {
+        return tryGetObject(maxAttempts, retryDelay, retryDelayUnit, DEFAULT_KIWI_ENV, type, supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE
+     * level, using the given {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param environment    the {@link KiwiEnvironment} to use when sleeping between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return an Optional which either contains a value, or is empty if all attempts failed
+     */
+    public static <T> Optional<T> tryGetObject(int maxAttempts,
+                                               long retryDelay, TimeUnit retryDelayUnit,
+                                               KiwiEnvironment environment,
+                                               Class<T> type,
+                                               Supplier<T> supplier) {
+        return tryGetObject(maxAttempts, retryDelay, retryDelayUnit, environment, type.getSimpleName(), TRACE, supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt at TRACE level, and logs
+     * retries at the given {@code level}, always using {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param environment    the {@link KiwiEnvironment} to use when sleeping between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param level          the SLF4J log {@link Level} at which to log retries
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return an Optional which either contains a value, or is empty if all attempts failed
+     */
+    public static <T> Optional<T> tryGetObject(int maxAttempts,
+                                               long retryDelay, TimeUnit retryDelayUnit,
+                                               KiwiEnvironment environment,
+                                               String type,
+                                               Level level,
+                                               Supplier<T> supplier) {
+
+        return IntStream.rangeClosed(1, maxAttempts)
+                .mapToObj(objectOrNull(maxAttempts, retryDelay, retryDelayUnit, environment, type, level, supplier))
+                .filter(Objects::nonNull)
+                .findFirst();
+    }
+
+    private <T> IntFunction<T> objectOrNull(int maxAttempts,
+                                            long retryDelay, TimeUnit retryDelayUnit,
+                                            KiwiEnvironment environment,
+                                            String type,
+                                            Level level,
+                                            Supplier<T> supplier) {
+
+        return currentAttempt -> {
+            RetryLogger.logAttempt(LOG, level, currentAttempt, ATTEMPT_MSG_TEMPLATE, currentAttempt, maxAttempts, type);
+
+            T object = safeGetOrNull(currentAttempt, maxAttempts, type, level, supplier);
+
+            if (isNull(object) && currentAttempt < maxAttempts) {
+                environment.sleepQuietly(retryDelay, retryDelayUnit);
+            } else if (nonNull(object)) {
+                traceLogResultReceived(currentAttempt, maxAttempts, type);
+            }
+
+            return object;
+        };
+    }
+
+    private static <T> T safeGetOrNull(int currentAttempt,
+                                       int maxAttempts,
+                                       String type,
+                                       Level level,
+                                       Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            RetryLogger.logAttempt(LOG, level, "Error occurred on attempt {} of {} getting {} from supplier",
+                    currentAttempt, maxAttempts, type, e);
+            return null;
+        }
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level
+     * using "object" as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return a {@link RetryResult}
+     */
+    public static <T> RetryResult<T> tryGetObjectCollectingErrors(int maxAttempts,
+                                                                  long retryDelay, TimeUnit retryDelayUnit,
+                                                                  Supplier<T> supplier) {
+        return tryGetObjectCollectingErrors(maxAttempts, retryDelay, retryDelayUnit, DEFAULT_KIWI_ENV, "object", supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level
+     * using the given {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return a {@link RetryResult}
+     */
+    public static <T> RetryResult<T> tryGetObjectCollectingErrors(int maxAttempts,
+                                                                  long retryDelay, TimeUnit retryDelayUnit,
+                                                                  Class<T> type,
+                                                                  Supplier<T> supplier) {
+        return tryGetObjectCollectingErrors(maxAttempts, retryDelay, retryDelayUnit, DEFAULT_KIWI_ENV, type, supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level
+     * using the given {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param environment    the {@link KiwiEnvironment} to use when sleeping between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return a {@link RetryResult}
+     */
+    public static <T> RetryResult<T> tryGetObjectCollectingErrors(int maxAttempts,
+                                                                  long retryDelay, TimeUnit retryDelayUnit,
+                                                                  KiwiEnvironment environment,
+                                                                  Class<T> type,
+                                                                  Supplier<T> supplier) {
+        return tryGetObjectCollectingErrors(maxAttempts, retryDelay, retryDelayUnit, environment, type.getSimpleName(), supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt and retries at TRACE level
+     * using the given {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param environment    the {@link KiwiEnvironment} to use when sleeping between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return a {@link RetryResult}
+     */
+    public static <T> RetryResult<T> tryGetObjectCollectingErrors(int maxAttempts,
+                                                                  long retryDelay, TimeUnit retryDelayUnit,
+                                                                  KiwiEnvironment environment,
+                                                                  String type,
+                                                                  Supplier<T> supplier) {
+        return tryGetObjectCollectingErrors(maxAttempts, retryDelay, retryDelayUnit, environment, type, TRACE, supplier);
+    }
+
+    /**
+     * Try to get an object, making up to {@code maxAttempts} attempts. Logs first attempt at TRACE level and logs
+     * retries at the given {@code level}, always using {@code type} as the description.
+     *
+     * @param maxAttempts    the maximum number of attempts to make before giving up
+     * @param retryDelay     constant delay time between attempts
+     * @param retryDelayUnit delay time unit between attempts
+     * @param environment    the {@link KiwiEnvironment} to use when sleeping between attempts
+     * @param type           the type of object we are attempting to return, used when logging attempts
+     * @param level          the SLF4J log {@link Level} at which to log retries
+     * @param supplier       on success return the object; return {@code null} or throw exception if attempt failed
+     * @param <T>            the type of object
+     * @return a {@link RetryResult}
+     */
+    public static <T> RetryResult<T> tryGetObjectCollectingErrors(int maxAttempts,
+                                                                  long retryDelay, TimeUnit retryDelayUnit,
+                                                                  KiwiEnvironment environment,
+                                                                  String type,
+                                                                  Level level,
+                                                                  Supplier<T> supplier) {
+
+        List<Pair<T, Exception>> results =
+                collectResults(maxAttempts, retryDelay, retryDelayUnit, environment, type, level, supplier);
+
+        var numAttemptsMade = results.size();
+
+        var object = results.stream()
+                .filter(pair -> nonNull(pair.getLeft()))
+                .map(Pair::getLeft)
+                .findFirst()
+                .orElse(null);
+
+        var errors = results.stream()
+                .filter(pair -> nonNull(pair.getRight()))
+                .map(Pair::getRight)
+                .collect(toList());
+
+        return new RetryResult<>(numAttemptsMade, maxAttempts, object, errors);
+    }
+
+    /**
+     * This method is specifically using imperative style because:
+     * <p>
+     * (1) JDK 9 has a takeWhile(Predicate) method but it only includes the stream items that match the
+     * predicate, which means we would lose the first non-matching item (the one with the actual result we need).
+     * <p>
+     * (2) Even though the lovely StreamEx library has a takeWhileInclusive(Predicate) that takes items while
+     * the predicate is matched, plus the first non-matching item, I don't want to have to include a hard dependency
+     * for just one function.
+     * <p>
+     * (3) Copying the code from StreamEx or trying to implement it here almost certainly is not worth it when
+     * considering benefits vs. costs. If we ever start needing StreamEx in a bunch of other places, then this decision
+     * can be revisited.
+     * <p>
+     * The following is what the code would look like using StreamEx and takeWhileInclusive:
+     * <pre>
+     * Stream&lt;Pair&lt;T, Exception>> resultStream = IntStream.rangeClosed(1, maxAttempts)
+     *     .mapToObj(currentAttempt ->
+     *         resultOrErrorPair(currentAttempt, maxAttempts, retryDelay, retryDelayUnit, environment, type, level, supplier));
+     *
+     * return StreamEx.of(resultStream)
+     *     .takeWhileInclusive(result -> isNull(result.getLeft())
+     *     .collect(toList());
+     * </pre>
+     */
+    private static <T> List<Pair<T, Exception>> collectResults(int maxAttempts,
+                                                               long retryDelay, TimeUnit retryDelayUnit,
+                                                               KiwiEnvironment environment,
+                                                               String type,
+                                                               Level level,
+                                                               Supplier<T> supplier) {
+
+        List<Pair<T, Exception>> results = new ArrayList<>();
+
+        for (int currentAttempt = 1; currentAttempt <= maxAttempts; currentAttempt++) {
+            Pair<T, Exception> resultOrError =
+                    resultOrErrorPair(currentAttempt, maxAttempts, retryDelay, retryDelayUnit, environment, type, level, supplier);
+
+            results.add(resultOrError);
+
+            if (nonNull(resultOrError.getLeft())) {
+                traceLogResultReceived(currentAttempt, maxAttempts, type);
+                break;
+            }
+        }
+
+        return results;
+    }
+
+    // Suppress Sonar "Methods should not have too many parameters" as this is a private method and there isn't
+    // a clearly superior alternative.
+    @SuppressWarnings("java:S107")
+    private static <T> Pair<T, Exception> resultOrErrorPair(int currentAttempt,
+                                                            int maxAttempts,
+                                                            long retryDelay, TimeUnit retryDelayUnit,
+                                                            KiwiEnvironment environment,
+                                                            String type,
+                                                            Level level,
+                                                            Supplier<T> supplier) {
+
+        RetryLogger.logAttempt(LOG, level, currentAttempt, ATTEMPT_MSG_TEMPLATE, currentAttempt, maxAttempts, type);
+
+        T object = null;
+        Exception error = null;
+        try {
+            object = supplier.get();
+        } catch (Exception e) {
+            error = e;
+        }
+
+        if (isNull(object) && currentAttempt < maxAttempts) {
+            environment.sleepQuietly(retryDelay, retryDelayUnit);
+        }
+
+        return Pair.of(object, error);
+    }
+
+    private static void traceLogResultReceived(int currentAttempt, int maxAttempts, String type) {
+        LOG.trace("Received a result on attempt {} of {} to get {}; no more attempts are needed",
+                currentAttempt, maxAttempts, type);
+    }
+}

--- a/src/test/java/org/kiwiproject/retry/ExceptionThrowingSupplier.java
+++ b/src/test/java/org/kiwiproject/retry/ExceptionThrowingSupplier.java
@@ -1,0 +1,30 @@
+package org.kiwiproject.retry;
+
+import lombok.Getter;
+
+class ExceptionThrowingSupplier<T> implements InvocationCountingSupplier<T> {
+
+    private final T value;
+    private int timesToThrowException;
+
+    @Getter
+    private int count;
+
+    ExceptionThrowingSupplier(T value) {
+        this.value = value;
+    }
+
+    ExceptionThrowingSupplier<T> withTimesToThrowException(int times) {
+        this.timesToThrowException = times;
+        return this;
+    }
+
+    @Override
+    public T get() {
+        ++count;
+        if (count <= timesToThrowException) {
+            throw new RuntimeException("error on attempt " + count);
+        }
+        return value;
+    }
+}

--- a/src/test/java/org/kiwiproject/retry/InMemoryAppender.java
+++ b/src/test/java/org/kiwiproject/retry/InMemoryAppender.java
@@ -2,6 +2,7 @@ package org.kiwiproject.retry;
 
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
@@ -25,6 +26,16 @@ public class InMemoryAppender extends AppenderBase<ILoggingEvent> {
     public InMemoryAppender() {
         this.messageOrder = new AtomicInteger();
         this.eventMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Assert this appender has the expected number of logging events, and if the assertion succeeds, return a
+     * list containing those events.
+     */
+    List<ILoggingEvent> assertNumberOfLoggingEventsAndGet(int expectedEventCount) {
+        var events = getOrderedEvents();
+        assertThat(events).hasSize(expectedEventCount);
+        return events;
     }
 
     @Override

--- a/src/test/java/org/kiwiproject/retry/InvocationCountingSupplier.java
+++ b/src/test/java/org/kiwiproject/retry/InvocationCountingSupplier.java
@@ -1,0 +1,8 @@
+package org.kiwiproject.retry;
+
+import java.util.function.Supplier;
+
+interface InvocationCountingSupplier<T> extends Supplier<T> {
+
+    int getCount();
+}

--- a/src/test/java/org/kiwiproject/retry/NullReturningSupplier.java
+++ b/src/test/java/org/kiwiproject/retry/NullReturningSupplier.java
@@ -1,0 +1,30 @@
+package org.kiwiproject.retry;
+
+import lombok.Getter;
+
+class NullReturningSupplier<T> implements InvocationCountingSupplier<T> {
+
+    private final T value;
+    private int timesToReturnNull;
+
+    @Getter
+    private int count;
+
+    NullReturningSupplier(T value) {
+        this.value = value;
+    }
+
+    NullReturningSupplier<T> withTimesToReturnNull(int times) {
+        this.timesToReturnNull = times;
+        return this;
+    }
+
+    @Override
+    public T get() {
+        ++count;
+        if (count <= timesToReturnNull) {
+            return null;
+        }
+        return value;
+    }
+}

--- a/src/test/java/org/kiwiproject/retry/RetryLoggerTest.java
+++ b/src/test/java/org/kiwiproject/retry/RetryLoggerTest.java
@@ -1,0 +1,77 @@
+package org.kiwiproject.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.kiwiproject.collect.KiwiLists.first;
+
+import ch.qos.logback.classic.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+@DisplayName("RetryLogger")
+class RetryLoggerTest {
+
+    // Note this is a Logback Logger, NOT an SLF4J one, because we need to be able to get the MapAppender
+    // The cast is necessary since LoggerFactory returns an SLF4J Logger.
+    private static final Logger LOG = (Logger) LoggerFactory.getLogger(RetryLoggerTest.class);
+
+    private InMemoryAppender appender;
+
+    @BeforeEach
+    void setUp() {
+        appender = (InMemoryAppender) LOG.getAppender("MEMORY");
+    }
+
+    @AfterEach
+    void tearDown() {
+        appender.clearEvents();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void shouldNotAcceptZeroOrNegativeAttemptNumbers(int currentAttempt) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> RetryLogger.logAttempt(LOG, Level.INFO, currentAttempt, "the answer is always 42"));
+    }
+
+    @Nested
+    class OnFirstAttempt {
+
+        @Test
+        void shouldAlwaysLogAtTraceLevel() {
+            RetryLogger.logAttempt(LOG, Level.WARN, 1, "the answer is {}", 42);
+
+            var events = appender.assertNumberOfLoggingEventsAndGet(1);
+
+            var event = first(events);
+            assertThat(event.getFormattedMessage()).isEqualTo("the answer is 42");
+            assertThat(event.getLevel()).isEqualTo(ch.qos.logback.classic.Level.TRACE);
+        }
+    }
+
+    @Nested
+    class OnRetries {
+
+        @ParameterizedTest
+        @EnumSource(Level.class)
+        void shouldLogAtSpecifiedLevel(Level slf4jLevel) {
+            RetryLogger.logAttempt(LOG, slf4jLevel, 2, "the answer is {}", 84);
+
+            var events = appender.assertNumberOfLoggingEventsAndGet(1);
+
+            var event = first(events);
+            assertThat(event.getFormattedMessage()).isEqualTo("the answer is 84");
+            assertThat(event.getLevel())
+                    .describedAs("Expected level to be: %s", slf4jLevel)
+                    .isEqualTo(ch.qos.logback.classic.Level.valueOf(slf4jLevel.name()));
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/retry/RetryResultLoggerTest.java
+++ b/src/test/java/org/kiwiproject/retry/RetryResultLoggerTest.java
@@ -382,9 +382,7 @@ class RetryResultLoggerTest {
     }
 
     private List<ILoggingEvent> assertNumberOfLoggingEventsAndGet(int expectedEventCount) {
-        var events = appender.getOrderedEvents();
-        assertThat(events).hasSize(expectedEventCount);
-        return events;
+        return appender.assertNumberOfLoggingEventsAndGet(expectedEventCount);
     }
 
     private static class GeneralDataException extends RuntimeException {

--- a/src/test/java/org/kiwiproject/retry/SimpleRetriesTest.java
+++ b/src/test/java/org/kiwiproject/retry/SimpleRetriesTest.java
@@ -1,0 +1,246 @@
+package org.kiwiproject.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.base.KiwiEnvironment;
+import org.slf4j.event.Level;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@DisplayName("SimpleRetries")
+class SimpleRetriesTest {
+
+    private static final int MAX_ATTEMPTS = 10;
+    private static final int RETRY_DELAY = 1;
+    private static final TimeUnit RETRY_UNIT = TimeUnit.SECONDS;
+
+    private KiwiEnvironment environment;
+
+    @BeforeEach
+    void setUp() {
+        environment = mock(KiwiEnvironment.class);
+    }
+
+    @Nested
+    class TryGetObject {
+
+        @Nested
+        class ShouldHaveObject {
+
+            @Test
+            void whenSucceedsOnFirstAttempt() {
+                var supplier = new NullReturningSupplier<>("orange").withTimesToReturnNull(0);
+                Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, RETRY_DELAY, RETRY_UNIT, environment, String.class, supplier);
+
+                assertThat(result).contains("orange");
+                assertThat(supplier.getCount()).isOne();
+
+                verifyNoInteractions(environment);
+            }
+
+            @Nested
+            class WhenSucceedsOnIntermediateAttempt {
+
+                @Test
+                void whenNoTypeGiven() {
+                    var numTimesToFail = 2;
+                    var supplier = new NullReturningSupplier<>("blue").withTimesToReturnNull(numTimesToFail);
+
+                    Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, 10, TimeUnit.MILLISECONDS, supplier);
+
+                    assertThat(result).contains("blue");
+                    assertThat(supplier.getCount()).isEqualTo(numTimesToFail + 1);
+                }
+
+                @Test
+                void whenGivenObjectType() {
+                    var numTimesToFail = 4;
+                    var supplier = new NullReturningSupplier<>("orange").withTimesToReturnNull(numTimesToFail);
+
+                    Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, 10, TimeUnit.MILLISECONDS, String.class, supplier);
+
+                    assertThat(result).contains("orange");
+                    assertThat(supplier.getCount()).isEqualTo(numTimesToFail + 1);
+                }
+
+                @Test
+                void whenGivenExplicitRetryLogLevel() {
+                    var numTimesToFail = 2;
+                    var supplier = new ExceptionThrowingSupplier<>("red").withTimesToThrowException(numTimesToFail);
+
+                    Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, 10, TimeUnit.MILLISECONDS, environment, "String", Level.WARN, supplier);
+
+                    assertThat(result).contains("red");
+                    assertThat(supplier.getCount()).isEqualTo(numTimesToFail + 1);
+                }
+
+                @Test
+                void whenSupplierReturnsValueOnSecondAttempt() {
+                    var numTimesToFail = 1;
+                    var supplier = new NullReturningSupplier<>("orange").withTimesToReturnNull(numTimesToFail);
+
+                    Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, RETRY_DELAY, RETRY_UNIT, environment, String.class, supplier);
+
+                    assertThat(result).contains("orange");
+                    assertThat(supplier.getCount()).isEqualTo(2);
+
+                    verify(environment, times(numTimesToFail)).sleepQuietly(RETRY_DELAY, RETRY_UNIT);
+                }
+
+                @Test
+                void whenSupplierReturnsValueOnLastAttempt() {
+                    var supplier = new NullReturningSupplier<>("blue").withTimesToReturnNull(MAX_ATTEMPTS - 1);
+
+                    Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, RETRY_DELAY, RETRY_UNIT, environment, supplier);
+
+                    assertThat(result).contains("blue");
+                    assertThat(supplier.getCount()).isEqualTo(MAX_ATTEMPTS);
+
+                    verify(environment, times(MAX_ATTEMPTS - 1)).sleepQuietly(RETRY_DELAY, RETRY_UNIT);
+                }
+
+                @Test
+                void whenSupplierThrowsExceptions() {
+                    var numTimesToFail = 5;
+                    var supplier = new ExceptionThrowingSupplier<>("yellow").withTimesToThrowException(numTimesToFail);
+
+                    Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, RETRY_DELAY, RETRY_UNIT, environment, supplier);
+
+                    assertThat(result).contains("yellow");
+                    assertThat(supplier.getCount()).isEqualTo(numTimesToFail + 1);
+
+                    verify(environment, times(numTimesToFail)).sleepQuietly(RETRY_DELAY, RETRY_UNIT);
+                }
+            }
+        }
+
+        @Nested
+        class ShouldNotHaveObject {
+
+            @Test
+            void whenSupplierAlwaysReturnsNull() {
+                var supplier = new NullReturningSupplier<>("purple").withTimesToReturnNull(MAX_ATTEMPTS);
+
+                Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, RETRY_DELAY, RETRY_UNIT, environment, supplier);
+
+                assertThat(result).isEmpty();
+                assertThat(supplier.getCount()).isEqualTo(MAX_ATTEMPTS);
+
+                verify(environment, times(MAX_ATTEMPTS - 1)).sleepQuietly(RETRY_DELAY, RETRY_UNIT);
+            }
+
+            @Test
+            void whenSupplierAlwaysThrowsExceptions() {
+                var supplier = new ExceptionThrowingSupplier<>("green").withTimesToThrowException(MAX_ATTEMPTS);
+
+                Optional<String> result = SimpleRetries.tryGetObject(MAX_ATTEMPTS, RETRY_DELAY, RETRY_UNIT, environment, supplier);
+
+                assertThat(result).isEmpty();
+                assertThat(supplier.getCount()).isEqualTo(MAX_ATTEMPTS);
+
+                verify(environment, times(MAX_ATTEMPTS - 1)).sleepQuietly(RETRY_DELAY, RETRY_UNIT);
+            }
+        }
+    }
+
+    @Nested
+    class TryGetObjectCollectingErrors {
+
+        @Nested
+        class ShouldHaveResultAndNoErrors {
+
+            @Test
+            void whenSucceedsOnFirstAttempt() {
+                Supplier<Integer> supplier = () -> 42;
+
+                var retryResult = SimpleRetries.tryGetObjectCollectingErrors(5, 1, TimeUnit.SECONDS, Integer.class, supplier);
+
+                assertThat(retryResult.succeeded()).isTrue();
+                assertThat(retryResult.getObjectIfPresent()).hasValue(42);
+                assertThat(retryResult.getErrors()).isEmpty();
+            }
+
+            @Test
+            void whenSucceedsOnLastAttempt_ButNoExceptionsWereThrown() {
+                int maxAttempts = 5;
+                var supplier = new NullReturningSupplier<>(42).withTimesToReturnNull(maxAttempts - 1);
+
+                var retryResult = SimpleRetries.tryGetObjectCollectingErrors(maxAttempts, 10, TimeUnit.MILLISECONDS, supplier);
+
+                assertThat(supplier.getCount()).isEqualTo(maxAttempts);
+                assertThat(retryResult.succeeded()).isTrue();
+                assertThat(retryResult.getObjectIfPresent()).hasValue(42);
+                assertThat(retryResult.getErrors()).isEmpty();
+            }
+        }
+
+        @Nested
+        class ShouldHaveResultAndErrors {
+
+            @Test
+            void whenSucceedsOnIntermediateAttempt_AndExceptionsWereThrown() {
+                int attemptsToFail = 2;
+                int maxAttempts = 5;
+                var supplier = new ExceptionThrowingSupplier<>(42).withTimesToThrowException(attemptsToFail);
+
+                var retryResult = SimpleRetries.tryGetObjectCollectingErrors(maxAttempts, 25, TimeUnit.MILLISECONDS, Integer.class, supplier);
+
+                assertThat(supplier.getCount()).isEqualTo(attemptsToFail + 1);
+                assertThat(retryResult.succeeded()).isTrue();
+                assertThat(retryResult.getObjectIfPresent()).hasValue(42);
+                assertThat(retryResult.getErrors()).hasSize(attemptsToFail);
+            }
+
+            @Test
+            void whenSucceedsOnLastAttempt_AndExceptionsWereThrown() {
+                int maxAttempts = 5;
+                var supplier = new ExceptionThrowingSupplier<>(42).withTimesToThrowException(maxAttempts - 1);
+
+                var retryResult = SimpleRetries.tryGetObjectCollectingErrors(maxAttempts, 10, TimeUnit.MILLISECONDS, supplier);
+
+                assertThat(supplier.getCount()).isEqualTo(maxAttempts);
+                assertThat(retryResult.succeeded()).isTrue();
+                assertThat(retryResult.getObjectIfPresent()).hasValue(42);
+                assertThat(retryResult.getErrors()).hasSize(maxAttempts - 1);
+            }
+        }
+
+        @Nested
+        class ShouldHaveNoResult {
+
+            @Test
+            void whenSupplierAlwaysThrowsException() {
+                int maxAttempts = 3;
+                var supplier = new ExceptionThrowingSupplier<>("gray").withTimesToThrowException(maxAttempts);
+
+                var retryResult = SimpleRetries.tryGetObjectCollectingErrors(maxAttempts, 10, TimeUnit.MILLISECONDS, supplier);
+
+                assertThat(retryResult.failed()).isTrue();
+                assertThat(retryResult.getObjectIfPresent()).isEmpty();
+                assertThat(retryResult.getErrors()).hasSize(maxAttempts);
+            }
+
+            @Test
+            void whenSupplierAlwaysReturnsNull_ButNoExceptionsThrown() {
+                int maxAttempts = 5;
+                var supplier = new NullReturningSupplier<>("black").withTimesToReturnNull(maxAttempts);
+
+                var retryResult = SimpleRetries.tryGetObjectCollectingErrors(maxAttempts, 10, TimeUnit.MILLISECONDS, supplier);
+
+                assertThat(retryResult.failed()).isTrue();
+                assertThat(retryResult.getObjectIfPresent()).isEmpty();
+                assertThat(retryResult.getErrors()).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -17,8 +17,13 @@
     -->
     <logger name="org.kiwiproject.logging.LazyLogParameterSupplierTest" level="DEBUG"/>
 
-    <!-- This is required for the RetryResultLoggerTest -->
+    <!-- This is required for RetryLoggerTest and RetryResultLoggerTest -->
     <appender name="MEMORY" class="org.kiwiproject.retry.InMemoryAppender"/>
+
+    <!-- This is required for the RetryLoggerTest -->
+    <logger name="org.kiwiproject.retry.RetryLoggerTest" level="TRACE">
+        <appender-ref ref="MEMORY"/>
+    </logger>
 
     <!-- This is required for the RetryResultLoggerTest -->
     <logger name="org.kiwiproject.retry.RetryResultLoggerTest" level="DEBUG">


### PR DESCRIPTION
* Add SimpleRetries and package-private helper RetryLogger
* Add test classes InvocationCountingSupplier, NullReturningSupplier,
  and ExceptionThrowingSupplier
* Modify logback.xml to use the in-memory appender on the
  RetryLoggerTest logger
* Move assertNumberOfLoggingEventsAndGet method from
  RetryResultLoggerTest to InMemoryAppender for re-use in
  RetryLoggerTest

Fixes #243