### PR TITLE
Auto-install H2 and Postgres JDBI plugins in Jdbi3Builders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
         <jsr305.version>3.0.2</jsr305.version>
 
         <!-- Versions for test dependencies -->
+        <h2.version>1.4.200</h2.version>
+        <jdbi3.version>3.14.4</jdbi3.version>
         <jersey-test-framework-core.version>2.31</jersey-test-framework-core.version>
 
     </properties>
@@ -533,6 +535,20 @@
                     <artifactId>jakarta.servlet-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-postgres</artifactId>
+            <version>${jdbi3.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/kiwiproject/dropwizard/jdbi3/DatabaseType.java
+++ b/src/main/java/org/kiwiproject/dropwizard/jdbi3/DatabaseType.java
@@ -1,0 +1,57 @@
+package org.kiwiproject.dropwizard.jdbi3;
+
+import lombok.Getter;
+import org.jdbi.v3.core.h2.H2DatabasePlugin;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+import java.util.Optional;
+
+/**
+ * This enum allows you to instantiate a {@link JdbiPlugin} for certain databases based on the JDBC database URL.
+ * <p>
+ * Currently supports only Postgres and H2.
+ */
+enum DatabaseType {
+
+    H2(H2DatabasePlugin.class.getName()),
+
+    POSTGRES("org.jdbi.v3.postgres.PostgresPlugin");
+
+    @Getter
+    private final String pluginClassName;
+
+    DatabaseType(String pluginClassName) {
+        this.pluginClassName = pluginClassName;
+    }
+
+    /**
+     * Given a JDBC database URL, attempt to find and instantiate a plugin.
+     * <p>
+     * Currently supports only H2 and Postgres.
+     *
+     * @param databaseUrl the JDBC database URL
+     * @return an Optional with a plugin instance or an empty Optional
+     */
+    static Optional<JdbiPlugin> pluginFromDatabaseUrl(String databaseUrl) {
+        return databaseTypeFromDatabaseUrl(databaseUrl)
+                .flatMap(databaseType -> Jdbi3Helpers.getPluginInstance(databaseType.getPluginClassName()));
+    }
+
+    /**
+     * Determine the database type from the given JDBC database URL.
+     * <p>
+     * Currently supports only H2 and Postgres.
+     *
+     * @param databaseUrl the JDBC database URL
+     * @return an Optional containing the database type if found, otherwise an empty Optional
+     */
+    static Optional<DatabaseType> databaseTypeFromDatabaseUrl(String databaseUrl) {
+        if (databaseUrl.startsWith("jdbc:postgresql:")) {
+            return Optional.of(POSTGRES);
+        } else if (databaseUrl.startsWith("jdbc:h2:")) {
+            return Optional.of(H2);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/kiwiproject/dropwizard/jdbi3/Jdbi3Helpers.java
+++ b/src/main/java/org/kiwiproject/dropwizard/jdbi3/Jdbi3Helpers.java
@@ -1,0 +1,51 @@
+package org.kiwiproject.dropwizard.jdbi3;
+
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+import java.util.Optional;
+
+/**
+ * Utilities for JDBI 3.
+ */
+@UtilityClass
+@Slf4j
+class Jdbi3Helpers {
+
+    /**
+     * Get a plugin instance for the given class name.
+     *
+     * @param pluginClassName the plugin class name
+     * @return an Optional containing a plugin instance, or empty Optional if plugin class not available or an error
+     * occurs. If an error occurs, that fact is logged at WARN level.
+     */
+    static Optional<JdbiPlugin> getPluginInstance(String pluginClassName) {
+        var result = isPluginAvailable(pluginClassName);
+
+        if (isTrue(result.getLeft())) {
+            try {
+                var pluginClass = result.getRight();
+                var pluginInstance = (JdbiPlugin) pluginClass.getDeclaredConstructor().newInstance();
+                return Optional.of(pluginInstance);
+            } catch (Exception e) {
+                LOG.warn("Error instantiating plugin for class: {}", pluginClassName);
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static Pair<Boolean, Class<?>> isPluginAvailable(String pluginClassName) {
+        try {
+            var pluginClass = Class.forName(pluginClassName);
+            return Pair.of(true, pluginClass);
+        } catch (ClassNotFoundException e) {
+            return Pair.of(false, null);
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/jdbi3/DatabaseTypeTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/jdbi3/DatabaseTypeTest.java
@@ -1,0 +1,34 @@
+package org.kiwiproject.dropwizard.jdbi3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jdbi.v3.core.h2.H2DatabasePlugin;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("DatabaseType")
+class DatabaseTypeTest {
+
+    @Nested
+    class DatabaseTypeEnum {
+
+        @Test
+        void shouldGetH2PluginInstance() {
+            var pluginOptional = DatabaseType.pluginFromDatabaseUrl("jdbc:h2:/tmp/h2-test-db-12345/testdb");
+            assertThat(pluginOptional).containsInstanceOf(H2DatabasePlugin.class);
+        }
+
+        @Test
+        void shouldGetPostgresPluginInstance() {
+            var pluginOptional = DatabaseType.pluginFromDatabaseUrl("jdbc:postgresql://localhost:5432/testdb");
+            assertThat(pluginOptional).containsInstanceOf(PostgresPlugin.class);
+        }
+
+        @Test
+        void shouldReturnEmptyOptionalForUnsupportedDatabase() {
+            assertThat(DatabaseType.pluginFromDatabaseUrl("jdbc:mysql://localhost:33060/sakila")).isEmpty();
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/jdbi3/Jdbi3HelpersTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/jdbi3/Jdbi3HelpersTest.java
@@ -1,0 +1,45 @@
+package org.kiwiproject.dropwizard.jdbi3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jdbi.v3.core.h2.H2DatabasePlugin;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Jdbi3Helpers")
+class Jdbi3HelpersTest {
+
+    @Nested
+    class GetPluginInstance {
+
+        @Test
+        void shouldReturnOptionalContainingPlugin_WhenClassIsAvailable() {
+            assertThat(Jdbi3Helpers.getPluginInstance(PostgresPlugin.class.getName()))
+                    .containsInstanceOf(PostgresPlugin.class);
+
+            assertThat(Jdbi3Helpers.getPluginInstance(H2DatabasePlugin.class.getName()))
+                    .containsInstanceOf(H2DatabasePlugin.class);
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenClassIsNotAvailable() {
+            assertThat(Jdbi3Helpers.getPluginInstance("org.jdbi.v3.mysql.MysqlPlugin"))
+                    .isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenErrorInstantiatingPluginClass() {
+            assertThat(Jdbi3Helpers.getPluginInstance(MisbehavingDatabasePlugin.class.getName()))
+                    .isEmpty();
+        }
+    }
+
+    public static class MisbehavingDatabasePlugin extends JdbiPlugin.Singleton {
+        public MisbehavingDatabasePlugin() {
+            throw new IllegalStateException("I cannot be created");
+        }
+    }
+}


### PR DESCRIPTION
* Add DatabaseType enum (package-private for now)
* Add Jdbi3Helpers (package-private for now)
* Add better documentation to top-level of Jdbi3Builders
* Renamed a few local vars and parameters in Jdbi3Builders from
  dataSource to managedDataSource for clarity
* Update Jdbi3Builders to install the H2 or Postgres JDBI plugin
  automatically if the database is detected as H2 or Postgres,
  respectively, from the JDBC database URL.
* Significantly de-mock the Jdbi3BuildersTest; the only remaining
  mock is the Dropwizard Environment. Use an in-memory H2 database to
  verify the real code, and that we can actually get a connection from
  the built Jdbi instance.

Fixes #382