### PR TITLE
Update dropwizard-jdbi to 2.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <commons-io.version>2.6</commons-io.version>
         <commons-text.version>1.8</commons-text.version>
         <dropwizard.version>2.0.12</dropwizard.version>
-        <dropwizard.modules.dropwizard-jdbi.version>2.0.9</dropwizard.modules.dropwizard-jdbi.version>
+        <dropwizard.modules.dropwizard-jdbi.version>2.0.12</dropwizard.modules.dropwizard-jdbi.version>
         <hibernate-validator.version>6.1.4.Final</hibernate-validator.version>
         <httpclient.version>4.5.12</httpclient.version>
         <guava-retrying.version>2.0.0</guava-retrying.version>
@@ -265,49 +265,6 @@
             <artifactId>dropwizard-jdbi</artifactId>
             <version>${dropwizard.modules.dropwizard-jdbi.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <!-- We are excluding dropwizard deps here because the module is a slightly different version
-                       than our version of dropwizard -->
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-core</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-db</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-jersey</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-lifecycle</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>io.dropwizard</groupId>
-                    <artifactId>dropwizard-util</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>io.dropwizard.metrics</groupId>
-                    <artifactId>metrics-core</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>io.dropwizard.metrics</groupId>
-                    <artifactId>metrics-healthchecks</artifactId>
-                </exclusion>
-
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-util</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Note this is specifically for dropwizard-jdbi in io.dropwizard.modules
which is for JDBI version 2.x.

Fixes #280