### PR TITLE
Allow only one element in KiwiIterators#cycleForever

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiIterators.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiIterators.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
 @UtilityClass
 public class KiwiIterators {
 
-    public static final String NOT_ENOUGH_VALUES_ERROR = "need at least 2 elements to cycle";
+    private static final String NOT_ENOUGH_VALUES_ERROR = "need at least 1 element to cycle";
 
     /**
      * Returns a <em>thread-safe</em> iterator that cycles indefinitely over the elements of {@code iterable}, base
@@ -39,8 +39,8 @@ public class KiwiIterators {
      * @return an Iterator that cycles through the given Iterable without terminating
      */
     public static <T> Iterator<T> cycleForever(Iterable<T> iterable) {
-        ImmutableList<T> elements = ImmutableList.copyOf(iterable);
-        checkArgument(elements.size() > 1, NOT_ENOUGH_VALUES_ERROR);
+        var elements = ImmutableList.copyOf(iterable);
+        checkArgument(!elements.isEmpty(), NOT_ENOUGH_VALUES_ERROR);
         return new ThreadSafeCyclicIterator<>(elements);
     }
 
@@ -62,7 +62,7 @@ public class KiwiIterators {
      */
     @SafeVarargs
     public static <T> Iterator<T> cycleForever(T... elements) {
-        checkArgument(elements.length > 1, NOT_ENOUGH_VALUES_ERROR);
+        checkArgument(elements.length > 0, NOT_ENOUGH_VALUES_ERROR);
         return new ThreadSafeCyclicIterator<>(newArrayList(elements));
     }
 

--- a/src/test/java/org/kiwiproject/collect/KiwiIteratorsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiIteratorsTest.java
@@ -2,7 +2,6 @@ package org.kiwiproject.collect;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,33 +36,27 @@ class KiwiIteratorsTest {
     void testCycleForever_ThrowsIllegalArgumentException_WhenSupplyEmptyIterable() {
         assertThatThrownBy(() -> KiwiIterators.cycleForever(new ArrayList<>()))
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("need at least 2 elements to cycle");
+                .hasMessage("need at least 1 element to cycle");
     }
 
     @Test
     void testCycleForever_ThrowsIllegalArgumentException_WhenDoNotPassAnyVarArgs() {
         assertThatThrownBy(KiwiIterators::cycleForever)
                 .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("need at least 2 elements to cycle");
+                .hasMessage("need at least 1 element to cycle");
     }
 
     @Test
     void testCycleForever_DoesNotPermitRemovingElements() {
-        tryRemoveElement(KiwiIterators.cycleForever(colorShades));
-    }
+        var cycler = KiwiIterators.cycleForever(colorShades);
 
-    private <E> void tryRemoveElement(Iterator<E> cycler) {
-        try {
-            cycler.remove();
-            fail("should not allow remove() on cycler");
-        } catch (Exception e) {
-            assertThat(e).isExactlyInstanceOf(UnsupportedOperationException.class)
-                    .hasMessageStartingWith("unsupported");
-        }
+        assertThatThrownBy(cycler::remove)
+                .isExactlyInstanceOf(UnsupportedOperationException.class)
+                .hasMessageStartingWith("unsupported");
     }
 
     @Test
-    void testCycleForever_ModificationsToOriginalCollection_ShouldNotEffectCycler() {
+    void testCycleForever_ModificationsToOriginalCollection_ShouldNotAffectCycler() {
         Iterator<String> cycleForever = KiwiIterators.cycleForever(colorShades);
         colorShades.add("lighter");
         colorShades.add("medium");
@@ -85,6 +78,14 @@ class KiwiIteratorsTest {
         assertThatThrownBy(() -> cycleForever.forEachRemaining(System.out::println))
                 .isExactlyInstanceOf(UnsupportedOperationException.class)
                 .hasMessageStartingWith("unsupported");
+    }
+
+    @Test
+    void testCycleForever_WhenOnlyOneElement() {
+        Iterator<Integer> cycleForever = KiwiIterators.cycleForever(42);
+        for (int i = 0; i < 500; i++) {
+            assertThat(cycleForever.next()).isEqualTo(42);
+        }
     }
 
     @Test


### PR DESCRIPTION
* Change cycleForever to require one or more elements
* Make the NOT_ENOUGH_VALUES_ERROR constant private; no idea why this
  was ever public

Fixes #339