### PR TITLE
Removing the temporary logging from FieldRangeValidatorTest

### DIFF
--- a/src/test/java/org/kiwiproject/validation/FieldRangeValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/FieldRangeValidatorTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.LoggerFactory;
 
 import javax.validation.Validator;
 import java.time.LocalDate;
@@ -130,15 +129,6 @@ class FieldRangeValidatorTest {
                     .season1(Season.SUMMER)
                     .season2(Season.SPRING)  // invalid (summer ordinal > spring ordinal)
                     .build();
-
-            // TODO Temporary!!!
-            var logger = LoggerFactory.getLogger(WhenNoMinOrMax.class);
-            logger.info("localTime1: {} ; localTime2: {}", obj.getLocalTime1(), obj.getLocalTime2());
-            logger.info("localTime1.compareTo(localTime2) = {}", obj.getLocalTime1().compareTo(obj.getLocalTime2()));
-            var violations = validator.validate(obj);
-            violations.forEach(v ->
-                    logger.info("{} {}", v.getPropertyPath(), v.getMessage()));
-            // TODO End Temporary!!!
 
             assertViolations(validator, obj,
                     "localTime1 must occur before localTime2",


### PR DESCRIPTION
The FieldRangeValidatorTest kept failing for some strange reason
and now removing the temporary logging that was accidentally
committed (and hoping the weird problem doesn't come back)