### PR TITLE
Add new Hibernate UserType for JSONB columns

### DIFF
--- a/src/main/java/org/kiwiproject/hibernate/usertype/JSONBUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/JSONBUserType.java
@@ -1,0 +1,94 @@
+package org.kiwiproject.hibernate.usertype;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiStrings.format;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.type.SerializationException;
+import org.hibernate.usertype.UserType;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Objects;
+
+/**
+ * A Hibernate user-defined type that maps to/from Postgres {@code jsonb} columns.
+ */
+@SuppressWarnings("java:S1130")
+public class JSONBUserType implements UserType {
+
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{Types.JAVA_OBJECT};
+    }
+
+    // Suppress IntelliJ and Sonar "Raw types should not be used"; the UserType interface defines it as the raw type
+    @SuppressWarnings({"java:S3740", "rawtypes"})
+    @Override
+    public Class returnedClass() {
+        return Object.class;
+    }
+
+    @Override
+    public boolean equals(Object ol, Object o2) throws HibernateException {
+        return Objects.equals(ol, o2);
+    }
+
+    @Override
+    public int hashCode(Object obj) throws HibernateException {
+        checkArgumentNotNull(obj, "cannot compute hashCode on null object");
+        return obj.hashCode();
+    }
+
+    @Override
+    public Object nullSafeGet(ResultSet rs, String[] names, SharedSessionContractImplementor session, Object owner)
+            throws HibernateException, SQLException {
+
+        var columnName = names[0]; // not a column-column type, so get first (and only) one
+        return rs.getString(columnName);
+    }
+
+    @Override
+    public void nullSafeSet(PreparedStatement st, Object value, int index, SharedSessionContractImplementor session)
+            throws HibernateException, SQLException {
+
+        if (value == null) {
+            st.setNull(index, Types.OTHER);
+        } else {
+            st.setObject(index, value, Types.OTHER);
+        }
+    }
+
+    @Override
+    public Object deepCopy(Object value) throws HibernateException {
+        return value;
+    }
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
+
+    @Override
+    public Serializable disassemble(Object value) throws HibernateException {
+        var deepCopy = deepCopy(value);
+        if (deepCopy instanceof Serializable) {
+            return (Serializable) deepCopy;
+        }
+        throw new SerializationException(format("deepCopy of %s is not serializable", value), null);
+    }
+
+    @Override
+    public Object assemble(Serializable cached, Object owner) throws HibernateException {
+        return deepCopy(cached);
+    }
+
+    @Override
+    public Object replace(Object original, Object target, Object owner) throws HibernateException {
+        return deepCopy(original);
+    }
+}

--- a/src/test/java/org/kiwiproject/hibernate/usertype/ArrayUserTypesUnitTest.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/ArrayUserTypesUnitTest.java
@@ -6,12 +6,14 @@ import lombok.Value;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.Serializable;
 
+@DisplayName("ArrayUserTypes (Unit)")
 class ArrayUserTypesUnitTest {
 
     private AbstractArrayUserType arrayUserType;

--- a/src/test/java/org/kiwiproject/hibernate/usertype/JSONBUserTypeIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/JSONBUserTypeIntegrationTest.java
@@ -1,0 +1,85 @@
+package org.kiwiproject.hibernate.usertype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.hibernate.usertype.UserTypeTestHelpers.buildHibernateConfiguration;
+import static org.kiwiproject.hibernate.usertype.UserTypeTestHelpers.preparedDbExtensionFor;
+
+import io.zonky.test.db.postgres.junit5.PreparedDbExtension;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.kiwiproject.internal.Fixtures;
+import org.kiwiproject.json.JsonHelper;
+
+import java.io.Serializable;
+
+@DisplayName("JSONBUserType (Integration)")
+class JSONBUserTypeIntegrationTest {
+
+    @RegisterExtension
+    static final PreparedDbExtension POSTGRES =
+            preparedDbExtensionFor("hibernate/UserTypeTests/jsonb-usertype-migration.xml");
+
+    private static SessionFactory sessionFactory;
+
+    private Session session;
+
+    @BeforeAll
+    static void beforeAll() {
+        var config = buildHibernateConfiguration(POSTGRES.getConnectionInfo(), SampleJsonbEntity.class);
+        sessionFactory = config.buildSessionFactory();
+    }
+
+    @BeforeEach
+    void setUp() {
+        session = sessionFactory.openSession();
+    }
+
+    @AfterEach
+    void tearDown() {
+        session.close();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        sessionFactory.close();
+    }
+
+    @Test
+    void shouldMapJsonbColumns() {
+        var entity = new SampleJsonbEntity();
+        entity.setTextCol("some text");
+        var json = Fixtures.fixture("hibernate/UserTypeTests/sample.json");
+        entity.setJsonbCol(json);
+
+        var id = saveAndClearSession(entity);
+
+        var foundEntity = session.get(SampleJsonbEntity.class, id);
+        var foundJson = foundEntity.getJsonbCol();
+        assertThat(foundJson).isNotBlank();
+        assertThat(JsonHelper.newDropwizardJsonHelper().jsonEquals(foundJson, json))
+                .describedAs("JSON should be equal (ignoring formatting differences)")
+                .isTrue();
+    }
+
+    @Test
+    void shouldPermitNullValues() {
+        var entity = new SampleJsonbEntity();
+        entity.setTextCol("some text");
+
+        var id = saveAndClearSession(entity);
+
+        var foundEntity = session.get(SampleJsonbEntity.class, id);
+        assertThat(foundEntity.getJsonbCol()).isNull();
+    }
+
+    private Serializable saveAndClearSession(SampleJsonbEntity entity) {
+        return UserTypeTestHelpers.saveAndClearSession(session, entity);
+    }
+}

--- a/src/test/java/org/kiwiproject/hibernate/usertype/JSONBUserTypeUnitTest.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/JSONBUserTypeUnitTest.java
@@ -1,0 +1,114 @@
+package org.kiwiproject.hibernate.usertype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import lombok.Value;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.hibernate.type.SerializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.Serializable;
+
+@DisplayName("JSONBUserType (Unit)")
+class JSONBUserTypeUnitTest {
+
+    private JSONBUserType jsonbUserType;
+
+    @BeforeEach
+    void setUp() {
+        jsonbUserType = new JSONBUserType();
+    }
+
+    @Test
+    void shouldReturnObjectAsExpectedClass() {
+        assertThat(jsonbUserType.returnedClass()).isEqualTo(Object.class);
+    }
+
+    @Nested
+    @ExtendWith(SoftAssertionsExtension.class)
+    class EqualsAndHashCode {
+
+        @Test
+        void shouldCompareUsingObjectsEquals(SoftAssertions softly) {
+            var obj1 = new Bar("an object", 42);
+            var obj2 = new Bar("an object", 42);
+            var obj3 = new Bar("another object", 84);
+
+            softly.assertThat(jsonbUserType.equals(obj1, obj1)).isTrue();
+            softly.assertThat(jsonbUserType.equals(obj1, obj2)).isTrue();
+            softly.assertThat(jsonbUserType.equals(obj1, obj2)).isTrue();
+            softly.assertThat(jsonbUserType.equals(obj1, obj3)).isFalse();
+            softly.assertThat(jsonbUserType.equals(obj2, obj3)).isFalse();
+        }
+
+        @Test
+        void shouldThrowIllegalArgumentException_GivenNullObject() {
+            //noinspection ResultOfMethodCallIgnored
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> jsonbUserType.hashCode(null));
+        }
+
+        @Test
+        void shouldReturnObjectHashCode_GivenNonNullObject() {
+            var obj = new Bar("object", 42);
+            assertThat(jsonbUserType.hashCode(obj)).hasSameHashCodeAs(obj);
+        }
+
+        @Value
+        class Bar {
+            String name;
+            int number;
+        }
+    }
+
+    @Nested
+    class Disassemble {
+
+        @Test
+        void shouldReturnSameInstance_WhenSerializable() {
+            var entity = new SerializableObject();
+            assertThat(jsonbUserType.disassemble(entity)).isSameAs(entity);
+        }
+
+        @Test
+        void shouldThrowSerializationException_GivenNonSerializableObject() {
+            var entity = new NotSerializableObject();
+            assertThatThrownBy(() -> jsonbUserType.disassemble(entity))
+                    .isExactlyInstanceOf(SerializationException.class);
+        }
+    }
+
+    @Nested
+    class Assemble {
+
+        @Test
+        void shouldReturnSameInstance() {
+            var cached = new SerializableObject();
+            var owner = new Object();
+            assertThat(jsonbUserType.assemble(cached, owner)).isSameAs(cached);
+        }
+    }
+
+    @Nested
+    class Replace {
+
+        @Test
+        void shouldReturnSameInstance() {
+            var original = new Object();
+            assertThat(jsonbUserType.replace(original, null, null)).isSameAs(original);
+        }
+    }
+
+    private static class SerializableObject implements Serializable {
+    }
+
+    private static class NotSerializableObject {
+    }
+}

--- a/src/test/java/org/kiwiproject/hibernate/usertype/SampleJsonbEntity.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/SampleJsonbEntity.java
@@ -1,0 +1,34 @@
+package org.kiwiproject.hibernate.usertype;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "sample_entity")
+@TypeDef(name = "jsonb", typeClass = JSONBUserType.class)
+@Getter
+@Setter
+@SuppressWarnings("JpaDataSourceORMInspection")
+class SampleJsonbEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "text_col")
+    private String textCol;
+
+    @Type(type = "jsonb")
+    @Column(name = "jsonb_col")
+    private String jsonbCol;
+}

--- a/src/test/java/org/kiwiproject/hibernate/usertype/UserTypeTestHelpers.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/UserTypeTestHelpers.java
@@ -1,0 +1,52 @@
+package org.kiwiproject.hibernate.usertype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.base.KiwiStrings.f;
+
+import io.zonky.test.db.postgres.embedded.ConnectionInfo;
+import io.zonky.test.db.postgres.embedded.LiquibasePreparer;
+import io.zonky.test.db.postgres.junit5.EmbeddedPostgresExtension;
+import io.zonky.test.db.postgres.junit5.PreparedDbExtension;
+import lombok.experimental.UtilityClass;
+import org.hibernate.Session;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.dialect.PostgreSQL95Dialect;
+import org.postgresql.Driver;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+@UtilityClass
+class UserTypeTestHelpers {
+
+    static PreparedDbExtension preparedDbExtensionFor(String classpathLocation) {
+        var liquibasePreparer = LiquibasePreparer.forClasspathLocation(classpathLocation);
+        return EmbeddedPostgresExtension.preparedDatabase(liquibasePreparer);
+    }
+
+    static Configuration buildHibernateConfiguration(ConnectionInfo connectionInfo, Class<?>... annotatedClasses) {
+        var url = f("jdbc:postgresql://localhost:{}/{}", connectionInfo.getPort(), connectionInfo.getDbName());
+
+        var config = new Configuration();
+        config.setProperty("hibernate.connection.driver_class", Driver.class.getName());
+        config.setProperty("hibernate.connection.url", url);
+        config.setProperty("hibernate.connection.username", connectionInfo.getUser());
+        config.setProperty("hibernate.connection.password", "");
+        config.setProperty("hibernate.dialect", PostgreSQL95Dialect.class.getName());
+
+        Arrays.stream(annotatedClasses).forEach(config::addAnnotatedClass);
+
+        return config;
+    }
+
+    static Serializable saveAndClearSession(Session session, Object entity) {
+        var id = session.save(entity);
+        assertThat(id)
+                .describedAs("Entity should have been flushed to database and now have an assigned ID")
+                .isNotNull();
+
+        session.clear();
+
+        return id;
+    }
+}

--- a/src/test/resources/hibernate/UserTypeTests/jsonb-usertype-migration.xml
+++ b/src/test/resources/hibernate/UserTypeTests/jsonb-usertype-migration.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="0001_create_sample_entity" author="bob">
+        <createTable tableName="sample_entity">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="text_col" type="text"/>
+            <column name="jsonb_col" type="jsonb"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/hibernate/UserTypeTests/sample.json
+++ b/src/test/resources/hibernate/UserTypeTests/sample.json
@@ -1,0 +1,9 @@
+{
+  "name": "Alice",
+  "age": 42,
+  "country": "France",
+  "languages": [
+    "French",
+    "English"
+  ]
+}


### PR DESCRIPTION
* Add JSONBUserType
* Add unit test: JSONBUserTypeUnitTest
* Add integration test: JSONBUserTypeIntegrationTest
* Extract common Hibernate and Embedded Postgres setup code into
  package-private UserTypeTestHelpers utility class
* Add DisplayName annotation to both ArrayUserType tests
* Add SampleJsonbEntity, a Hibernate entity class for tests
* Add jsonb-usertype-migration.xml, a Liquibase migration for tests
* Add sample.json, a sample JSON file for tests

Fixes #392