### PR TITLE
Better Map input handling in BeanConverter#convert

### DIFF
--- a/src/main/java/org/kiwiproject/beans/BeanConverter.java
+++ b/src/main/java/org/kiwiproject/beans/BeanConverter.java
@@ -45,7 +45,7 @@ public class BeanConverter<T> {
      */
     @Getter
     @Setter
-    private Set<String> exclusionList = Sets.newHashSet("class", "new");
+    private Set<String> exclusions = Sets.newHashSet("class", "new");
 
     /**
      * Allows for a failed conversion to throw an exception if {@code true}; otherwise just logs a failure if {@code false}
@@ -105,7 +105,7 @@ public class BeanConverter<T> {
 
         // remove exclusions
         return propertyNames.stream()
-                .filter(not(prop -> exclusionList.contains(prop)))
+                .filter(not(prop -> exclusions.contains(prop)))
                 .collect(toSet());
     }
 

--- a/src/main/java/org/kiwiproject/beans/BeanConverter.java
+++ b/src/main/java/org/kiwiproject/beans/BeanConverter.java
@@ -81,7 +81,7 @@ public class BeanConverter<T> {
         var inputWrapper = new BeanWrapperImpl(input);
         var targetWrapper = new BeanWrapperImpl(target);
 
-        var propertyNames = getPropertyList(input, inputWrapper);
+        var propertyNames = getPropertySet(input, inputWrapper);
 
         // This can not be a foreach because if failOnError is true, the exceptions need to bubble.
         for (String propName : propertyNames) {
@@ -100,19 +100,23 @@ public class BeanConverter<T> {
         return target;
     }
 
-    @SuppressWarnings("unchecked")
-    protected Set<String> getPropertyList(T input, BeanWrapper inputWrapper) {
-        var propertyNames = Stream.of(inputWrapper.getPropertyDescriptors())
-                .map(PropertyDescriptor::getName)
-                .collect(toSet());
-
-        if (input instanceof Map) {
-            propertyNames.addAll(((Map<String, ?>) input).keySet());
-        }
+    protected Set<String> getPropertySet(T input, BeanWrapper inputWrapper) {
+        var propertyNames = getPropertyNamesAsSet(input, inputWrapper);
 
         // remove exclusions
         return propertyNames.stream()
                 .filter(not(prop -> exclusionList.contains(prop)))
+                .collect(toSet());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> Set<String> getPropertyNamesAsSet(T input, BeanWrapper inputWrapper) {
+        if (input instanceof Map) {
+            return ((Map) input).keySet();
+        }
+
+        return Stream.of(inputWrapper.getPropertyDescriptors())
+                .map(PropertyDescriptor::getName)
                 .collect(toSet());
     }
 

--- a/src/test/java/org/kiwiproject/beans/BeanConverterTest.java
+++ b/src/test/java/org/kiwiproject/beans/BeanConverterTest.java
@@ -54,7 +54,7 @@ class BeanConverterTest {
         );
 
         var converter = new BeanConverter<Map<String, Object>>();
-        converter.setExclusionList(Set.of("numberField"));
+        converter.setExclusions(Set.of("numberField"));
 
         var testData = converter.convert(input, new TestData());
 
@@ -81,9 +81,9 @@ class BeanConverterTest {
     @Test
     void testBasicConvertTypeToMap_WithExclusions() {
         var converter = new BeanConverter<TestData>();
-        converter.setExclusionList(Set.of("numberField", "mapField"));
+        converter.setExclusions(Set.of("numberField", "mapField"));
 
-        assertThat(converter.getExclusionList()).contains("numberField", "mapField");
+        assertThat(converter.getExclusions()).contains("numberField", "mapField");
 
         var output = converter.convert(constructTestData(), KiwiMaps.newHashMap());
 

--- a/src/test/java/org/kiwiproject/beans/BeanConverterTest.java
+++ b/src/test/java/org/kiwiproject/beans/BeanConverterTest.java
@@ -46,6 +46,26 @@ class BeanConverterTest {
     }
 
     @Test
+    void testBasicConvertMapToTargetType_WithExclusions() {
+        var input = Map.of(
+                "numberField", 1,
+                "stringField", "foo",
+                "mapField", Map.of("innerFoo", "innerBar")
+        );
+
+        var converter = new BeanConverter<Map<String, Object>>();
+        converter.setExclusionList(Set.of("numberField"));
+
+        var testData = converter.convert(input, new TestData());
+
+        assertThat(testData.getNumberField())
+                .describedAs("numberField should have been excluded!")
+                .isNull();
+        assertThat(testData.getStringField()).isEqualTo("foo");
+        assertThat(testData.getMapField()).contains(entry("innerFoo", "innerBar"));
+    }
+
+    @Test
     void testBasicConvertTypeToMap() {
         var converter = new BeanConverter<TestData>();
 
@@ -158,6 +178,7 @@ class BeanConverterTest {
             // The following MUST declare a variable else the exception is not thrown.
             // It does not, however, matter whether it is declared with an explicit type.
             assertThatThrownBy(() -> {
+                //noinspection unused
                 var aDouble = badResultTypeMapper.apply(testData);
             }).describedAs("should throw when try to assign result whether explicit type or using LVTI (var)")
                     .isExactlyInstanceOf(ClassCastException.class);


### PR DESCRIPTION
* Rename protected getPropertyList to getPropertySet (since it returns
  a Set<String> and saying we return a List is just a bit confusing...)
* Change BeanConverter#getPropertySet so that, when the input is a
  Map, we assume the properties are simply the keys in the Map

Fixes #403