### PR TITLE
Add KiwiRetryerPredicates

### DIFF
--- a/src/main/java/org/kiwiproject/retry/KiwiRetryerPredicates.java
+++ b/src/main/java/org/kiwiproject/retry/KiwiRetryerPredicates.java
@@ -1,0 +1,85 @@
+package org.kiwiproject.retry;
+
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
+import static org.apache.commons.lang3.exception.ExceptionUtils.indexOfType;
+
+import com.google.common.base.Predicate;
+import lombok.experimental.UtilityClass;
+
+import javax.net.ssl.SSLHandshakeException;
+import javax.ws.rs.core.Response;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+
+/**
+ * Some potentially useful predicates that can be used out of the box with {@link KiwiRetryer} or directly with
+ * {@link com.github.rholder.retry.RetryerBuilder}, or anything else that accepts a Guava {@link Predicate}.
+ * <p>
+ * Note that the Jakarta RS-API needs to be available at runtime to use the {@link Response} predicates.
+ *
+ * @implNote These use Guava's and not the JDK's predicate class, because the guava-retrying library used in
+ * {@link KiwiRetryer} uses Guava's {@link Predicate}.
+ */
+@SuppressWarnings({"Guava", "java:S4738"})
+@UtilityClass
+public class KiwiRetryerPredicates {
+
+    /**
+     * Check if a given {@link Throwable} is or has a root cause of {@link UnknownHostException}.
+     *
+     * @implNote UnknownHostException does not have a cause, which is why we check only the instance and root cause
+     */
+    public static final Predicate<Throwable> UNKNOWN_HOST = ex ->
+            ex instanceof UnknownHostException || getRootCause(ex) instanceof UnknownHostException;
+
+
+    /**
+     * Check if a given {@link Throwable} is or has a root cause of {@link ConnectException}.
+     *
+     * @implNote ConnectException does not have a cause, which is why we check only the instance and root cause
+     */
+    public static final Predicate<Throwable> CONNECTION_ERROR = ex ->
+            ex instanceof ConnectException || getRootCause(ex) instanceof ConnectException;
+
+
+    /**
+     * Check if a given {@link Throwable} is or has a root cause of {@link SocketTimeoutException}.
+     *
+     * @implNote SocketTimeoutException does not have a cause, which is why we check only the instance and root cause
+     */
+    public static final Predicate<Throwable> SOCKET_TIMEOUT = ex ->
+            ex instanceof SocketTimeoutException || getRootCause(ex) instanceof SocketTimeoutException;
+
+
+    /**
+     * Check if a given {@link Throwable} is or contains a {@link javax.net.ssl.SSLHandshakeException} somewhere in
+     * the causal chain.
+     */
+    public static final Predicate<Throwable> SSL_HANDSHAKE_ERROR = ex ->
+            ex instanceof SSLHandshakeException || indexOfType(ex, SSLHandshakeException.class) > -1;
+
+
+    /**
+     * Check if a given {@link Throwable} is or has a root cause of {@link NoRouteToHostException}.
+     *
+     * @implNote NoRouteToHostException does not have a cause, which is why we check only the instance and root cause
+     */
+    public static final Predicate<Throwable> NO_ROUTE_TO_HOST = ex ->
+            ex instanceof NoRouteToHostException || getRootCause(ex) instanceof NoRouteToHostException;
+
+    /**
+     * Check if a given JAX-RS {@link Response} is a client error (4xx).
+     */
+    public static final Predicate<Response> IS_HTTP_400s = response ->
+            nonNull(response) && Response.Status.Family.CLIENT_ERROR == response.getStatusInfo().getFamily();
+
+    /**
+     * Check if a given JAX-RS {@link Response} is a client error (4xx).
+     */
+    public static final Predicate<Response> IS_HTTP_500s = response ->
+            nonNull(response) && Response.Status.Family.SERVER_ERROR == response.getStatusInfo().getFamily();
+
+}

--- a/src/test/java/org/kiwiproject/retry/KiwiRetryerPredicatesTest.java
+++ b/src/test/java/org/kiwiproject/retry/KiwiRetryerPredicatesTest.java
@@ -1,0 +1,241 @@
+package org.kiwiproject.retry;
+
+import static com.google.common.base.Verify.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.net.ssl.SSLHandshakeException;
+import javax.ws.rs.core.Response;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.net.ConnectException;
+import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Locale;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * @implNote The nested classes ending in "_Predicate" and extending {@link AbstractThrowablePredicateTest}
+ * automatically execute all the tests defined in that base class for a given predicate. The steps for adding
+ * a new predicate are:
+ * <ol>
+ *     <li>Create a {@link Nested} class named as "[PREDICATE_NAME]_Predicate"</li>
+ *     <li>Make the class extend {@link AbstractThrowablePredicateTest}</li>
+ *     <li>Implement the required getter methods (easiest to use Lombok to generate the getter methods)</li>
+ * </ol>
+ */
+@DisplayName("KiwiRetryerPredicates")
+class KiwiRetryerPredicatesTest {
+
+    @Nested
+    @Getter
+    class UNKNOWN_HOST_Predicate extends AbstractThrowablePredicateTest {
+        private final Throwable throwable = new UnknownHostException("This host is not known to me!");
+        private final Predicate<Throwable> predicate = KiwiRetryerPredicates.UNKNOWN_HOST;
+    }
+
+    @Nested
+    @Getter
+    class CONNECTION_ERROR_Predicate extends AbstractThrowablePredicateTest {
+        private final Throwable throwable = new ConnectException("I'm having trouble connecting...");
+        private final Predicate<Throwable> predicate = KiwiRetryerPredicates.CONNECTION_ERROR;
+    }
+
+    @Nested
+    @Getter
+    class SOCKET_TIMEOUT_Predicate extends AbstractThrowablePredicateTest {
+        private final Throwable throwable = new SocketTimeoutException("Did it actually finish? No idea...");
+        private final Predicate<Throwable> predicate = KiwiRetryerPredicates.SOCKET_TIMEOUT;
+    }
+
+    @Nested
+    @Getter
+    class SSL_HANDSHAKE_ERROR_Predicate extends AbstractThrowablePredicateTest {
+        private final Throwable throwable = new SSLHandshakeException("Remote host closed connection during handshake");
+        private final Predicate<Throwable> predicate = KiwiRetryerPredicates.SSL_HANDSHAKE_ERROR;
+    }
+
+    @Nested
+    @Getter
+    class NO_ROUTE_TO_HOST_Predicate extends AbstractThrowablePredicateTest {
+        private final Throwable throwable = new NoRouteToHostException("Where did it go?");
+        private final Predicate<Throwable> predicate = KiwiRetryerPredicates.NO_ROUTE_TO_HOST;
+    }
+
+    /**
+     * Base class providing test generation for the Throwable predicates in KiwiRetryerPredicates.
+     */
+    @DisplayNameGeneration(PredicateDisplayNameGenerator.class)
+    static abstract class AbstractThrowablePredicateTest {
+
+        /**
+         * The predicate to test.
+         */
+        abstract Predicate<Throwable> getPredicate();
+
+        /**
+         * An exception instance of the same type that the above predicate tests.
+         */
+        abstract Throwable getThrowable();
+
+        @Test
+        void whenTheExpectedExceptionIsTheDirectException_shouldBeTrue() {
+            assertThat(getPredicate().test(getThrowable())).isTrue();
+        }
+
+        @Test
+        void whenTheExpectedExceptionIsTheExceptionCause_shouldBeTrue() {
+            assertThat(getPredicate().test(makeThrowableTheExceptionCause(getThrowable()))).isTrue();
+        }
+
+        @Test
+        void whenTheExpectedExceptionIsTheRootCause_shouldBeTrue() {
+            assertThat(getPredicate().test(makeThrowableTheRootCause(getThrowable()))).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(classes = {
+                RuntimeException.class,
+                IllegalStateException.class,
+                IOException.class,
+                FileNotFoundException.class
+        })
+        void whenIsAnExceptionOfType_shouldBeFalse(Class<?> clazz) throws Exception {
+            var throwable = (Throwable) clazz.getDeclaredConstructor(String.class).newInstance("oopsy daisy");
+
+            assertThat(getPredicate().test(throwable)).isFalse();
+        }
+
+        private IOException makeThrowableTheExceptionCause(Throwable t) {
+            return new IOException("well, something went wrong", t);
+        }
+
+        private UncheckedIOException makeThrowableTheRootCause(Throwable t) {
+            return new UncheckedIOException(makeThrowableTheExceptionCause(t));
+        }
+    }
+
+    /**
+     * Name generator for test classes that extend {@link AbstractThrowablePredicateTest}.
+     */
+    private static class PredicateDisplayNameGenerator implements DisplayNameGenerator {
+
+        @Override
+        public String generateDisplayNameForClass(Class<?> testClass) {
+            return testClass.getSimpleName();
+        }
+
+        @Override
+        public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+            return f("The {} predicate returns", stripTrailingTestSuffix(nestedClass));
+        }
+
+        private String stripTrailingTestSuffix(Class<?> clazz) {
+            return clazz.getSimpleName().replace("_Predicate", "");
+        }
+
+        // Generates display name like: "true when the expected exception is the root cause" from
+        // method names that have the format: <camelCaseConditionDescription>_[shouldBeTrue|shouldBeFalse]
+        @Override
+        public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+            var methodName = testMethod.getName();
+            var parts = methodName.split("_");
+
+            verify(parts.length == 2, "Invalid test method name: %s", methodName);
+            verify("shouldBeTrue".equals(parts[1]) || "shouldBeFalse".equals(parts[1]),
+                    "Test method must end with shouldBeTrue or shouldBeFalse");
+
+            var expectedTestResult = parts[1].equals("shouldBeTrue") ? "true" : "false";
+            var conditionMessage = String.join(" ", StringUtils.splitByCharacterTypeCamelCase(parts[0]))
+                    .toLowerCase(Locale.ENGLISH);
+
+            return f("{} {}", expectedTestResult, conditionMessage);
+        }
+    }
+
+    @Nested
+    class IS_HTTP_400s {
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.retry.KiwiRetryerPredicatesTest#httpNonErrorResponseProvider")
+        @DisplayName("should return false when given a status code between 100-399")
+        void IS_HTTP_400s_shouldReturnFalse_whenNonErrorResponses(Response response) {
+            assertThat(KiwiRetryerPredicates.IS_HTTP_400s.apply(response)).isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.retry.KiwiRetryerPredicatesTest#httpClientErrorResponseProvider")
+        @DisplayName("should return true when given a status code between 400-499")
+        void IS_HTTP_400s_shouldReturnTrue_whenClientErrorResponses(Response response) {
+            assertThat(KiwiRetryerPredicates.IS_HTTP_400s.apply(response)).isTrue();
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.retry.KiwiRetryerPredicatesTest#httpServerErrorResponseProvider")
+        @DisplayName("should return false when given a status code between 500-599")
+        void IS_HTTP_400s_shouldReturnFalse_whenServerErrorResponses(Response response) {
+            assertThat(KiwiRetryerPredicates.IS_HTTP_400s.apply(response)).isFalse();
+        }
+    }
+
+    @Nested
+    class IS_HTTP_500s {
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.retry.KiwiRetryerPredicatesTest#httpNonErrorResponseProvider")
+        @DisplayName("should return false when given a status code between 100-399")
+        void shouldReturnFalse_whenNonErrorResponses(Response response) {
+            assertThat(KiwiRetryerPredicates.IS_HTTP_500s.apply(response)).isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.retry.KiwiRetryerPredicatesTest#httpClientErrorResponseProvider")
+        @DisplayName("should return false when given a status code between 400-499")
+        void shouldReturnFalse_whenClientErrorResponses(Response response) {
+            assertThat(KiwiRetryerPredicates.IS_HTTP_500s.apply(response)).isFalse();
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.retry.KiwiRetryerPredicatesTest#httpServerErrorResponseProvider")
+        @DisplayName("should return true when given a status code between 500-599")
+        void shouldReturnTrue_whenServerErrorResponses(Response response) {
+            assertThat(KiwiRetryerPredicates.IS_HTTP_500s.apply(response)).isTrue();
+        }
+    }
+
+    private static Stream<Arguments> httpNonErrorResponseProvider() {
+        return intArgumentsStream(100, 399);
+    }
+
+    private static Stream<Arguments> httpClientErrorResponseProvider() {
+        return intArgumentsStream(400, 499);
+    }
+
+    private static Stream<Arguments> httpServerErrorResponseProvider() {
+        return intArgumentsStream(500, 599);
+    }
+
+    private static Stream<Arguments> intArgumentsStream(int startInclusive, int endInclusive) {
+        return IntStream.rangeClosed(startInclusive, endInclusive)
+                .mapToObj(Response::status)
+                .map(Response.ResponseBuilder::build)
+                .map(Arguments::of);
+    }
+}


### PR DESCRIPTION
* Add KiwiRetryerPredicates utility class
* Note the test "generates" tests for Predicate<Throwable> constants
  based on an abstract base class; it executes the same tests for each
  predicate. It also uses a custom test display name generator.

Fixes #240