### PR TITLE
Remove the last vestiges of JUnit 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,13 +622,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback-classic.version}</version>

--- a/src/test/java/org/kiwiproject/jaxrs/ResponsesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/ResponsesTest.java
@@ -1,24 +1,23 @@
 package org.kiwiproject.jaxrs;
 
-import org.assertj.core.api.JUnitSoftAssertions;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 import java.util.Arrays;
 import java.util.function.Consumer;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-public class ResponsesTest {
-
-    @Rule
-    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+@ExtendWith(SoftAssertionsExtension.class)
+class ResponsesTest {
 
     @Test
-    public void testSuccessful_ForStatusCodes() {
+    void testSuccessful_ForStatusCodes(SoftAssertions softly) {
         forEachStatus(status -> {
             int statusCode = status.getStatusCode();
             boolean successfulFamily = successful(Family.familyOf(statusCode));
@@ -29,7 +28,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testNotSuccessful_ForStatusCodes() {
+    void testNotSuccessful_ForStatusCodes(SoftAssertions softly) {
         forEachStatus(status -> {
             int statusCode = status.getStatusCode();
             boolean successfulFamily = successful(Family.familyOf(statusCode));
@@ -40,7 +39,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testSuccessful_ForStatus() {
+    void testSuccessful_ForStatus(SoftAssertions softly) {
         forEachStatus(status -> {
             boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
             softly.assertThat(Responses.successful(status))
@@ -50,7 +49,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testNotSuccessful_ForStatus() {
+    void testNotSuccessful_ForStatus(SoftAssertions softly) {
         forEachStatus(status -> {
             boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
             softly.assertThat(Responses.notSuccessful(status))
@@ -60,7 +59,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testSuccessful_ForSuccessfulStatusType() {
+    void testSuccessful_ForSuccessfulStatusType(SoftAssertions softly) {
         Response.StatusType type = new Response.StatusType() {
             @Override
             public int getStatusCode() {
@@ -82,7 +81,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testSuccessful_ForUnsuccessfulStatusType() {
+    void testSuccessful_ForUnsuccessfulStatusType(SoftAssertions softly) {
         Response.StatusType type = new Response.StatusType() {
             @Override
             public int getStatusCode() {
@@ -104,7 +103,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testSuccessful_ForResponse() {
+    void testSuccessful_ForResponse(SoftAssertions softly) {
         forEachStatus(status -> {
             Response response = mock(Response.class);
             when(response.getStatus()).thenReturn(status.getStatusCode());
@@ -116,7 +115,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testNotSuccessful_ForResponse() {
+    void testNotSuccessful_ForResponse(SoftAssertions softly) {
         forEachStatus(status -> {
             Response response = mock(Response.class);
             when(response.getStatus()).thenReturn(status.getStatusCode());
@@ -128,7 +127,7 @@ public class ResponsesTest {
     }
 
     @Test
-    public void testNotSuccessful_ForFamily() {
+    void testNotSuccessful_ForFamily(SoftAssertions softly) {
         Arrays.stream(Family.values()).forEach(family -> {
             boolean successfulFamily = successful(family);
             softly.assertThat(Responses.notSuccessful(family))


### PR DESCRIPTION
Today will be a day long remembered. It has seen the end of Kenobi,
and will soon see the end of the Rebellion...

Oh wait, this is only removing JUnit 4 by first converting ResponsesTest
to Jupiter and then removing the junit-vintage-engine test dependency.
Also update to use SoftAssertionsExtension.

Fixes #276