### PR TITLE
Add JaxrsValidationException

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/exception/ErrorMessage.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/ErrorMessage.java
@@ -26,11 +26,10 @@ import java.util.Map;
 @Slf4j
 public class ErrorMessage {
 
-    // TODO These were originally public; not sure why or if they need to be
-    private static final String KEY_CODE = "code";
-    private static final String KEY_FIELD_NAME = "fieldName";
-    private static final String KEY_ITEM_ID = "itemId";
-    private static final String KEY_MESSAGE = "message";
+    public static final String KEY_CODE = "code";
+    public static final String KEY_FIELD_NAME = "fieldName";
+    public static final String KEY_ITEM_ID = "itemId";
+    public static final String KEY_MESSAGE = "message";
 
     static final String DEFAULT_MSG = "Unknown error";
     static final int DEFAULT_CODE = 500;

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsBadRequestException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsBadRequestException.java
@@ -5,6 +5,9 @@ package org.kiwiproject.jaxrs.exception;
  */
 public class JaxrsBadRequestException extends JaxrsException {
 
+    /**
+     * The status code for all instances of this exception.
+     */
     public static final int CODE = 400;
 
     /**

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsConflictException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsConflictException.java
@@ -5,6 +5,9 @@ package org.kiwiproject.jaxrs.exception;
  */
 public class JaxrsConflictException extends JaxrsException {
 
+    /**
+     * The status code for all instances of this exception.
+     */
     public static final int CODE = 409;
 
     /**

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsForbiddenException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsForbiddenException.java
@@ -5,6 +5,9 @@ package org.kiwiproject.jaxrs.exception;
  */
 public class JaxrsForbiddenException extends JaxrsException {
 
+    /**
+     * The status code for all instances of this exception.
+     */
     public static final int CODE = 403;
 
     /**

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsNotAuthorizedException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsNotAuthorizedException.java
@@ -5,6 +5,9 @@ package org.kiwiproject.jaxrs.exception;
  */
 public class JaxrsNotAuthorizedException extends JaxrsException {
 
+    /**
+     * The status code for all instances of this exception.
+     */
     public static final int CODE = 401;
 
     /**

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsNotFoundException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsNotFoundException.java
@@ -5,6 +5,9 @@ package org.kiwiproject.jaxrs.exception;
  */
 public class JaxrsNotFoundException extends JaxrsException {
 
+    /**
+     * The status code for all instances of this exception.
+     */
     public static final int CODE = 404;
 
     /**

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsValidationException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsValidationException.java
@@ -1,0 +1,108 @@
+package org.kiwiproject.jaxrs.exception;
+
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toList;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Exception representing a 422 status code that extends {@link JaxrsException} to use Kiwi's {@link ErrorMessage}.
+ */
+public class JaxrsValidationException extends JaxrsException {
+
+    /**
+     * The status code for all instances of this exception.
+     */
+    public static final int CODE = 422;
+
+    private static final String VALIDATION_FAILED_MESSAGE = "Validation failed";
+
+    /**
+     * New instance with given item ID and error messages.
+     * <p>
+     * Each map contained in {@code errorMessageMaps} must have entries with at least two keys:
+     * {@link ErrorMessage#KEY_FIELD_NAME} and {@link ErrorMessage#KEY_MESSAGE}. In other words, the
+     * maps should contain an entry whose key is {@link ErrorMessage#KEY_FIELD_NAME} and another entry
+     * whose key is {@link ErrorMessage#KEY_MESSAGE}. Any other entries are ignored. The value of these
+     * two entries become the field name and message in the resulting {@link ErrorMessage} objects.
+     *
+     * @param itemId           the unique ID of the item that caused this error
+     * @param errorMessageMaps a list containing maps containing
+     */
+    public JaxrsValidationException(String itemId, List<Map<String, String>> errorMessageMaps) {
+        super(VALIDATION_FAILED_MESSAGE, CODE);
+
+        checkArgumentNotNull(errorMessageMaps);
+        var errorMessages = errorMessageMaps.stream()
+                .map(entry -> {
+                    var fieldName = entry.get(ErrorMessage.KEY_FIELD_NAME);
+                    var message = entry.get(ErrorMessage.KEY_MESSAGE);
+                    return new ErrorMessage(itemId, CODE, message, fieldName);
+                }).collect(toList());
+        setErrors(errorMessages);
+    }
+
+    /**
+     * New instance with given item ID and constraint violations.
+     *
+     * @param itemId     the unique ID of the item that caused this error
+     * @param violations the constraint violations to transform into {@link ErrorMessage} objects
+     */
+    public JaxrsValidationException(String itemId, Set<? extends ConstraintViolation<?>> violations) {
+        super(VALIDATION_FAILED_MESSAGE, CODE);
+
+        checkArgumentNotNull(violations);
+        var errorMessages = violations.stream()
+                .map(violation -> buildErrorMessage(itemId, violation))
+                .collect(toList());
+        setErrors(errorMessages);
+    }
+
+    /**
+     * New instance with given item ID, constraint violations, and a map containing entries whose keys are the
+     * property path of the {@link ConstraintViolation} and values are the field/property name that should be
+     * used in place of the property path.
+     * <p>
+     * For example, {@code propertyPathMappings} might contain an entry with key "firstName" and value
+     * "First Name". In the resulting instance, the corresponding {@link ErrorMessage} object contained in the
+     * list returned by {@link #getErrors()} will have "First Name" as the field name.
+     *
+     * @param itemId               the unique ID of the item that caused this error
+     * @param violations           the constraint violations to transform into {@link ErrorMessage} objects
+     * @param propertyPathMappings mappings from property path of a {@link ConstraintViolation} to the field name
+     *                             to use in the {@link ErrorMessage} objects
+     */
+    public JaxrsValidationException(String itemId,
+                                    Set<? extends ConstraintViolation<?>> violations,
+                                    Map<String, String> propertyPathMappings) {
+        super(VALIDATION_FAILED_MESSAGE, CODE);
+
+        checkArgumentNotNull(violations);
+        var errorMessages = violations.stream()
+                .map(violation -> {
+                    var propertyPath = violation.getPropertyPath().toString();
+                    var fieldNameOrNull = propertyPathMappings.get(propertyPath);
+                    return buildErrorMessage(itemId, violation, fieldNameOrNull);
+                }).collect(toList());
+        setErrors(errorMessages);
+    }
+
+    private static ErrorMessage buildErrorMessage(String itemId,
+                                                  @NotNull ConstraintViolation<?> violation) {
+        checkArgumentNotNull(violation, "violation cannot be null");
+        return buildErrorMessage(itemId, violation, violation.getPropertyPath().toString());
+    }
+
+    private static ErrorMessage buildErrorMessage(String itemId,
+                                                  @NotNull ConstraintViolation<?> violation,
+                                                  String fieldName) {
+        checkArgumentNotNull(violation, "violation cannot be null");
+        var fieldNameOrPropertyPath = nonNull(fieldName) ? fieldName : violation.getPropertyPath().toString();
+        return new ErrorMessage(itemId, CODE, violation.getMessage(), fieldNameOrPropertyPath);
+    }
+}

--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsValidationException.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsValidationException.java
@@ -4,6 +4,8 @@ import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toList;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.constraints.NotNull;
 import java.util.List;
@@ -98,9 +100,10 @@ public class JaxrsValidationException extends JaxrsException {
         return buildErrorMessage(itemId, violation, violation.getPropertyPath().toString());
     }
 
-    private static ErrorMessage buildErrorMessage(String itemId,
-                                                  @NotNull ConstraintViolation<?> violation,
-                                                  String fieldName) {
+    @VisibleForTesting
+    static ErrorMessage buildErrorMessage(String itemId,
+                                          @NotNull ConstraintViolation<?> violation,
+                                          String fieldName) {
         checkArgumentNotNull(violation, "violation cannot be null");
         var fieldNameOrPropertyPath = nonNull(fieldName) ? fieldName : violation.getPropertyPath().toString();
         return new ErrorMessage(itemId, CODE, violation.getMessage(), fieldNameOrPropertyPath);

--- a/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsValidationExceptionTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsValidationExceptionTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.jaxrs.exception;
 
 import static java.util.Comparator.comparing;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
 import static org.kiwiproject.collect.KiwiLists.third;
@@ -11,6 +12,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.hibernate.validator.constraints.Length;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.validation.KiwiValidations;
@@ -126,6 +128,30 @@ class JaxrsValidationExceptionTest {
                 new TreeSet<ConstraintViolation<Person>>(comparing(violation -> violation.getPropertyPath().toString()));
         sortedViolations.addAll(violations);
         return sortedViolations;
+    }
+
+    @Nested
+    class BuildErrorMessage {
+
+        @Test
+        void shouldUseGivenFieldName() {
+            var bob = new Person("Bob", "", null);
+            var violation = KiwiValidations.validate(bob).iterator().next();
+
+            var errorMessage = JaxrsValidationException.buildErrorMessage("42", violation, "Email address");
+
+            assertThat(errorMessage.getFieldName()).isEqualTo("Email address");
+        }
+
+        @Test
+        void shouldUsePropertyPath_WhenFieldNameIsNull() {
+            var contactDetail = new ContactDetail("bob");
+            var violation = KiwiValidations.validate(contactDetail).iterator().next();
+
+            var errorMessage = JaxrsValidationException.buildErrorMessage("42", violation, null);
+
+            assertThat(errorMessage.getFieldName()).isEqualTo("emailAddress");
+        }
     }
 
     @AllArgsConstructor

--- a/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsValidationExceptionTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsValidationExceptionTest.java
@@ -1,0 +1,152 @@
+package org.kiwiproject.jaxrs.exception;
+
+import static java.util.Comparator.comparing;
+import static org.kiwiproject.collect.KiwiLists.first;
+import static org.kiwiproject.collect.KiwiLists.second;
+import static org.kiwiproject.collect.KiwiLists.third;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.hibernate.validator.constraints.Length;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.validation.KiwiValidations;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * @implNote We are relying on the exact messages in the Beans Validation properties
+ * file ({@code ValidationMessages.properties}). If the messages ever change, then this test will break.
+ * It could be made more robust by looking the messages up in the properties file, but since the
+ * messages changing seems unlikely, we are hard coding them in this test.
+ */
+@DisplayName("JaxrsValidationException")
+@ExtendWith(SoftAssertionsExtension.class)
+class JaxrsValidationExceptionTest {
+
+    @Test
+    void shouldConstructFromListOfMaps(SoftAssertions softly) {
+        var errorMessageMaps = List.of(
+                Map.of(ErrorMessage.KEY_FIELD_NAME, "firstName", ErrorMessage.KEY_MESSAGE, "must not be blank"),
+                Map.of(ErrorMessage.KEY_FIELD_NAME, "emailAddress", ErrorMessage.KEY_MESSAGE, "must be a well-formed email address")
+        );
+        var ex = new JaxrsValidationException("42", errorMessageMaps);
+
+        softly.assertThat(ex.getStatusCode()).isEqualTo(422);
+        softly.assertThat(ex.getErrors()).hasSize(2);
+
+        var firstNameError = first(ex.getErrors());
+        softly.assertThat(firstNameError.getItemId()).isEqualTo("42");
+        softly.assertThat(firstNameError.getCode()).isEqualTo(422);
+        softly.assertThat(firstNameError.getFieldName()).isEqualTo("firstName");
+        softly.assertThat(firstNameError.getMessage()).isEqualTo("must not be blank");
+
+        var emailAddressError = second(ex.getErrors());
+        softly.assertThat(emailAddressError.getItemId()).isEqualTo("42");
+        softly.assertThat(emailAddressError.getCode()).isEqualTo(422);
+        softly.assertThat(emailAddressError.getFieldName()).isEqualTo("emailAddress");
+        softly.assertThat(emailAddressError.getMessage()).isEqualTo("must be a well-formed email address");
+    }
+
+    @Test
+    void shouldConstructFromConstraintViolations(SoftAssertions softly) {
+        var person = new Person("", "X", new ContactDetail("x"));
+        var sortedViolations = validateAndSort(person);
+
+        var ex = new JaxrsValidationException("84", sortedViolations);
+
+        softly.assertThat(ex.getStatusCode()).isEqualTo(422);
+        softly.assertThat(ex.getErrors()).hasSize(3);
+
+        var emailError = first(ex.getErrors());
+        softly.assertThat(emailError.getItemId()).isEqualTo("84");
+        softly.assertThat(emailError.getCode()).isEqualTo(422);
+        softly.assertThat(emailError.getFieldName()).isEqualTo("contact.emailAddress");
+        softly.assertThat(emailError.getMessage()).isEqualTo("must be a well-formed email address");
+
+        var firstNameError = second(ex.getErrors());
+        softly.assertThat(firstNameError.getItemId()).isEqualTo("84");
+        softly.assertThat(firstNameError.getCode()).isEqualTo(422);
+        softly.assertThat(firstNameError.getFieldName()).isEqualTo("firstName");
+        softly.assertThat(firstNameError.getMessage()).isEqualTo("must not be blank");
+
+        var lastNameError = third(ex.getErrors());
+        softly.assertThat(lastNameError.getItemId()).isEqualTo("84");
+        softly.assertThat(lastNameError.getCode()).isEqualTo(422);
+        softly.assertThat(lastNameError.getFieldName()).isEqualTo("lastName");
+        softly.assertThat(lastNameError.getMessage()).isEqualTo("length must be between 2 and 255");
+    }
+
+    @Test
+    void shouldConstructFromConstraintViolations_WithFieldNameOverrides(SoftAssertions softly) {
+        var person = new Person("", "X", new ContactDetail("x"));
+        TreeSet<ConstraintViolation<Person>> sortedViolations = validateAndSort(person);
+
+        var propertyPathMappings = Map.of(
+                "contact.emailAddress", "Email",
+                "firstName", "First Name",
+                "lastName", "Last Name"
+        );
+        var ex = new JaxrsValidationException("84", sortedViolations, propertyPathMappings);
+
+        softly.assertThat(ex.getStatusCode()).isEqualTo(422);
+        softly.assertThat(ex.getErrors()).hasSize(3);
+
+        var emailError = first(ex.getErrors());
+        softly.assertThat(emailError.getItemId()).isEqualTo("84");
+        softly.assertThat(emailError.getCode()).isEqualTo(422);
+        softly.assertThat(emailError.getFieldName()).isEqualTo("Email");
+        softly.assertThat(emailError.getMessage()).isEqualTo("must be a well-formed email address");
+
+        var firstNameError = second(ex.getErrors());
+        softly.assertThat(firstNameError.getItemId()).isEqualTo("84");
+        softly.assertThat(firstNameError.getCode()).isEqualTo(422);
+        softly.assertThat(firstNameError.getFieldName()).isEqualTo("First Name");
+        softly.assertThat(firstNameError.getMessage()).isEqualTo("must not be blank");
+
+        var lastNameError = third(ex.getErrors());
+        softly.assertThat(lastNameError.getItemId()).isEqualTo("84");
+        softly.assertThat(lastNameError.getCode()).isEqualTo(422);
+        softly.assertThat(lastNameError.getFieldName()).isEqualTo("Last Name");
+        softly.assertThat(lastNameError.getMessage()).isEqualTo("length must be between 2 and 255");
+    }
+
+    private static TreeSet<ConstraintViolation<Person>> validateAndSort(Person person) {
+        var violations = KiwiValidations.validate(person);
+        var sortedViolations =
+                new TreeSet<ConstraintViolation<Person>>(comparing(violation -> violation.getPropertyPath().toString()));
+        sortedViolations.addAll(violations);
+        return sortedViolations;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class ContactDetail {
+        @Email
+        private final String emailAddress;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private static class Person {
+
+        @NotBlank
+        private final String firstName;
+
+        @NotBlank
+        @Length(min = 2, max = 255)
+        private final String lastName;
+
+        @Valid
+        private final ContactDetail contact;
+    }
+}


### PR DESCRIPTION
* Add JaxrsValidationException and test
* Change the constants in ErrorMessage from private to public; the
  KEY_FIELD_NAME and KEY_MESSAGE are referenced directly in
  JaxrsValidationException, and which are the property names for
  the JSON-serialization of ErrorMessage instances

Misc:
* Add javadoc comment for CODE constants in other
  JaxrsException subclasses

Fixes #348