### PR TITLE
Rename internal test helper class JaxRsTestHelper to JaxrsTestHelper

### DIFF
--- a/src/test/java/org/kiwiproject/jaxrs/JaxrsTestHelper.java
+++ b/src/test/java/org/kiwiproject/jaxrs/JaxrsTestHelper.java
@@ -11,8 +11,15 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This is a subset of the methods in the class of the same name in the
+ * <a href="https://github.com/kiwiproject/kiwi-test">kiwi-test</a> library.
+ * <p>
+ * We can't use kiwi-test here otherwise we would create a cyclic dependency since kiwi-test
+ * depends on kiwi.
+ */
 @UtilityClass
-public class JaxRsTestHelper {
+public class JaxrsTestHelper {
 
     public static void assertResponseStatusCode(Response response, Response.Status expectedStatusCode) {
         assertResponseStatusCode(response, expectedStatusCode.getStatusCode());

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
@@ -3,12 +3,12 @@ package org.kiwiproject.jaxrs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertCreatedResponseWithLocation;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertCustomHeaderFirstValue;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertOkResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntity;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseType;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertStatusAndResponseEntity;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertCreatedResponseWithLocation;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertCustomHeaderFirstValue;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertOkResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntity;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertStatusAndResponseEntity;
 
 import lombok.Value;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiStandardResponsesIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiStandardResponsesIntegrationTest.java
@@ -2,14 +2,14 @@ package org.kiwiproject.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertAcceptedResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertBadRequestResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertCreatedResponseWithLocation;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertJsonResponseType;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertNoContentResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertNotFoundResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertOkResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertUnauthorizedFoundResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertAcceptedResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertBadRequestResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertCreatedResponseWithLocation;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertJsonResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertNoContentResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertOkResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertUnauthorizedFoundResponse;
 
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiStandardResponsesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiStandardResponsesTest.java
@@ -1,14 +1,14 @@
 package org.kiwiproject.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertAcceptedResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertCreatedResponseWithLocation;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertJsonResponseType;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertNoContentResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertNotFoundResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertOkResponse;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntity;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntityHasOneErrorMessage;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertAcceptedResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertCreatedResponseWithLocation;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertJsonResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertNoContentResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertOkResponse;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntity;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntityHasOneErrorMessage;
 
 import lombok.Value;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/org/kiwiproject/jaxrs/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/ConstraintViolationExceptionMapperTest.java
@@ -1,9 +1,9 @@
 package org.kiwiproject.jaxrs.exception;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertHasMapEntity;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseStatusCode;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertHasMapEntity;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseStatusCode;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseType;
 
 import lombok.Builder;
 import lombok.Value;

--- a/src/test/java/org/kiwiproject/jaxrs/exception/IllegalArgumentExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/IllegalArgumentExceptionMapperTest.java
@@ -1,8 +1,8 @@
 package org.kiwiproject.jaxrs.exception;
 
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntityHasOneErrorMessage;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseStatusCode;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntityHasOneErrorMessage;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseStatusCode;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/org/kiwiproject/jaxrs/exception/IllegalStateExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/IllegalStateExceptionMapperTest.java
@@ -1,8 +1,8 @@
 package org.kiwiproject.jaxrs.exception;
 
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntityHasOneErrorMessage;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseStatusCode;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntityHasOneErrorMessage;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseStatusCode;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/JaxrsExceptionMapperTest.java
@@ -3,10 +3,10 @@ package org.kiwiproject.jaxrs.exception;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertHasMapEntity;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntityHasOneErrorMessage;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseStatusCode;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertHasMapEntity;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntityHasOneErrorMessage;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseStatusCode;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/kiwiproject/jaxrs/exception/WebApplicationExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/WebApplicationExceptionMapperTest.java
@@ -1,8 +1,8 @@
 package org.kiwiproject.jaxrs.exception;
 
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseEntityHasOneErrorMessage;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseStatusCode;
-import static org.kiwiproject.jaxrs.JaxRsTestHelper.assertResponseType;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseEntityHasOneErrorMessage;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseStatusCode;
+import static org.kiwiproject.jaxrs.JaxrsTestHelper.assertResponseType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
Doing this for consistency with all other JaxrsXxx classes.