### PR TITLE
Add @FieldRange validation annotation and validator

### DIFF
--- a/src/main/java/org/kiwiproject/validation/FieldRange.java
+++ b/src/main/java/org/kiwiproject/validation/FieldRange.java
@@ -1,0 +1,107 @@
+package org.kiwiproject.validation;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * The annotated <em>type</em> must have two fields that define a valid range, i.e. in the simplest configuration
+ * {@link #startField()} must come before {@link #endField()}. You can have multiple {@link FieldRange} annotations
+ * on a type, either as standalone annotations or inside a {@link FieldRanges} annotation.
+ * <p>
+ * The main restriction imposed by this annotation is that {@link #startField()} and {@link #endField()} must be
+ * {@link Comparable}. It is also assumed that they are defined to both have the same type, e.g. both are Integer
+ * or {@link java.time.Instant}. No guarantees are made if they are different types, and most likely unpredictable
+ * results and/or exceptions will occur.
+ * <p>
+ * Note also that <em>direct field access using reflection</em> is used to obtain the start and end values as
+ * currently implemented.
+ * <p>
+ * By default null values are not allowed, and the range check is exclusive, meaning start cannot equal end. You can
+ * change the default behavior using the various options.
+ * <p>
+ * In addition to ensuring that the start and end fields define a valid range, you can also constrain them to minimum
+ * and/or maximum values.
+ * <p>
+ * Finally, this validator's type support depends on whether minimum and maximum values are specified as part of the
+ * configuration. If minimum and/or maximum are specified, then the supported types are the same as those supported
+ * by {@link Range} since the minimum/maximum values must be converted from strings into the type of object that
+ * the start and end fields are. If there are no minimum or maximum values defined, then any type that implements
+ * {@link Comparable} is supported.
+ */
+@Documented
+@Constraint(validatedBy = {FieldRangeValidator.class})
+@Target({TYPE})
+@Retention(RUNTIME)
+@Repeatable(FieldRanges.class)
+public @interface FieldRange {
+
+    String message() default "{org.kiwiproject.validation.FieldRange.between.message}";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * @return the name of the field that defines the range start
+     */
+    String startField();
+
+    /**
+     * @return the name of the field that defines the range end
+     */
+    String endField();
+
+    /**
+     * @return the label to use in error messages instead of the end field
+     * @implNote There is no equivalent for start field since the errors are attached to the start field, such that
+     * the message is defined relative to the start field. For example, the property path in a constraint violation
+     * is startField and will have the associated message "must occur before [endField|endFieldLabel]".
+     */
+    String endFieldLabel() default "";
+
+    /**
+     * @return true if the start and end can be the same value; the default is false
+     */
+    boolean allowStartToEqualEnd() default false;
+
+    /**
+     * If true, the range only includes the end field. This is mainly useful when used with a max value.
+     *
+     * @return true to define a range that only considers the end field
+     */
+    boolean allowNullStart() default false;
+
+    /**
+     * If true, the range only includes the start field. This is mainly useful when used with a min value.
+     *
+     * @return true to define a range that only considers the start field
+     */
+    boolean allowNullEnd() default false;
+
+    /**
+     * @return the minimum value allowed for the start of the range
+     */
+    String min() default "";
+
+    /**
+     * @return the label to be used in error messages in place of the minimum value, e.g. "ten" instead of 10
+     */
+    String minLabel() default "";
+
+    /**
+     * @return the minimum value allowed for the end of the range
+     */
+    String max() default "";
+
+    /**
+     * @return the label to be used in error messages in place of the maximum value, e.g. "ten" instead of 10
+     */
+    String maxLabel() default "";
+}

--- a/src/main/java/org/kiwiproject/validation/FieldRangeValidator.java
+++ b/src/main/java/org/kiwiproject/validation/FieldRangeValidator.java
@@ -1,0 +1,147 @@
+package org.kiwiproject.validation;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.kiwiproject.validation.InternalKiwiValidators.TEMPLATE_REQUIRED;
+import static org.kiwiproject.validation.InternalKiwiValidators.toComparableOrNull;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Validator class for {@link FieldRange}.
+ */
+@Slf4j
+public class FieldRangeValidator implements ConstraintValidator<FieldRange, Object> {
+
+    private static final String TEMPLATE_BETWEEN = "{org.kiwiproject.validation.FieldRange.between.message}";
+    private static final String TEMPLATE_MIN_ONLY = "{org.kiwiproject.validation.FieldRange.minOnly.message}";
+    private static final String TEMPLATE_MAX_ONLY = "{org.kiwiproject.validation.FieldRange.maxOnly.message}";
+    private static final String TEMPLATE_AFTER_EXCLUSIVE = "{org.kiwiproject.validation.FieldRange.afterExclusive.message}";
+    private static final String TEMPLATE_AFTER_INCLUSIVE = "{org.kiwiproject.validation.FieldRange.afterInclusive.message}";
+
+    private FieldRange fieldRange;
+
+    @Override
+    public void initialize(FieldRange constraintAnnotation) {
+        this.fieldRange = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        Validity validity;
+        try {
+            var start = getFieldValueAsComparable(value, fieldRange.startField());
+            var end = getFieldValueAsComparable(value, fieldRange.endField());
+
+            validity = checkValidity(start, end, context);
+        } catch (Exception e) {
+            addUnknownErrorConstraintViolation(context, fieldRange);
+            logWarning(value, fieldRange, e);
+            validity = Validity.INVALID;
+        }
+
+        return validity == Validity.VALID;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Comparable<Object> getFieldValueAsComparable(Object value, String fieldName) {
+        return (Comparable<Object>) KiwiValidations.getPropertyValue(value, fieldName);
+    }
+
+    private Validity checkValidity(Comparable<Object> start, Comparable<Object> end, ConstraintValidatorContext context) {
+        var validity = checkMinMax(start, end, context);
+
+        if (validity == Validity.VALID) {
+            // check null first as checkRange checks won't work if null
+            validity = checkNull(start, end, context);
+
+            if (validity == Validity.CONTINUE) {
+                validity = checkRange(start, end, context);
+            }
+        }
+
+        return validity;
+    }
+
+    private Validity checkMinMax(Comparable<Object> start, Comparable<Object> end, ConstraintValidatorContext context) {
+        var validity = Validity.VALID;
+
+        var min = toComparableOrNull(fieldRange.min(), start);
+        if (nonNull(min) && start.compareTo(min) < 0) {
+            var template = isBlank(fieldRange.max()) ? TEMPLATE_MIN_ONLY : TEMPLATE_BETWEEN;
+            KiwiValidations.addError(context, template, fieldRange.startField());
+            validity = Validity.INVALID;
+        }
+
+        var max = toComparableOrNull(fieldRange.max(), end);
+        if (nonNull(max) && end.compareTo(max) > 0) {
+            var template = isBlank(fieldRange.min()) ? TEMPLATE_MAX_ONLY : TEMPLATE_BETWEEN;
+            KiwiValidations.addError(context, template, fieldRange.endField());
+            validity = Validity.INVALID;
+        }
+
+        return validity;
+    }
+
+    private Validity checkNull(Comparable<Object> start, Comparable<Object> end, ConstraintValidatorContext context) {
+        var startValidity = checkFieldNullity(start, fieldRange.startField(), fieldRange.allowNullStart(), context);
+        var endValidity = checkFieldNullity(end, fieldRange.endField(), fieldRange.allowNullEnd(), context);
+
+        if (startValidity == Validity.INVALID || endValidity == Validity.INVALID) {
+            return Validity.INVALID;
+        }
+
+        if (isNull(start) || isNull(end)) {
+            return Validity.VALID;
+        }
+
+        return Validity.CONTINUE;
+    }
+
+    private static Validity checkFieldNullity(Comparable<Object> comparable,
+                                              String field,
+                                              boolean allowNull,
+                                              ConstraintValidatorContext context) {
+
+        if (nonNull(comparable) || allowNull) {
+            return Validity.CONTINUE;
+        }
+
+        KiwiValidations.addError(context, TEMPLATE_REQUIRED, field);
+        return Validity.INVALID;
+    }
+
+    private Validity checkRange(Comparable<Object> start, Comparable<Object> end, ConstraintValidatorContext context) {
+        verify(nonNull(start), "start should not be null at this point; checkNull should not have returned CONTINUE!");
+        verify(nonNull(end), "end should not be null at this point; checkNull should not have returned CONTINUE!");
+
+        var validity = Validity.VALID;
+
+        if (fieldRange.allowStartToEqualEnd()) {
+            if (start.compareTo(end) > 0) {
+                KiwiValidations.addError(context, TEMPLATE_AFTER_INCLUSIVE, fieldRange.startField());
+                validity = Validity.INVALID;
+            }
+        } else if (start.compareTo(end) >= 0) {
+            KiwiValidations.addError(context, TEMPLATE_AFTER_EXCLUSIVE, fieldRange.startField());
+            validity = Validity.INVALID;
+        }
+
+        return validity;
+    }
+
+    private static void addUnknownErrorConstraintViolation(ConstraintValidatorContext context, FieldRange fieldRange) {
+        KiwiValidations.addError(context, "unknown validation error", fieldRange.startField());
+    }
+
+    private static void logWarning(Object value, FieldRange fieldRange, Exception e) {
+        var valueAsString = isNull(value) ? "null" : value.getClass().getName();
+        LOG.warn("Error validating FieldRange with startField: {}, endField: {}, for value: {}; considering invalid",
+                fieldRange.startField(), fieldRange.endField(), valueAsString, e);
+    }
+}

--- a/src/main/java/org/kiwiproject/validation/FieldRangeValidator.java
+++ b/src/main/java/org/kiwiproject/validation/FieldRangeValidator.java
@@ -56,7 +56,7 @@ public class FieldRangeValidator implements ConstraintValidator<FieldRange, Obje
     private Validity checkValidity(Comparable<Object> start, Comparable<Object> end, ConstraintValidatorContext context) {
         var validity = checkMinMax(start, end, context);
 
-        if (validity == Validity.VALID) {
+        if (validity == Validity.CONTINUE) {
             // check null first as checkRange checks won't work if null
             validity = checkNull(start, end, context);
 
@@ -69,7 +69,7 @@ public class FieldRangeValidator implements ConstraintValidator<FieldRange, Obje
     }
 
     private Validity checkMinMax(Comparable<Object> start, Comparable<Object> end, ConstraintValidatorContext context) {
-        var validity = Validity.VALID;
+        var validity = Validity.CONTINUE;
 
         var min = toComparableOrNull(fieldRange.min(), start);
         if (nonNull(min) && start.compareTo(min) < 0) {

--- a/src/main/java/org/kiwiproject/validation/FieldRanges.java
+++ b/src/main/java/org/kiwiproject/validation/FieldRanges.java
@@ -1,0 +1,19 @@
+package org.kiwiproject.validation;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Holder for multiple {@link FieldRange} annotations.
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RUNTIME)
+public @interface FieldRanges {
+
+    FieldRange[] value();
+}

--- a/src/main/java/org/kiwiproject/validation/InEnumValidator.java
+++ b/src/main/java/org/kiwiproject/validation/InEnumValidator.java
@@ -80,7 +80,7 @@ public class InEnumValidator implements ConstraintValidator<InEnum, String> {
                 return true;
             }
 
-            addCustomErrorMessage(context);
+            KiwiValidations.addError(context, errorMessage);
             return false;
         }
 
@@ -89,7 +89,7 @@ public class InEnumValidator implements ConstraintValidator<InEnum, String> {
             return true;
         }
 
-        addCustomErrorMessage(context);
+        KiwiValidations.addError(context, errorMessage);
         return false;
     }
 
@@ -105,8 +105,4 @@ public class InEnumValidator implements ConstraintValidator<InEnum, String> {
         return inEnum.ignoreCase() ? uppercase(value) : value;
     }
 
-    private void addCustomErrorMessage(ConstraintValidatorContext context) {
-        context.disableDefaultConstraintViolation();
-        context.buildConstraintViolationWithTemplate(errorMessage).addConstraintViolation();
-    }
 }

--- a/src/main/java/org/kiwiproject/validation/InternalKiwiValidators.java
+++ b/src/main/java/org/kiwiproject/validation/InternalKiwiValidators.java
@@ -1,0 +1,91 @@
+package org.kiwiproject.validation;
+
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.json.JsonHelper;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Date;
+
+/**
+ * Internal shared validation code.
+ */
+@UtilityClass
+class InternalKiwiValidators {
+
+    private static final JsonHelper JSON_HELPER = JsonHelper.newDropwizardJsonHelper();
+
+    static final String TEMPLATE_REQUIRED = "{org.kiwiproject.validation.Required.message}";
+
+    /**
+     * Convert a string representation of a "compare value" (for example a string representing a minimum or maximum)
+     * into an object of the same type as {@code value}.
+     * <p>
+     * If the "compare value" is blank (null, empty, or only whitespace) or {@code value} is {@code null}, then
+     * {@code null} is returned.
+     * <p>
+     * As a concrete example, the {@code compareValue} might be the String from a min() or max() in a validation
+     * annotation such as {@link Range}. In order to compare with {@code value}, we need to convert that String to the
+     * same type as {@code value}. Suppose we are given a compare value of "10" and {@code value} is a {@link Long}.
+     * In this case, "10" must is converted into a {@link Long}.
+     * <p>
+     * The supported types are:
+     * <ul>
+     *     <li>{@code byte}, {@code short}, {@code int}, {@code long}, and their respective wrapper types</li>
+     *     <li>{@code float}, {@code double}, and their respective wrapper types</li>
+     *     <li>{@code BigDecimal}</li>
+     *     <li>{@code BigInteger}</li>
+     *     <li>Date, using epoch millis for the min and max values</li>
+     *     <li>Instant, using epoch millis for the min and max values</li>
+     *     <li>JSON, using JSON to define the min and max values</li>
+     * </ul>
+     *
+     * @param compareValue a string representation of a value that should be converted into the same type as the
+     *                     {@code value} argument
+     * @param value        the value being validated, and which defines the conversion type
+     * @implNote This is non-ideal with the massive if/else if/else, but since we have to check each type we
+     * support, I cannot think of a "better" or "cleaner" way to do this without it becoming so abstract that
+     * it becomes unreadable. Interestingly, neither IntelliJ not Sonar is complaining...maybe we don't have the
+     * appropriate rules enabled. Suggestions for improvement welcome!
+     */
+    static Comparable<?> toComparableOrNull(String compareValue, Comparable<?> value) {
+        if (isBlank(compareValue) || isNull(value)) {
+            return null;
+        }
+
+        Comparable<?> typedValue;
+
+        if (value instanceof Double) {
+            typedValue = Double.valueOf(compareValue);
+        } else if (value instanceof Float) {
+            typedValue = Float.valueOf(compareValue);
+        } else if (value instanceof Byte) {
+            typedValue = Byte.valueOf(compareValue);
+        } else if (value instanceof Short) {
+            typedValue = Short.valueOf(compareValue);
+        } else if (value instanceof Integer) {
+            typedValue = Integer.valueOf(compareValue);
+        } else if (value instanceof Long) {
+            typedValue = Long.valueOf(compareValue);
+        } else if (value instanceof BigDecimal) {
+            typedValue = new BigDecimal(compareValue);
+        } else if (value instanceof BigInteger) {
+            typedValue = new BigInteger(compareValue);
+        } else if (value instanceof Date) {
+            typedValue = new Date(Long.parseLong(compareValue));
+        } else if (value instanceof Instant) {
+            typedValue = Instant.ofEpochMilli(Long.parseLong(compareValue));
+        } else if (compareValue.stripLeading().startsWith("{")) {
+            typedValue = JSON_HELPER.toObject(compareValue, value.getClass());
+        } else {
+            var message = "This validator does not support validating objects of type: " + value.getClass().getName();
+            throw new IllegalArgumentException(message);
+        }
+
+        return typedValue;
+    }
+}

--- a/src/main/java/org/kiwiproject/validation/KiwiValidations.java
+++ b/src/main/java/org/kiwiproject/validation/KiwiValidations.java
@@ -105,6 +105,26 @@ public class KiwiValidations {
     }
 
     /**
+     * Adds an error to the {@link ConstraintValidatorContext} using the specified template and property name,
+     * thereby overriding the constraint's default message.
+     * <p>
+     * This is intended to be used when a validation annotation applies at the type level, as opposed to a field
+     * or method. The {@code propertyName} can be used to specify the property node that the violation should be
+     * attached to. For example, if a validator validates multiple fields and the annotation is applied to the
+     * type, then this can be used to specify which field a constraint violation applies to.
+     *
+     * @param context      the validator context
+     * @param template     the template to use
+     * @param propertyName the property name to attach constrain violations to
+     */
+    public static void addError(ConstraintValidatorContext context, String template, String propertyName) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(template)
+                .addPropertyNode(propertyName)
+                .addConstraintViolation();
+    }
+
+    /**
      * Finds the value of the specified property <em>by direct field access</em>.
      * <p>
      * This is provided for validators to obtain the value of a specific field, and will only be useful when

--- a/src/main/java/org/kiwiproject/validation/Required.java
+++ b/src/main/java/org/kiwiproject/validation/Required.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 public @interface Required {
 
-    String message() default "{org.kiwiproject.validation.Required.message}";
+    String message() default InternalKiwiValidators.TEMPLATE_REQUIRED;
 
     Class<?>[] groups() default {};
 

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,4 +1,9 @@
 org.kiwiproject.validation.DirectoryPath.message=is not a valid directory path (and may not be readable or writable)
+org.kiwiproject.validation.FieldRange.afterExclusive.message=must occur before ${endFieldLabel.length() > 0 ? endFieldLabel : endField}
+org.kiwiproject.validation.FieldRange.afterInclusive.message=must occur before or match ${endFieldLabel.length() > 0 ? endFieldLabel : endField}
+org.kiwiproject.validation.FieldRange.between.message=must be between ${minLabel.length() > 0 ? minLabel : min} and ${maxLabel.length() > 0 ? maxLabel : max}
+org.kiwiproject.validation.FieldRange.maxOnly.message=must be below or equal to ${maxLabel.length() > 0 ? maxLabel : max}
+org.kiwiproject.validation.FieldRange.minOnly.message=must be equal to or above ${minLabel.length() > 0 ? minLabel : min}
 org.kiwiproject.validation.FilePath.message=is not a valid file path
 org.kiwiproject.validation.InEnum.message=is not in the list
 org.kiwiproject.validation.Ipv4Address.message=is not a valid IPv4 address

--- a/src/test/java/org/kiwiproject/validation/FieldRangeValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/FieldRangeValidatorTest.java
@@ -1,0 +1,391 @@
+package org.kiwiproject.validation;
+
+import static org.kiwiproject.validation.ValidationTestHelper.assertNoViolations;
+import static org.kiwiproject.validation.ValidationTestHelper.assertViolations;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.validation.Validator;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Year;
+import java.time.ZonedDateTime;
+
+@DisplayName("FieldRangeValidator")
+class FieldRangeValidatorTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = KiwiValidations.getValidator();
+    }
+
+    @Nested
+    class WhenNotAllowingNull {
+
+        @Nested
+        class ShouldBeValid {
+
+            @Test
+            void whenStartAndEndFieldsAreNonNull() {
+                var obj = NotAllowNull.builder().a1(1).a2(10).build();
+                assertNoViolations(validator, obj);
+            }
+        }
+
+        @Nested
+        class ShouldBeInvalid {
+
+            @Test
+            void whenStartFieldIsNull() {
+                var obj = NotAllowNull.builder().a1(null).a2(42).build();
+                assertViolations(validator, obj, "a1 is required");
+            }
+
+            @Test
+            void whenEndFieldIsNull() {
+                var obj = NotAllowNull.builder().a1(42).a2(null).build();
+                assertViolations(validator, obj, "a2 is required");
+            }
+
+            @Test
+            void whenBothFieldsAreNull() {
+                var obj = NotAllowNull.builder().a1(null).a2(null).build();
+                assertViolations(validator, obj, "a1 is required", "a2 is required");
+            }
+        }
+    }
+
+    @Nested
+    class WhenAllowingNull {
+
+        @Nested
+        class ShouldBeValid {
+
+            @Test
+            void whenStartFieldIsNull() {
+                var obj = AllowNull.builder().b1(null).b2(8).build();
+                assertNoViolations(validator, obj);
+            }
+
+            @Test
+            void whenEndFieldIsNull() {
+                var obj = AllowNull.builder().b1(96).b2(null).build();
+                assertNoViolations(validator, obj);
+            }
+
+            @Test
+            void whenBothFieldsAreNull() {
+                var obj = AllowNull.builder().b1(null).b2(null).build();
+                assertNoViolations(validator, obj);
+            }
+        }
+    }
+
+    @Nested
+    class UnsupportedTypes {
+
+        @Test
+        void shouldBeInvalid_WhenMinMaxForcesConversionToComparable() {
+            var today = LocalDate.now();
+            var obj = HasUnsupportedType.builder().date1(today).date2(today.plusDays(2)).build();
+            assertViolations(validator, obj, "date1 unknown validation error");
+        }
+
+        @Test
+        void shouldBeInvalid_WhenNotComparable() {
+            var obj = HasAnIncomparable.builder().ic1(new AnIncomparable()).ic2(new AnIncomparable()).build();
+            assertViolations(validator, obj, "ic1 unknown validation error");
+        }
+    }
+
+    @Nested
+    class WhenNoMinOrMax {
+
+        @Test
+        void shouldBeAbleToSupportAnyComparable() {
+            var nowZdt = ZonedDateTime.now();
+
+            var obj = NoMinOrMax.builder()
+                    .localDate1(LocalDate.now())
+                    .localDate2(LocalDate.now().plusDays(1))  // valid
+                    .localTime1(LocalTime.now())
+                    .localTime2(LocalTime.now().minusHours(1))  // invalid
+                    .zdt1(nowZdt)
+                    .zdt2(nowZdt)  // invalid
+                    .zdt3(nowZdt)
+                    .zdt4(nowZdt)  // valid
+                    .year1(Year.of(1995))
+                    .year2(Year.of(2000))  // valid
+                    .season1(Season.SUMMER)
+                    .season2(Season.SPRING)  // invalid (summer ordinal > spring ordinal)
+                    .build();
+
+            assertViolations(validator, obj,
+                    "localTime1 must occur before localTime2",
+                    "zdt1 must occur before zdt2",
+                    "season1 must occur before season2");
+        }
+    }
+
+    @Nested
+    class WhenFieldRangeHasOnlyMin {
+
+        @ParameterizedTest
+        @ValueSource(ints = {10, 11, 12, 15, 18})
+        void shouldBeValid_WhenStartEqualsOrAboveMin(int start) {
+            var obj = HasOnlyMin.builder().m1(start).m2(19).build();
+            assertNoViolations(validator, obj);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 0, 5, 8, 9})
+        void shouldBeInvalid_WhenBelowMin(int start) {
+            var obj = HasOnlyMin.builder().m1(start).m2(19).build();
+            assertViolations(validator, obj, "m1 must be equal to or above 10");
+        }
+    }
+
+    @Nested
+    class WhenFieldRangeHasOnlyMax {
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, 5, 10, 19, 20})
+        void shouldBeValid_WhenEndBelowOrEqualToMax(int end) {
+            var obj = HasOnlyMax.builder().m1(-10).m2(end).build();
+            assertNoViolations(validator, obj);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {21, 22, 30, 50})
+        void shouldBeInvalid_WhenAboveMax(int end) {
+            var obj = HasOnlyMax.builder().m1(-8).m2(end).build();
+            assertViolations(validator, obj, "m2 must be below or equal to 20");
+        }
+    }
+
+    @Nested
+    class WhenFieldRangeHasMinAndMax {
+
+        @ParameterizedTest
+        @CsvSource({
+                "10,20",
+                "11,19",
+                "13,18",
+                "10,11",
+                "19,20",
+        })
+        void shouldBeValid_WhenStartEqualsOrAboveMin_AndEndBelowOrEqualToMax(int start, int end) {
+            var obj = HasMinAndMax.builder().m1(start).m2(end).build();
+            assertNoViolations(validator, obj);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "9,20",
+                "8,15",
+                "0,11",
+        })
+        void shouldBeInvalid_WhenStartBelowMin(int start, int end) {
+            var obj = HasMinAndMax.builder().m1(start).m2(end).build();
+            assertViolations(validator, obj, "m1 must be between 10 and 20");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "10,21",
+                "15,25",
+                "19,21",
+        })
+        void shouldBeInvalid_WhenEndAboveMin(int start, int end) {
+            var obj = HasMinAndMax.builder().m1(start).m2(end).build();
+            assertViolations(validator, obj, "m2 must be between 10 and 20");
+        }
+    }
+
+    @Nested
+    class RangeCheck {
+
+        @Nested
+        class WhenNotAllowingStartToEqualStop {
+
+            @ParameterizedTest
+            @ValueSource(ints = {5, 10, 20, 23, 24})
+            void shouldBeValid_WhenStartLessThanEnd(int start) {
+                var obj = NotAllowStartToEqualEnd.builder().s1(start).s2(25).build();
+                assertNoViolations(validator, obj);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {25, 26, 50, 100})
+            void shouldBeInvalid_WhenStartEqualOrAboveEnd(int start) {
+                var obj = NotAllowStartToEqualEnd.builder().s1(start).s2(25).build();
+                assertViolations(validator, obj, "s1 must occur before s2");
+            }
+        }
+
+        @Nested
+        class WhenAllowingStartToEqualStop {
+
+            @ParameterizedTest
+            @ValueSource(ints = {5, 10, 20, 24, 25})
+            void shouldBeValid_WhenStartLessThanOrEqualToEnd(int start) {
+                var obj = AllowStartToEqualEnd.builder().s1(start).s2(25).build();
+                assertNoViolations(validator, obj);
+            }
+
+            @ParameterizedTest
+            @ValueSource(ints = {26, 27, 50, 100})
+            void shouldBeInvalid_WhenStartAboveEnd(int start) {
+                var obj = AllowStartToEqualEnd.builder().s1(start).s2(25).build();
+                assertViolations(validator, obj, "s1 must occur before or match s2");
+            }
+        }
+    }
+
+    @Nested
+    class WhenHasLabels {
+
+        @Test
+        void shouldUseMinAndMaxLabelsInValidationErrorMessages() {
+            var obj = HasLabels.builder().mm1(50).mm2(600).build();
+            assertViolations(validator, obj,
+                    "mm1 must be between one hundred and two hundred",
+                    "mm2 must be between one hundred and two hundred");
+        }
+
+        @Test
+        void shouldUseEndFieldLabel() {
+            var obj = HasLabels.builder().mm1(150).mm2(140).build();
+            assertViolations(validator, obj, "mm1 must occur before Em-Em-2");
+        }
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "a1", endField = "a2")
+    private static class NotAllowNull {
+        private final Integer a1;
+        private final Integer a2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "b1", allowNullStart = true, endField = "b2", allowNullEnd = true)
+    private static class AllowNull {
+        private final Integer b1;
+        private final Integer b2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "m1", min = "10", endField = "m2")
+    private static class HasOnlyMin {
+        private final Integer m1;
+        private final Integer m2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "m1", endField = "m2", max = "20")
+    private static class HasOnlyMax {
+        private final Integer m1;
+        private final Integer m2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "m1", min = "10", endField = "m2", max = "20")
+    private static class HasMinAndMax {
+        private final Integer m1;
+        private final Integer m2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "s1", endField = "s2")
+    private static class NotAllowStartToEqualEnd {
+        private final Integer s1;
+        private final Integer s2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "s1", endField = "s2", allowStartToEqualEnd = true)
+    private static class AllowStartToEqualEnd {
+        private final Integer s1;
+        private final Integer s2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "ic1", endField = "ic2")
+    static class HasAnIncomparable {
+        AnIncomparable ic1;
+        AnIncomparable ic2;
+    }
+
+    private static class AnIncomparable {
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "date1", min = "2020-01-01", endField = "date2", max = "2020-12-31")
+    static class HasUnsupportedType {
+        LocalDate date1;
+        LocalDate date2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(
+            startField = "mm1", min = "100", minLabel = "one hundred",
+            endField = "mm2", endFieldLabel = "Em-Em-2", max = "200", maxLabel = "two hundred")
+    private static class HasLabels {
+        private final Integer mm1;
+        private final Integer mm2;
+    }
+
+    @Builder
+    @Getter
+    @FieldRange(startField = "localDate1", endField = "localDate2")
+    @FieldRange(startField = "localTime1", endField = "localTime2")
+    @FieldRange(startField = "zdt1", endField = "zdt2")
+    @FieldRange(startField = "zdt3", endField = "zdt4", allowStartToEqualEnd = true)
+    @FieldRange(startField = "year1", endField = "year2")
+    @FieldRange(startField = "season1", endField = "season2")
+    private static class NoMinOrMax {
+
+        LocalDate localDate1;
+        LocalDate localDate2;
+
+        LocalTime localTime1;
+        LocalTime localTime2;
+
+        ZonedDateTime zdt1;
+        ZonedDateTime zdt2;
+
+        ZonedDateTime zdt3;
+        ZonedDateTime zdt4;
+
+        Year year1;
+        Year year2;
+
+        Season season1;
+        Season season2;
+    }
+
+    // Enums are Comparable (using their ordinal number)
+    enum Season {
+        WINTER, SPRING, SUMMER, FALL
+    }
+}

--- a/src/test/java/org/kiwiproject/validation/RangeValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/RangeValidatorTest.java
@@ -51,23 +51,23 @@ class RangeValidatorTest {
         }
     }
 
+    /**
+     * @implNote In these cases, there should be a WARN level log, but we're not going to try to test
+     * that side-effect, and will just rely instead on manual inspection.
+     */
     @Nested
     class UnsupportedTypes {
 
-        /**
-         * @implNote In this case, there should be a WARN level log, but we're not going to try to test
-         * that side-effect, and will just rely instead on manual inspection.
-         */
         @Test
         void shouldBeInvalid() {
             var obj = new HasUnsupportedType(LocalDate.now());
-            assertPropertyViolations(validator, obj, "value");
+            assertPropertyViolations(validator, obj, "value", "unknown validation error");
         }
 
         @Test
         void shouldBeInvalid_WhenNotComparable() {
             var obj = new HasAnIncomparable(new AnIncomparable());
-            assertPropertyViolations(validator, obj, "value");
+            assertPropertyViolations(validator, obj, "value", "unknown validation error");
         }
     }
 
@@ -340,7 +340,7 @@ class RangeValidatorTest {
         AnIncomparable value;
     }
 
-    static class AnIncomparable {
+    private static class AnIncomparable {
     }
 
     @Builder

--- a/src/test/java/org/kiwiproject/validation/ValidationTestHelper.java
+++ b/src/test/java/org/kiwiproject/validation/ValidationTestHelper.java
@@ -30,6 +30,21 @@ public class ValidationTestHelper {
         assertThat(violations).hasSize(numExpectedViolations);
     }
 
+    public static void assertViolations(Validator validator, Object object, String... expectedCombinedMessages) {
+        var violations = validator.validate(object);
+
+        var actualCombinedMessages = KiwiConstraintViolations.simpleCombinedErrorMessages(violations);
+
+        var missingMessages = Arrays.stream(expectedCombinedMessages)
+                .filter(value -> !actualCombinedMessages.contains(value))
+                .collect(toUnmodifiableList());
+
+        if (!missingMessages.isEmpty()) {
+            fail("Messages [%s] not found in actual messages %s",
+                    String.join(",", missingMessages), actualCombinedMessages);
+        }
+    }
+
     public static void assertOnePropertyViolation(Validator validator, Object object, String propertyName) {
         assertPropertyViolations(validator, object, propertyName, 1);
     }


### PR DESCRIPTION
* Add @FieldRange validation annotation
* Add @FieldRanges annotation, which can hold multiple @FieldRange
  annotations
* Add overloaded KiwiValidations#addError method that accepts the
  property path the constraint violation should be attached to
* Add FieldRangeValidator, the validator class for @FieldRange
* Refactor common code shared by RangeValidator and FieldRangeValidator
  into package-private InternalKiwiValidators
* Update ValidationMessages.properties with the custom error message
  for violations of the @FieldRange annotation

Misc cleanup:

* Update InEnumValidator to use KiwiValidations.addError
* Update RangeValidator to use KiwiValidations.addError
* Update @Required#message() to use TEMPLATE_REQUIRED constant from
  new InternalKiwiValidators utility class

Fixes #309
Fixes #310