### PR TITLE
Add to YamlHelper: toObject, toObjectList, toMap

### DIFF
--- a/src/main/java/org/kiwiproject/yaml/YamlHelper.java
+++ b/src/main/java/org/kiwiproject/yaml/YamlHelper.java
@@ -2,13 +2,18 @@ package org.kiwiproject.yaml;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Some utilities to make it easy to work with YAML.
@@ -17,6 +22,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
  * be available at runtime.
  */
 public class YamlHelper {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
+    };
 
     private final ObjectMapper objectMapper;
 
@@ -78,5 +86,89 @@ public class YamlHelper {
         } catch (JsonProcessingException e) {
             throw new RuntimeYamlException(e);
         }
+    }
+
+    /**
+     * Convert the given YAML into the specified type.
+     *
+     * @param yaml        the YAML content
+     * @param targetClass the type of obejct to convert into
+     * @param <T>         the object type
+     * @return a new instance of the given type
+     * @throws IllegalArgumentException if the YAML is blank or null
+     */
+    public <T> T toObject(String yaml, Class<T> targetClass) {
+        checkYamlNotBlank(yaml);
+        try {
+            return objectMapper.readValue(yaml, targetClass);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeYamlException(e);
+        }
+    }
+
+    /**
+     * Convert the given YAML into an object of type {@code T} using the given {@link TypeReference}.
+     *
+     * @param yaml       the YAML content
+     * @param targetType the {@link TypeReference} representing the target object type
+     * @param <T>        the object type
+     * @return a new instance of the given type reference
+     * @throws IllegalArgumentException if the YAML is blank or null
+     */
+    public <T> T toObject(String yaml, TypeReference<T> targetType) {
+        checkYamlNotBlank(yaml);
+        try {
+            return objectMapper.readValue(yaml, targetType);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeYamlException(e);
+        }
+    }
+
+    /**
+     * Convert the given YAML into a List of objects of type {@code T}.
+     *
+     * @param yaml           the YAML content
+     * @param targetListType the {@link TypeReference} representing the target object type
+     * @param <T>            the object type
+     * @return a list containing objects of the given type
+     * @throws IllegalArgumentException if the YAML is blank or null
+     */
+    public <T> List<T> toObjectList(String yaml, TypeReference<List<T>> targetListType) {
+        checkYamlNotBlank(yaml);
+        return toObject(yaml, targetListType);
+    }
+
+    /**
+     * Convert the given YAML into a map with String keys and Object values.
+     *
+     * @param yaml the YAML content
+     * @return the parsed map
+     * @throws IllegalArgumentException if the YAML is blank or null
+     */
+    public Map<String, Object> toMap(String yaml) {
+        return toMap(yaml, MAP_TYPE_REFERENCE);
+    }
+
+    /**
+     * Convert the given YAML into a map with keys of type {@code K} and values of type {@code V}.
+     *
+     * @param yaml          the YAML content
+     * @param targetMapType the {@link TypeReference} representing the target map type
+     * @param <K>           the type of keys in the map
+     * @param <V>           the type of values in the map
+     * @return the parsed map
+     * @throws IllegalArgumentException if the YAML is blank or null
+     */
+    public <K, V> Map<K, V> toMap(String yaml, TypeReference<Map<K, V>> targetMapType) {
+        checkYamlNotBlank(yaml);
+        try {
+            return objectMapper.readValue(yaml, targetMapType);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeYamlException(e);
+        }
+    }
+
+    public void checkYamlNotBlank(String yaml) {
+        checkArgumentNotBlank(yaml, "yaml cannot be blank");
     }
 }


### PR DESCRIPTION
* Add overloaded toObject: one accepts Class<T>, other TypeReference<T>
* Add toObjectList
* Add overloaded toMap: one assumes Map<String, Object>; the other
  accepts a TypeReference<Map<K, V>>

Fixes #285