### PR TITLE
Add @DirectoryPath validation annotation and validator

### DIFF
--- a/src/main/java/org/kiwiproject/validation/DirectoryPath.java
+++ b/src/main/java/org/kiwiproject/validation/DirectoryPath.java
@@ -1,0 +1,92 @@
+package org.kiwiproject.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * The annotated element must point to an existing directory.
+ * <p>
+ * By default does not permit null values. If the element being validated allows {@code null} values, you can
+ * set {@link #allowNull()} to {@code true}.
+ * <p>
+ * You can also use {@link #ensureReadable()} and {@link #ensureWritable()} to verify that the directory is readable
+ * or writable by the current process.
+ * <p>
+ * Finally, the {@link #mkdirs()} option provides a way to actually create the specified directory if it does not
+ * exist. <em>Please read the documentation for this option.</em>
+ * <p>
+ * Examples:
+ * <pre>
+ * {@literal @}DirectoryPath
+ *  private String tempDir;
+ * </pre>
+ * <pre>
+ * {@literal @}DirectoryPath(allowNull = true)
+ *  public String getTempDir() { return this.tempDir; }
+ * </pre>
+ * <pre>
+ * {@literal @}DirectoryPath(ensureReadable = true, ensureWritable = true, mkdirs = true)
+ *  private String tempDir;
+ * </pre>
+ */
+@Documented
+@Constraint(validatedBy = {DirectoryPathValidator.class})
+@Target({METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+public @interface DirectoryPath {
+
+    String message() default "{org.kiwiproject.validation.DirectoryPath.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * Whether to consider null as valid. The default is false.
+     *
+     * @return true to consider null as valid
+     */
+    boolean allowNull() default false;
+
+    /**
+     * Whether to verify that the specified directory can be read by the current process.
+     * The default is false (no verification is performed).
+     *
+     * @return true to validate the directory is readable; if false does not verify
+     */
+    boolean ensureReadable() default false;
+
+    /**
+     * Whether to verify that the specified directory can be read by the current process.
+     * The default is false (no verification is performed).
+     *
+     * @return true to validate the directory is writable; if false does not verify
+     */
+    boolean ensureWritable() default false;
+
+    /**
+     * Whether this validator will attempt to create the directory if it does not exist.
+     * <p>
+     * <strong>IMPORTANT: This is generally unexpected behavior (to have any side-effects during validation)</strong>.
+     * <p>
+     * However, based on the use cases we have encountered, this is a <em>pragmatic</em> way to ensure directories are
+     * present, and we have found the alternatives to be clumsy at best, overly complicated at worst. One common
+     * example is to ensure a temporary or working directory exists for an application to use.
+     * <p>
+     * <em>Regardless, please be sure you understand the side-effecting behavior if you set this to {@code true}.</em>
+     *
+     * @return true to create any missing directories; if false directories are not created
+     */
+    boolean mkdirs() default false;
+}

--- a/src/main/java/org/kiwiproject/validation/DirectoryPathValidator.java
+++ b/src/main/java/org/kiwiproject/validation/DirectoryPathValidator.java
@@ -1,0 +1,79 @@
+package org.kiwiproject.validation;
+
+import static java.util.Objects.isNull;
+import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.io.File;
+import java.nio.file.Path;
+
+/**
+ * Validates that a string value is a valid path, exists, and is a directory.
+ * <p>
+ * Optionally, this validator will verify that the directory is readable and/or writable.
+ * <p>
+ * As mentioned in the documentation for {@link DirectoryPath}, this may also attempt to create the directory
+ * if it does not already exist, which may be an unexpected side-effect.
+ */
+@Slf4j
+public class DirectoryPathValidator implements ConstraintValidator<DirectoryPath, String> {
+
+    private DirectoryPath directoryPath;
+
+    @Override
+    public void initialize(DirectoryPath constraintAnnotation) {
+        this.directoryPath = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (isNull(value)) {
+            return directoryPath.allowNull();
+        }
+
+        try {
+            var file = Path.of(value).toFile();
+            LOG.trace("Validating access to directory: {}", lazy(file::getAbsolutePath));
+
+            var exists = file.exists();
+            var directoryCreated = createDirectoryIfNecessary(file, exists);
+            var directoryExistsOrWasCreated = (exists || directoryCreated);
+
+            return directoryExistsOrWasCreated &&
+                    file.isDirectory() &&
+                    isReadableOrIgnoresEnsureReadable(file) &&
+                    isWritableOrIgnoresEnsureReadable(file);
+
+        } catch (Exception e) {
+            var hasNulCharacter = value.contains("\0") ? " Path contains Nul character!" : "";
+            LOG.warn("Exception thrown validating path [{}].{}", value, hasNulCharacter, e);
+            return false;
+        }
+    }
+
+    private boolean createDirectoryIfNecessary(File file, boolean exists) {
+        if (exists || !directoryPath.mkdirs()) {
+            return false;
+        }
+
+        var absolutePath = file.getAbsolutePath();
+        LOG.info("Directory does not exist and 'mkdirs' option is true. Creating directory: {}", absolutePath);
+        var created = file.mkdirs();
+        if (!created) {
+            LOG.error("Unable to create directory: {}", absolutePath);
+        }
+
+        return created;
+    }
+
+    private boolean isReadableOrIgnoresEnsureReadable(File file) {
+        return !directoryPath.ensureReadable() || file.canRead();
+    }
+
+    private boolean isWritableOrIgnoresEnsureReadable(File file) {
+        return !directoryPath.ensureWritable() || file.canWrite();
+    }
+}

--- a/src/main/java/org/kiwiproject/validation/FilePathValidator.java
+++ b/src/main/java/org/kiwiproject/validation/FilePathValidator.java
@@ -31,7 +31,7 @@ public class FilePathValidator implements ConstraintValidator<FilePath, String> 
             var file = Path.of(value).toFile();
             return file.exists() && file.isFile();
         } catch (Exception e) {
-            LOG.trace("Exception thrown validating path [{}]", value, e);
+            LOG.warn("Exception thrown validating path [{}]", value, e);
             return false;
         }
     }

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,3 +1,4 @@
+org.kiwiproject.validation.DirectoryPath.message=is not a valid directory path (and may not be readable or writable)
 org.kiwiproject.validation.FilePath.message=is not a valid file path
 org.kiwiproject.validation.InEnum.message=is not in the list
 org.kiwiproject.validation.Ipv4Address.message=is not a valid IPv4 address

--- a/src/test/java/org/kiwiproject/validation/DirectoryPathValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/DirectoryPathValidatorTest.java
@@ -1,0 +1,253 @@
+package org.kiwiproject.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.validation.ValidationTestHelper.assertNoPropertyViolations;
+import static org.kiwiproject.validation.ValidationTestHelper.assertOnePropertyViolation;
+import static org.kiwiproject.validation.ValidationTestHelper.assertPropertyViolations;
+
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.validation.Validator;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+
+@DisplayName("DirectoryPathValidator")
+class DirectoryPathValidatorTest {
+
+    private static final String CUSTOM_MESSAGE = "is not a directory, is not readable, or is not writable";
+    private static final String DEFAULT_MESSAGE = "is not a valid directory path (and may not be readable or writable)";
+
+    private Validator validator;
+    private Config config;
+    private String tempFolderPath;
+
+    @TempDir
+    Path folder;
+
+    @BeforeEach
+    void setUp() {
+        validator = KiwiValidations.getValidator();
+        config = new Config();
+        tempFolderPath = folder.toString();
+    }
+
+    @Nested
+    class ValidationMessage {
+
+        @Test
+        void shouldUseDefaultMessage() {
+            assertPropertyViolations(validator, config, "directoryPath1", DEFAULT_MESSAGE);
+        }
+
+        @Test
+        void shouldUseCustomMessage() {
+            assertPropertyViolations(validator, config, "directoryPath2",
+                    CUSTOM_MESSAGE);
+        }
+    }
+
+    @Nested
+    class WhenNullValue {
+
+        @Test
+        void shouldBeValid_WhenAllowingNulls() {
+            assertNoPropertyViolations(validator, config, "directoryPath3");
+        }
+
+        @Test
+        void shouldBeInvalid_ByDefault() {
+            assertPropertyViolations(validator, config, "directoryPath4", DEFAULT_MESSAGE);
+        }
+    }
+
+    @Nested
+    class ShouldBeValid {
+
+        @Test
+        void whenDirectoryExists() {
+            config.setDirectoryPath1(tempFolderPath);
+            assertNoPropertyViolations(validator, config, "directoryPath1");
+        }
+
+        @Test
+        void whenEnsuringReadable() {
+            config.setDirectoryPath5(tempFolderPath);
+            assertNoPropertyViolations(validator, config, "directoryPath5");
+        }
+
+        @Test
+        void whenEnsuringWritable() {
+            config.setDirectoryPath6(tempFolderPath);
+            assertNoPropertyViolations(validator, config, "directoryPath6");
+        }
+
+        @Test
+        void whenEnsuringReadableAndWritable() {
+            config.setDirectoryPath7(tempFolderPath);
+            assertNoPropertyViolations(validator, config, "directoryPath7");
+        }
+    }
+
+    @Nested
+    class WhenMkdirsTrue {
+
+        @Test
+        void shouldDoNothing_WhenDirectoryExists() {
+            config.setDirectoryPath8(tempFolderPath);
+
+            assertNoPropertyViolations(validator, config, "directoryPath8");
+        }
+
+        @Test
+        void shouldCreateDirectory_WhenDirectoryDoesNotExist() {
+            var newDirectory = new File(tempFolderPath, "newSubDir");
+            assertThat(newDirectory)
+                    .describedAs("precondition violated: directory should not exist")
+                    .doesNotExist();
+
+            config.setDirectoryPath8(newDirectory.getAbsolutePath());
+
+            assertNoPropertyViolations(validator, config, "directoryPath8");
+
+            assertThat(newDirectory)
+                    .describedAs("should have created directory")
+                    .exists();
+        }
+
+        @Test
+        void shouldFailValidation_WhenUnableToCreateDirectory() {
+            var notWritable = new File(tempFolderPath, "notWritable");
+            assertThat(notWritable.mkdir()).isTrue();
+            assertThat(notWritable.setWritable(false)).isTrue();
+
+            var secondSubDir = new File(notWritable, "subDirOfNotWritable");
+            config.setDirectoryPath8(secondSubDir.getAbsolutePath());
+
+            assertOnePropertyViolation(validator, config, "directoryPath8");
+        }
+    }
+
+    @Nested
+    class ShouldBeInvalid {
+
+        @Test
+        void whenDirectoryDoesNotExist() {
+            config.setDirectoryPath1(Path.of(tempFolderPath, "does-not-exist").toString());
+
+            assertPropertyViolations(validator, config, "directoryPath1", DEFAULT_MESSAGE);
+        }
+
+        @Test
+        void whenInvalidPathExceptionThrown() {
+            var file = new File(tempFolderPath, "\0");
+            config.setDirectoryPath1(file.getAbsolutePath());  // "Nul" character is not allowed in paths
+
+            assertOnePropertyViolation(validator, config, "directoryPath1");
+        }
+
+        @Test
+        void whenIsRegularFile() throws IOException {
+            var file = Path.of(tempFolderPath, "a-file.txt");
+            var newFile = Files.writeString(file, "tic tac toe");
+
+            assertThat(newFile)
+                    .describedAs("precondition violated: file should be a regular file")
+                    .isRegularFile();
+
+            config.setDirectoryPath2(newFile.toString());
+
+            assertPropertyViolations(validator, config, "directoryPath2", CUSTOM_MESSAGE);
+        }
+
+        @Test
+        void whenEnsuringReadable_ButDirectoryNotReadable() {
+            var notReadable = new File(tempFolderPath, "notReadable");
+            assertThat(notReadable.mkdir()).isTrue();
+            setFilePermissions(notReadable, false, true);
+
+            runEnsureTest(notReadable, config, (file, cfg) -> {
+                cfg.setDirectoryPath5(file.getAbsolutePath());
+                assertOnePropertyViolation(validator, cfg, "directoryPath5");
+            });
+        }
+
+        @Test
+        void whenEnsuringWritable_ButDirectoryNotWritable() {
+            var notWritable = new File(tempFolderPath, "notWritable");
+            assertThat(notWritable.mkdir()).isTrue();
+            setFilePermissions(notWritable, true, false);
+
+            runEnsureTest(notWritable, config, (file, cfg) -> {
+                cfg.setDirectoryPath6(file.getAbsolutePath());
+                assertOnePropertyViolation(validator, cfg, "directoryPath6");
+            });
+        }
+
+        @Test
+        void whenEnsuringReadWrite_ButDirectoryIsNeitherReadableNorWritable() {
+            var notAccessible = new File(tempFolderPath, "notAccessible");
+            assertThat(notAccessible.mkdir()).isTrue();
+            setFilePermissions(notAccessible, false, false);
+
+            runEnsureTest(notAccessible, config, (file, cfg) -> {
+                cfg.setDirectoryPath7(file.getAbsolutePath());
+                assertOnePropertyViolation(validator, cfg, "directoryPath7");
+            });
+        }
+
+        private void runEnsureTest(File file, Config config, BiConsumer<File, Config> fileConsumer) {
+            try {
+                fileConsumer.accept(file, config);
+            } finally {
+                setFilePermissions(file, true, true);
+            }
+        }
+    }
+
+    private static void setFilePermissions(File file, boolean canRead, boolean canWrite) {
+        assertThat(file.setReadable(canRead))
+                .describedAs("failed to set readable on %s to %s", file, canRead)
+                .isTrue();
+
+        assertThat(file.setWritable(canWrite))
+                .describedAs("failed to set writable on %s to %s", file, canWrite)
+                .isTrue();
+    }
+
+    @Data
+    static class Config {
+
+        @DirectoryPath
+        private String directoryPath1;
+
+        @DirectoryPath(message = CUSTOM_MESSAGE)
+        private String directoryPath2;
+
+        @DirectoryPath(allowNull = true)
+        private String directoryPath3;
+
+        @SuppressWarnings("DefaultAnnotationParam")
+        @DirectoryPath(allowNull = false)
+        private String directoryPath4;
+
+        @DirectoryPath(ensureReadable = true)
+        private String directoryPath5;
+
+        @DirectoryPath(ensureWritable = true)
+        private String directoryPath6;
+
+        @DirectoryPath(ensureReadable = true, ensureWritable = true)
+        private String directoryPath7;
+
+        @DirectoryPath(mkdirs = true, ensureReadable = true, ensureWritable = true)
+        private String directoryPath8;
+    }
+}


### PR DESCRIPTION
* Add @DirectoryPath validation annotation
* Add DirectoryPathValidator, the validator class for @DirectoryPath
* Update ValidationMessages.properties with the custom error message
  for violations of the @DirectoryPath annotation
* Change log level in FilePathValidator from TRACE to WARN if there
  is an exception thrown during validation. The reason is simply
  because this should only happen in very exceptional circumstances,
  for example a "Nul" character in a path causing an
  InvalidPathException to be thrown. This is also consistent with
  how DirectoryPathValidator behaves.

Fixes #305