### PR TITLE
Update JaxrsExceptionMapper#toJaxrsException with early return

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsExceptionMapper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/JaxrsExceptionMapper.java
@@ -148,6 +148,7 @@ public class JaxrsExceptionMapper implements ExceptionMapper<JaxrsException> {
         if (KiwiMaps.isNullOrEmpty(entity) || !entity.containsKey(KEY_ERRORS)) {
             var ex = new JaxrsException((String) null, status);
             ex.setOtherData(entity);
+            return ex;
         }
 
         try {

--- a/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsExceptionMapperTest.java
@@ -194,7 +194,9 @@ class JaxrsExceptionMapperTest {
             assertThat(ex).isNotNull();
             assertThat(ex.getStatusCode()).isEqualTo(statusCode);
 
-            assertThat(ex.getErrors()).isEmpty();
+            assertThat(ex.getErrors()).containsExactly(
+                    new ErrorMessage(ErrorMessage.DEFAULT_CODE, ErrorMessage.DEFAULT_MSG)
+            );
             assertThat(ex.getOtherData()).containsOnly(
                     entry("key1", "value1"),
                     entry("key2", "value2")
@@ -294,7 +296,21 @@ class JaxrsExceptionMapperTest {
     class ToJaxrsExceptionFromMap {
 
         @Test
-        void whenResponseContainsMapEntity_WithErrorsValueHavingNullsAndErrorMessages() {
+        void whenMapIsEmpty() {
+            var statusCode = 400;
+            var ex = JaxrsExceptionMapper.toJaxrsException(statusCode, Map.of());
+
+            assertThat(ex).isNotNull();
+            assertThat(ex.getStatusCode()).isEqualTo(statusCode);
+
+            assertThat(ex.getErrors()).containsExactly(
+                    new ErrorMessage(statusCode, ErrorMessage.DEFAULT_MSG)
+            );
+            assertThat(ex.getOtherData()).isEmpty();
+        }
+
+        @Test
+        void whenMapHasNullsAndErrorMessages() {
             var statusCode = 400;
             var error1 = new ErrorMessage(400, "You submitted invalid data");
             var error2 = new ErrorMessage("42", 401, "You are not authorized to change this data", "emailAddress");


### PR DESCRIPTION
* Missed the early return in the case when the map entity is empty
  or null or doesn't contain an "errors" key

Fixes #351 (again)