### PR TITLE
Add more methods and javadoc to existing methods in KiwiResponses

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/KiwiResponses.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiResponses.java
@@ -1,51 +1,311 @@
 package org.kiwiproject.jaxrs;
 
-import lombok.experimental.UtilityClass;
+import static java.util.Objects.nonNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
+import java.util.Optional;
 
+/**
+ * Static utilities related to JAX-RS responses.
+ */
 @UtilityClass
+@Slf4j
 public class KiwiResponses {
 
+    /**
+     * Return a media type suitable for use as the value of a corresponding HTTP header. This will consist
+     * of the primary type and and subtype, e.g. {@code application/json}.
+     *
+     * @param response the response object
+     * @return Optional that may or may not contain a media type
+     * @see MediaType#toString()
+     * @see MediaType#getType()
+     * @see MediaType#getSubtype()
+     */
+    public static Optional<String> mediaType(Response response) {
+        checkArgumentNotNull(response);
+
+        return Optional.ofNullable(response.getMediaType()).map(Object::toString);
+    }
+
+    /**
+     * Check if the given response has a status code in {@link Family#SUCCESSFUL}.
+     * <p>
+     * <strong>NOTE:</strong> This does <em>not</em> close the {@link Response} or read the response entity.
+     *
+     * @param response the response object
+     * @return true if the response is successful, false otherwise
+     * @see Family#SUCCESSFUL
+     */
     public static boolean successful(Response response) {
         return successful(response.getStatus());
     }
 
+    /**
+     * Check if the given response has a status code that is <em>not</em> in {@link Family#SUCCESSFUL}.
+     * <p>
+     * <strong>NOTE:</strong> This does <em>not</em> close the {@link Response} or read the response entity.
+     *
+     * @param response the response object
+     * @return true if the response is <em>not</em> successful, false otherwise
+     */
     public static boolean notSuccessful(Response response) {
         return notSuccessful(response.getStatus());
     }
 
+    /**
+     * Check if the given status code is in {@link Family#SUCCESSFUL}.
+     *
+     * @param status the response Status object
+     * @return true if the status indicates success, false otherwise
+     */
     public static boolean successful(Response.Status status) {
         return successful(status.getStatusCode());
     }
 
-    public static boolean successful(Response.StatusType status) {
-        return successful(status.getStatusCode());
-    }
-
-    public static boolean notSuccessful(Response.StatusType status) {
-        return notSuccessful(status.getStatusCode());
-    }
-
+    /**
+     * Check if the given status code is <em>not</em> in {@link Family#SUCCESSFUL}.
+     *
+     * @param status the response Status object
+     * @return true if the status does <em>not</em> indicate success, false otherwise
+     */
     public static boolean notSuccessful(Response.Status status) {
         return notSuccessful(status.getStatusCode());
     }
 
+    /**
+     * Check if the given status type is in {@link Family#SUCCESSFUL}.
+     *
+     * @param status the response StatusType object
+     * @return true if the status indicates success, false otherwise
+     */
+    public static boolean successful(Response.StatusType status) {
+        return successful(status.getStatusCode());
+    }
+
+    /**
+     * Check if the given status type is <em>not</em> in {@link Family#SUCCESSFUL}.
+     *
+     * @param status the response StatusType object
+     * @return true if the status does <em>not</em> indicate success, false otherwise
+     */
+    public static boolean notSuccessful(Response.StatusType status) {
+        return notSuccessful(status.getStatusCode());
+    }
+
+    /**
+     * Check if the given status code is in {@link Family#SUCCESSFUL}.
+     *
+     * @param statusCode the response status code
+     * @return true if the status code indicates success, false otherwise
+     */
     public static boolean successful(int statusCode) {
         return successful(Family.familyOf(statusCode));
     }
 
+    /**
+     * Check if the given status code is <em>not</em> in {@link Family#SUCCESSFUL}.
+     *
+     * @param statusCode the response status code
+     * @return true if the status code doe <em>not</em> indicate success, false otherwise
+     */
     public static boolean notSuccessful(int statusCode) {
         return !successful(statusCode);
     }
 
+    /**
+     * Check if the given response family is {@link Family#SUCCESSFUL}.
+     *
+     * @param family the response family
+     * @return true if the family is successful, false otherwise
+     */
     public static boolean successful(Family family) {
         return family == Family.SUCCESSFUL;
     }
 
+    /**
+     * Check if the given response family is <em>not</em> {@link Family#SUCCESSFUL}.
+     *
+     * @param family the response family
+     * @return true if the family is <em>not</em> successful, false otherwise
+     */
     public static boolean notSuccessful(Family family) {
         return !successful(family);
+    }
+
+    /**
+     * Check if the given response has a status code in {@link Family#SUCCESSFUL}, <em>then close the response</em>.
+     * <p>
+     * <strong>NOTE:</strong> Closes the response after performing the check.
+     *
+     * @param response the response object
+     * @return true if the response is successful, false otherwise
+     */
+    public static boolean successfulAlwaysClosing(Response response) {
+        checkArgumentNotNull(response, "response cannot be null");
+        try {
+            return successful(response);
+        } finally {
+            closeQuietly(response);
+        }
+    }
+
+    /**
+     * Check if the given response has a status code that is <em>not</em> in {@link Family#SUCCESSFUL},
+     * <em>then close the response</em>.
+     * <p>
+     * <strong>NOTE:</strong> Closes the response after performing the check.
+     *
+     * @param response the response object
+     * @return true if the response is <em>not</em> successful, false otherwise
+     */
+    public static boolean notSuccessfulAlwaysClosing(Response response) {
+        return !successfulAlwaysClosing(response);
+    }
+
+    /**
+     * Closes the given {@link Response}, which can be {@code null}, swallowing any exceptions and logging them
+     * at INFO level.
+     *
+     * @param response the response object
+     */
+    public static void closeQuietly(Response response) {
+        if (nonNull(response)) {
+            try {
+                response.close();
+            } catch (Exception e) {
+                LOG.info("Error closing response", e);
+            }
+        }
+    }
+
+    /**
+     * Check if the given response has status 200 OK.
+     *
+     * @param response the response object
+     * @return true if the response status is 200 OK, false otherwise
+     */
+    public static boolean ok(Response response) {
+        return hasStatus(response, Response.Status.OK);
+    }
+
+    /**
+     * Check if the given response has status 201 Created.
+     *
+     * @param response the response object
+     * @return true if the response status is 201 Created, false otherwise
+     */
+    public static boolean created(Response response) {
+        return hasStatus(response, Response.Status.CREATED);
+    }
+
+    /**
+     * Check if the given response has status 404 Not Found.
+     *
+     * @param response the response object
+     * @return true if the response status is 404 Not Found, false otherwise
+     */
+    public static boolean notFound(Response response) {
+        return hasStatus(response, Response.Status.NOT_FOUND);
+    }
+
+    /**
+     * Check if the given response has status 500 Internal Server Error.
+     *
+     * @param response the response object
+     * @return true if the response status is 500 Internal Server Error, false otherwise
+     */
+    public static boolean internalServerError(Response response) {
+        return hasStatus(response, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check if the given response has the expected status.
+     *
+     * @param response the response object
+     * @param status   the expected status
+     * @return true if the response has the given status, false otherwise
+     */
+    public static boolean hasStatus(Response response, Response.Status status) {
+        checkArgumentNotNull(response);
+        checkArgumentNotNull(status);
+
+        return response.getStatusInfo().getStatusCode() == status.getStatusCode();
+    }
+
+    /**
+     * Check if the given response is in the INFORMATIONAL (1xx codes) family.
+     *
+     * @param response the response object
+     * @return true if the response is in the INFORMATIONAL family, false otherwise
+     * @see Family#INFORMATIONAL
+     */
+    public static boolean informational(Response response) {
+        return hasFamily(response, Family.INFORMATIONAL);
+    }
+
+    /**
+     * Check if the given response is in the REDIRECTION (3xx codes) family.
+     *
+     * @param response the response object
+     * @return true if the response is in the REDIRECTION family, false otherwise
+     * @see Family#REDIRECTION
+     */
+    public static boolean redirection(Response response) {
+        return hasFamily(response, Family.REDIRECTION);
+    }
+
+    /**
+     * Check if the given response is in the CLIENT_ERROR (4xx codes) family.
+     *
+     * @param response the response object
+     * @return true if the response is in the CLIENT_ERROR family, false otherwise
+     * @see Family#CLIENT_ERROR
+     */
+    public static boolean clientError(Response response) {
+        return hasFamily(response, Family.CLIENT_ERROR);
+    }
+
+    /**
+     * Check if the given response is in the SERVER_ERROR (5xx codes) family.
+     *
+     * @param response the response object
+     * @return true if the response is in the SERVER_ERROR family, false otherwise
+     * @see Family#SERVER_ERROR
+     */
+    public static boolean serverError(Response response) {
+        return hasFamily(response, Family.SERVER_ERROR);
+    }
+
+    /**
+     * Check if the given response is in the OTHER (unrecognized status codes) family.
+     *
+     * @param response the response object
+     * @return true if the response is in the OTHER family, false otherwise
+     * @see Family#OTHER
+     */
+    public static boolean otherFamily(Response response) {
+        return hasFamily(response, Family.OTHER);
+    }
+
+    /**
+     * Check if the given response has the expected family.
+     *
+     * @param response the response object
+     * @param family   the expected family
+     * @return true if the response has the given status, false otherwise
+     */
+    public static boolean hasFamily(Response response, Family family) {
+        checkArgumentNotNull(response);
+        checkArgumentNotNull(family);
+
+        return response.getStatusInfo().getFamily() == family;
     }
 
 }

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiResponsesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiResponsesTest.java
@@ -1,147 +1,406 @@
 package org.kiwiproject.jaxrs;
 
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
+import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_XML;
+import static javax.ws.rs.core.MediaType.TEXT_XML_TYPE;
+import static javax.ws.rs.core.MediaType.WILDCARD;
+import static javax.ws.rs.core.MediaType.WILDCARD_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 @ExtendWith(SoftAssertionsExtension.class)
 class KiwiResponsesTest {
 
-    @Test
-    void testSuccessful_ForStatusCodes(SoftAssertions softly) {
-        forEachStatus(status -> {
-            int statusCode = status.getStatusCode();
-            boolean successfulFamily = successful(Family.familyOf(statusCode));
-            softly.assertThat(KiwiResponses.successful(statusCode))
-                    .describedAs("Status code: %d", statusCode)
-                    .isEqualTo(successfulFamily);
-        });
+    @Nested
+    class GetMediaType {
+
+        @Test
+        void shouldReturnMediaType_WhenResponseContainsMediaType(SoftAssertions softly) {
+            softly.assertThat(KiwiResponses.mediaType(newMockResponseWithMediaType(APPLICATION_JSON_TYPE)))
+                    .hasValue(APPLICATION_JSON);
+
+            softly.assertThat(KiwiResponses.mediaType(newMockResponseWithMediaType(WILDCARD_TYPE)))
+                    .hasValue(WILDCARD);
+
+            softly.assertThat(KiwiResponses.mediaType(newMockResponseWithMediaType(TEXT_XML_TYPE)))
+                    .hasValue(TEXT_XML);
+
+            softly.assertThat(KiwiResponses.mediaType(newMockResponseWithMediaType(APPLICATION_OCTET_STREAM_TYPE)))
+                    .hasValue(APPLICATION_OCTET_STREAM);
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenResponseHasNoMediaType() {
+            var response = newMockResponseWithMediaType(null);
+
+            assertThat(KiwiResponses.mediaType(response)).isEmpty();
+        }
     }
 
-    @Test
-    void testNotSuccessful_ForStatusCodes(SoftAssertions softly) {
-        forEachStatus(status -> {
-            int statusCode = status.getStatusCode();
-            boolean successfulFamily = successful(Family.familyOf(statusCode));
-            softly.assertThat(KiwiResponses.notSuccessful(statusCode))
-                    .describedAs("Status code: %d", statusCode)
-                    .isNotEqualTo(successfulFamily);
-        });
+    private static Response newMockResponseWithMediaType(MediaType mediaType) {
+        var response = mock(Response.class);
+        when(response.getMediaType()).thenReturn(mediaType);
+        return response;
     }
 
-    @Test
-    void testSuccessful_ForStatus(SoftAssertions softly) {
-        forEachStatus(status -> {
-            boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
-            softly.assertThat(KiwiResponses.successful(status))
-                    .describedAs("Status: %s (%d)", status, status.getStatusCode())
-                    .isEqualTo(successfulFamily);
-        });
+    @Nested
+    class SuccessCheckMethods {
+
+        @Test
+        void shouldCheckSuccessful_ForStatusCodes(SoftAssertions softly) {
+            forEachStatus(status -> {
+                int statusCode = status.getStatusCode();
+                boolean successfulFamily = successful(Family.familyOf(statusCode));
+                softly.assertThat(KiwiResponses.successful(statusCode))
+                        .describedAs("Status code: %d", statusCode)
+                        .isEqualTo(successfulFamily);
+            });
+        }
+
+        @Test
+        void shouldCheckNotSuccessful_ForStatusCodes(SoftAssertions softly) {
+            forEachStatus(status -> {
+                int statusCode = status.getStatusCode();
+                boolean successfulFamily = successful(Family.familyOf(statusCode));
+                softly.assertThat(KiwiResponses.notSuccessful(statusCode))
+                        .describedAs("Status code: %d", statusCode)
+                        .isNotEqualTo(successfulFamily);
+            });
+        }
+
+        @Test
+        void shouldCheckSuccessful_ForStatusObjects(SoftAssertions softly) {
+            forEachStatus(status -> {
+                boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
+                softly.assertThat(KiwiResponses.successful(status))
+                        .describedAs("Status: %s (%d)", status, status.getStatusCode())
+                        .isEqualTo(successfulFamily);
+            });
+        }
+
+        @Test
+        void shouldCheckNotSuccessful_ForStatusObjects(SoftAssertions softly) {
+            forEachStatus(status -> {
+                boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
+                softly.assertThat(KiwiResponses.notSuccessful(status))
+                        .describedAs("Status: %s (%d)", status, status.getStatusCode())
+                        .isNotEqualTo(successfulFamily);
+            });
+        }
+
+        @Test
+        void shouldCheckSuccessful_ForSuccessfulStatusTypeObjects(SoftAssertions softly) {
+            var type = new Response.StatusType() {
+                @Override
+                public int getStatusCode() {
+                    return 200;
+                }
+
+                @Override
+                public Family getFamily() {
+                    return Family.SUCCESSFUL;
+                }
+
+                @Override
+                public String getReasonPhrase() {
+                    return "OK";
+                }
+            };
+            softly.assertThat(KiwiResponses.successful(type)).isTrue();
+            softly.assertThat(KiwiResponses.notSuccessful(type)).isFalse();
+        }
+
+        @Test
+        void shouldCheckSuccessful_ForUnsuccessfulStatusTypeObjects(SoftAssertions softly) {
+            var type = new Response.StatusType() {
+                @Override
+                public int getStatusCode() {
+                    return 500;
+                }
+
+                @Override
+                public Family getFamily() {
+                    return Family.SERVER_ERROR;
+                }
+
+                @Override
+                public String getReasonPhrase() {
+                    return "Server Error";
+                }
+            };
+            softly.assertThat(KiwiResponses.successful(type)).isFalse();
+            softly.assertThat(KiwiResponses.notSuccessful(type)).isTrue();
+        }
+
+        @Test
+        void shouldCheckSuccessful_ForResponseObjects(SoftAssertions softly) {
+            forEachStatus(status -> {
+                var statusCode = status.getStatusCode();
+                var response = newMockResponseWithStatusCode(statusCode);
+                boolean successfulFamily = successful(Family.familyOf(statusCode));
+                softly.assertThat(KiwiResponses.successful(response))
+                        .describedAs("Status: %s (%d)", status, statusCode)
+                        .isEqualTo(successfulFamily);
+                verify(response, never()).close();
+            });
+        }
+
+        @Test
+        void shouldCheckNotSuccessful_ForResponseObjects(SoftAssertions softly) {
+            forEachStatus(status -> {
+                var statusCode = status.getStatusCode();
+                var response = newMockResponseWithStatusCode(statusCode);
+                boolean successfulFamily = successful(Family.familyOf(statusCode));
+                softly.assertThat(KiwiResponses.notSuccessful(response))
+                        .describedAs("Status: %s (%d)", status, statusCode)
+                        .isNotEqualTo(successfulFamily);
+                verify(response, never()).close();
+            });
+        }
+
+        @Test
+        void shouldCheckSuccessful_ForFamilyObjects(SoftAssertions softly) {
+            Arrays.stream(Family.values()).forEach(family -> {
+                boolean successfulFamily = successful(family);
+                softly.assertThat(KiwiResponses.successful(family))
+                        .describedAs("Family: %s", family)
+                        .isEqualTo(successfulFamily);
+            });
+        }
+
+        @Test
+        void shouldCheckNotSuccessful_ForFamilyObjects(SoftAssertions softly) {
+            Arrays.stream(Family.values()).forEach(family -> {
+                boolean successfulFamily = successful(family);
+                softly.assertThat(KiwiResponses.notSuccessful(family))
+                        .describedAs("Family: %s", family)
+                        .isNotEqualTo(successfulFamily);
+            });
+        }
     }
 
-    @Test
-    void testNotSuccessful_ForStatus(SoftAssertions softly) {
-        forEachStatus(status -> {
-            boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
-            softly.assertThat(KiwiResponses.notSuccessful(status))
-                    .describedAs("Status: %s (%d)", status, status.getStatusCode())
-                    .isNotEqualTo(successfulFamily);
-        });
-    }
-
-    @Test
-    void testSuccessful_ForSuccessfulStatusType(SoftAssertions softly) {
-        Response.StatusType type = new Response.StatusType() {
-            @Override
-            public int getStatusCode() {
-                return 200;
-            }
-
-            @Override
-            public Family getFamily() {
-                return Family.SUCCESSFUL;
-            }
-
-            @Override
-            public String getReasonPhrase() {
-                return "OK";
-            }
-        };
-        softly.assertThat(KiwiResponses.successful(type)).isTrue();
-        softly.assertThat(KiwiResponses.notSuccessful(type)).isFalse();
-    }
-
-    @Test
-    void testSuccessful_ForUnsuccessfulStatusType(SoftAssertions softly) {
-        Response.StatusType type = new Response.StatusType() {
-            @Override
-            public int getStatusCode() {
-                return 500;
-            }
-
-            @Override
-            public Family getFamily() {
-                return Family.SERVER_ERROR;
-            }
-
-            @Override
-            public String getReasonPhrase() {
-                return "Server Error";
-            }
-        };
-        softly.assertThat(KiwiResponses.successful(type)).isFalse();
-        softly.assertThat(KiwiResponses.notSuccessful(type)).isTrue();
-    }
-
-    @Test
-    void testSuccessful_ForResponse(SoftAssertions softly) {
-        forEachStatus(status -> {
-            Response response = mock(Response.class);
-            when(response.getStatus()).thenReturn(status.getStatusCode());
-            boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
-            softly.assertThat(KiwiResponses.successful(response))
-                    .describedAs("Status: %s (%d)", status, status.getStatusCode())
-                    .isEqualTo(successfulFamily);
-        });
-    }
-
-    @Test
-    void testNotSuccessful_ForResponse(SoftAssertions softly) {
-        forEachStatus(status -> {
-            Response response = mock(Response.class);
-            when(response.getStatus()).thenReturn(status.getStatusCode());
-            boolean successfulFamily = successful(Family.familyOf(status.getStatusCode()));
-            softly.assertThat(KiwiResponses.notSuccessful(response))
-                    .describedAs("Status: %s (%d)", status, status.getStatusCode())
-                    .isNotEqualTo(successfulFamily);
-        });
-    }
-
-    @Test
-    void testNotSuccessful_ForFamily(SoftAssertions softly) {
-        Arrays.stream(Family.values()).forEach(family -> {
-            boolean successfulFamily = successful(family);
-            softly.assertThat(KiwiResponses.notSuccessful(family))
-                    .describedAs("Family: %s", family)
-                    .isNotEqualTo(successfulFamily);
-        });
-    }
-
-    private void forEachStatus(Consumer<Response.Status> statusConsumer) {
+    private static void forEachStatus(Consumer<Response.Status> statusConsumer) {
         Arrays.stream(Response.Status.values()).forEach(statusConsumer);
     }
 
-    private boolean successful(Family family) {
+    private static boolean successful(Family family) {
         return family == Family.SUCCESSFUL;
     }
 
+    @Nested
+    class AlwaysClosingResponseMethods {
+
+        @Test
+        void shouldCheckSuccessful_AndCloseResponse_WhenSuccessfulResponse() {
+            var response = newMockResponseWithStatus(Response.Status.OK);
+
+            assertThat(KiwiResponses.successfulAlwaysClosing(response)).isTrue();
+
+            verify(response).close();
+        }
+
+        @Test
+        void shouldCheckSuccessful_AndCloseResponse_WhenNotSuccessfulResponse() {
+            var response = newMockResponseWithStatus(Response.Status.UNAUTHORIZED);
+
+            assertThat(KiwiResponses.successfulAlwaysClosing(response)).isFalse();
+
+            verify(response).close();
+        }
+
+        @Test
+        void shouldCheckNotSuccessful_AndCloseResponse_WhenSuccessfulResponse() {
+            var response = newMockResponseWithStatus(Response.Status.NO_CONTENT);
+
+            assertThat(KiwiResponses.notSuccessfulAlwaysClosing(response)).isFalse();
+
+            verify(response).close();
+        }
+
+        @Test
+        void shouldCheckNotSuccessful_AndCloseResponse_WhenNotSuccessfulResponse() {
+            var response = newMockResponseWithStatus(Response.Status.MOVED_PERMANENTLY);
+
+            assertThat(KiwiResponses.notSuccessfulAlwaysClosing(response)).isTrue();
+
+            verify(response).close();
+        }
+    }
+
+    @Nested
+    class CloseQuietly {
+
+        @Test
+        void shouldCloseNonNullResponses() {
+            var response = newMockResponseWithStatus(Response.Status.OK);
+
+            KiwiResponses.closeQuietly(response);
+
+            verify(response).close();
+        }
+
+        @Test
+        void shouldIgnoreNullResponses() {
+            assertThatCode(() -> KiwiResponses.closeQuietly(null))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldIgnoreExceptions() {
+            var response = newMockResponseWithStatus(Response.Status.INTERNAL_SERVER_ERROR);
+            doThrow(new ProcessingException("error closing")).when(response).close();
+
+            assertThatCode(() -> KiwiResponses.closeQuietly(response))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    private static Response newMockResponseWithStatus(Response.Status status) {
+        return newMockResponseWithStatusCode(status.getStatusCode());
+    }
+
+    private static Response newMockResponseWithStatusCode(int statusCode) {
+        var response = mock(Response.class);
+        when(response.getStatus()).thenReturn(statusCode);
+        return response;
+    }
+
+    @Nested
+    class ResponseTypeMethods {
+
+        @Test
+        void shouldCheckOkResponse(SoftAssertions softly) {
+            softly.assertThat(KiwiResponses.ok(newResponseWithStatus(Response.Status.OK))).isTrue();
+            softly.assertThat(KiwiResponses.ok(newResponseWithStatus(Response.Status.NO_CONTENT))).isFalse();
+        }
+
+        @Test
+        void shouldCheckCreatedResponse(SoftAssertions softly) {
+            softly.assertThat(KiwiResponses.created(newResponseWithStatus(Response.Status.CREATED))).isTrue();
+            softly.assertThat(KiwiResponses.created(newResponseWithStatus(Response.Status.OK))).isFalse();
+        }
+
+        @Test
+        void shouldCheckNotFoundResponse(SoftAssertions softly) {
+            softly.assertThat(KiwiResponses.notFound(newResponseWithStatus(Response.Status.NOT_FOUND))).isTrue();
+            softly.assertThat(KiwiResponses.notFound(newResponseWithStatus(Response.Status.OK))).isFalse();
+            softly.assertThat(KiwiResponses.notFound(newResponseWithStatus(Response.Status.UNAUTHORIZED))).isFalse();
+        }
+
+        @Test
+        void shouldCheckInternalServerErrorResponse(SoftAssertions softly) {
+            softly.assertThat(KiwiResponses.internalServerError(newResponseWithStatus(Response.Status.INTERNAL_SERVER_ERROR))).isTrue();
+            softly.assertThat(KiwiResponses.internalServerError(newResponseWithStatus(Response.Status.OK))).isFalse();
+            softly.assertThat(KiwiResponses.internalServerError(newResponseWithStatus(Response.Status.NOT_FOUND))).isFalse();
+        }
+    }
+
+    private static Response newResponseWithStatus(Response.Status status) {
+        return Response.status(status).build();
+    }
+
+    @Nested
+    class FamilyCheckMethods {
+
+        @Test
+        void shouldCheckInformational() {
+            IntStream.rangeClosed(100, 199).forEach(statusCode ->
+                    assertThat(KiwiResponses.informational(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isTrue());
+
+            IntStream.rangeClosed(200, 599).forEach(statusCode ->
+                    assertThat(KiwiResponses.informational(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+        }
+
+        @Test
+        void shouldCheckRedirection() {
+            IntStream.rangeClosed(100, 299).forEach(statusCode ->
+                    assertThat(KiwiResponses.redirection(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+
+            IntStream.rangeClosed(300, 399).forEach(statusCode ->
+                    assertThat(KiwiResponses.redirection(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isTrue());
+
+            IntStream.rangeClosed(400, 599).forEach(statusCode ->
+                    assertThat(KiwiResponses.redirection(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+        }
+
+        @Test
+        void shouldCheckClientError() {
+            IntStream.rangeClosed(100, 399).forEach(statusCode ->
+                    assertThat(KiwiResponses.clientError(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+
+            IntStream.rangeClosed(400, 499).forEach(statusCode ->
+                    assertThat(KiwiResponses.clientError(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isTrue());
+
+            IntStream.rangeClosed(500, 599).forEach(statusCode ->
+                    assertThat(KiwiResponses.clientError(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+        }
+
+        @Test
+        void shouldCheckServerError() {
+            IntStream.rangeClosed(100, 499).forEach(statusCode ->
+                    assertThat(KiwiResponses.serverError(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+
+            IntStream.rangeClosed(500, 599).forEach(statusCode ->
+                    assertThat(KiwiResponses.serverError(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isTrue());
+        }
+
+        @Test
+        void shouldCheckOther() {
+            IntStream.rangeClosed(100, 599).forEach(statusCode ->
+                    assertThat(KiwiResponses.otherFamily(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isFalse());
+
+            IntStream.rangeClosed(600, 999).forEach(statusCode ->
+                    assertThat(KiwiResponses.otherFamily(newResponseWithStatusCode(statusCode)))
+                            .describedAs("Status: %d", statusCode)
+                            .isTrue());
+        }
+    }
+
+    private static Response newResponseWithStatusCode(int status) {
+        return Response.status(status).build();
+    }
 }


### PR DESCRIPTION
This does not complete the associated issue #326  - there are still more methods. This PR includes the rest of "simple" methods.
