### PR TITLE
Fix several tests whose name did not match what they tested

### DIFF
--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -74,7 +74,7 @@ class StripedLockTest {
 
         var completableFutures = List.of(
                 Async.doAsync(() -> lock.runWithWriteLock(recorder1.id, () -> recorder1.record(task))),
-                Async.doAsync(() -> lock.runWithReadLock(recorder2.id, () -> recorder2.record(task)))
+                Async.doAsync(() -> lock.runWithWriteLock(recorder2.id, () -> recorder2.record(task)))
         );
 
         waitForAll(completableFutures);
@@ -91,7 +91,7 @@ class StripedLockTest {
 
         var completableFutures = List.of(
                 Async.doAsync(() -> lock.runWithWriteLock(recorder1.id, () -> recorder1.record(task))),
-                Async.doAsync(() -> lock.runWithReadLock(recorder2.id, () -> recorder2.record(task)))
+                Async.doAsync(() -> lock.runWithWriteLock(recorder2.id, () -> recorder2.record(task)))
         );
 
         waitForAll(completableFutures);


### PR DESCRIPTION
Fix testRunWithLock_WhenBlocking_ForWriteAndWriteLocks which was
testing a write and READ lock when it should have been two WRITE locks.

Fix testRunWithLock_WhenNonBlocking_ForWriteAndWriteLocks which was
testing a write and READ lock when it should have been two WRITE locks.

Sonar was flagging these as duplicate tests saying to
"Replace these 3 tests with a single Parameterized one" (java:S5976)
however it turns out that the tests were actually not testing what
they said they were.