### PR TITLE
Add new KiwiLists subListExcludingXxx methods

### DIFF
--- a/src/main/java/org/kiwiproject/ansible/vault/Utils.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/Utils.java
@@ -16,10 +16,6 @@ class Utils {
     //  - moving subList methods into KiwiLists
     //  - moving readProcessXxx methods into KiwiIO
 
-    static List<String> subListExcludingLast(List<String> input) {
-        return input.subList(0, input.size() - 1);
-    }
-
     static List<String> subListFrom(List<String> input, int number) {
         return input.subList(number - 1, input.size());
     }

--- a/src/main/java/org/kiwiproject/collect/KiwiLists.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiLists.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toList;
 
-import com.google.common.annotations.VisibleForTesting;
 import lombok.experimental.UtilityClass;
 
 import java.util.Collection;
@@ -250,19 +249,6 @@ public class KiwiLists {
         return nonNull(collection) ? collection.stream().distinct().collect(toList()) : null;
     }
 
-    @VisibleForTesting
-    static <T> void checkMinimumSize(List<T> items, int minSize) {
-        checkNonNullInputList(items);
-        checkArgument(minSize > 0, "number must be positive");
-        checkArgument(items.size() >= minSize,
-                "expected at least %s items (actual size: %s)",
-                minSize, items.size());
-    }
-
-    public static <T> void checkNonNullInputList(List<T> items) {
-        checkNotNull(items, "items cannot be null");
-    }
-
     /**
      * Returns a new list with the same elements and the same size as the original, however the initial position in the list
      * is now the element specified by the "startOffset" and the list wraps around through the contents to end with "startOffset" - 1
@@ -275,5 +261,75 @@ public class KiwiLists {
     public static <T> List<T> newListStartingAtCircularOffset(List<T> input, long startOffset) {
         var size = input.size();
         return IntStream.range(0, size).mapToObj(i -> input.get((int) (startOffset + i) % size)).collect(toList());
+    }
+
+    /**
+     * Returns a view of the portion of the given list excluding the first element.
+     * <p>
+     * This method has the same semantics as {@link List#subList(int, int)} since it calls that method.
+     *
+     * @param items the list
+     * @param <T>   the type of the items in the list
+     * @return a view of the given list excluding the first item backed by the original list
+     * @throws NullPointerException if the list is null
+     * @see List#subList(int, int)
+     */
+    public static <T> List<T> subListExcludingFirst(List<T> items) {
+        checkNonNullInputList(items);
+        if (items.isEmpty()) {
+            return zeroSubList(items);
+        }
+        return items.subList(1, items.size());
+    }
+
+    /**
+     * Returns a view of the portion of the given list excluding the last element.
+     * <p>
+     * This method has the same semantics as {@link List#subList(int, int)} since it calls that method.
+     *
+     * @param items the list
+     * @param <T>   the type of the items in the list
+     * @return a view of the given list excluding the last item backed by the original list
+     * @throws NullPointerException if the list is null
+     * @see List#subList(int, int)
+     */
+    public static <T> List<T> subListExcludingLast(List<T> items) {
+        checkNonNullInputList(items);
+        if (items.isEmpty()) {
+            return zeroSubList(items);
+        }
+        return items.subList(0, items.size() - 1);
+    }
+
+    private static <T> List<T> zeroSubList(List<T> items) {
+        return items.subList(0, 0);
+    }
+
+    /**
+     * Checks that the given list is not null and has the given minimum size.
+     *
+     * @param items   the list
+     * @param minSize the minimum required size
+     * @param <T>     the type of the items in the list
+     * @throws NullPointerException     if the list is null
+     * @throws IllegalArgumentException if minSize is not positive or the list does not contain minSize elements
+     */
+    public static <T> void checkMinimumSize(List<T> items, int minSize) {
+        checkNonNullInputList(items);
+        checkArgument(minSize > 0, "number must be positive");
+        checkArgument(items.size() >= minSize,
+                "expected at least %s items (actual size: %s)",
+                minSize, items.size());
+    }
+
+    /**
+     * Checks that the given list is not null.
+     *
+     * @param items the list
+     * @param <T>   the type of the items in the list
+     * @throws NullPointerException if the list is null
+     */
+    public static <T> void checkNonNullInputList(List<T> items) {
+        checkNotNull(items, "items cannot be null");
     }
 }

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptionHelperTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptionHelperTest.java
@@ -4,7 +4,7 @@ import static java.util.Objects.isNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.kiwiproject.ansible.vault.Utils.subListExcludingLast;
+import static org.kiwiproject.collect.KiwiLists.subListExcludingLast;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/src/test/java/org/kiwiproject/collect/KiwiListsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiListsTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.collect;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.util.Lists.newArrayList;
 
@@ -376,6 +377,60 @@ class KiwiListsTest {
         void shouldWrapWhenOffsetIsBeyonfEndOfList() {
             assertThat(KiwiLists.newListStartingAtCircularOffset(newArrayList("zero", "one", "two", "three"), 4))
                     .containsExactly("zero", "one", "two", "three");
+        }
+    }
+
+    @Nested
+    class SubListExcludingFirst {
+
+        @Test
+        void shouldThrow_WhenGivenNullArg() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> KiwiLists.subListExcludingFirst(null));
+        }
+
+        @Test
+        void shouldReturnEmptyList_WhenGivenEmptyList() {
+            assertThat(KiwiLists.subListExcludingFirst(List.of())).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyList_GivenOneElementList() {
+            assertThat(KiwiLists.subListExcludingFirst(List.of(42))).isEmpty();
+        }
+
+        @Test
+        void shouldReturnElementsExceptFirst(SoftAssertions softly) {
+            softly.assertThat(KiwiLists.subListExcludingFirst(List.of(1, 2))).isEqualTo(List.of(2));
+            softly.assertThat(KiwiLists.subListExcludingFirst(List.of(1, 2, 3))).isEqualTo(List.of(2, 3));
+            softly.assertThat(KiwiLists.subListExcludingFirst(List.of(1, 2, 3, 4, 5))).isEqualTo(List.of(2, 3, 4, 5));
+        }
+    }
+
+    @Nested
+    class SubListExcludingLast {
+
+        @Test
+        void shouldThrow_WhenGivenNullArg() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> KiwiLists.subListExcludingLast(null));
+        }
+
+        @Test
+        void shouldReturnEmptyList_WhenGivenEmptyList() {
+            assertThat(KiwiLists.subListExcludingLast(List.of())).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyList_GivenOneElementList() {
+            assertThat(KiwiLists.subListExcludingLast(List.of(84))).isEmpty();
+        }
+
+        @Test
+        void shouldReturnElementsExceptLast(SoftAssertions softly) {
+            softly.assertThat(KiwiLists.subListExcludingLast(List.of(1, 2))).isEqualTo(List.of(1));
+            softly.assertThat(KiwiLists.subListExcludingLast(List.of(1, 2, 3))).isEqualTo(List.of(1, 2));
+            softly.assertThat(KiwiLists.subListExcludingLast(List.of(1, 2, 3, 4, 5))).isEqualTo(List.of(1, 2, 3, 4));
         }
     }
 }


### PR DESCRIPTION
* Add subListExcludingFirst
* Add subListExcludingLast
* Made KiwiLists#checkMinimumSize public, because why not? It could
  be useful, and the similar checkNonNullInputList method is already
  public.
* Move checkMinimumSize and checkNonNullInputList to bottom of KiwiLists
* Remove Utils#subListExcludingLast in ansible.vault package; replace
  usages with the new one from KiwiLists

Fixes #267
Fixes #268