### PR TITLE
Add more precondition variants

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiPreconditions.java
+++ b/src/main/java/org/kiwiproject/base/KiwiPreconditions.java
@@ -336,7 +336,32 @@ public class KiwiPreconditions {
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositive(int value) {
-        checkState(value > 0, "value must be a positive number");
+        checkPositive(value, "value must be a positive number");
+    }
+
+    /**
+     * Ensures int {@code value} is a positive number (greater than zero).
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositive(int value, String errorMessage) {
+        checkState(value > 0, errorMessage);
+    }
+
+    /**
+     * Ensures int {@code value} is a positive number (greater than zero).
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositive(int value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkState(value > 0, errorMessageTemplate, errorMessageArgs);
     }
 
     /**
@@ -347,7 +372,32 @@ public class KiwiPreconditions {
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositive(long value) {
-        checkState(value > 0, "value must be a positive number");
+        checkPositive(value, "value must be a positive number");
+    }
+
+    /**
+     * Ensures long {@code value} is a positive number (greater than zero).
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositive(long value, String errorMessage) {
+        checkState(value > 0, errorMessage);
+    }
+
+    /**
+     * Ensures long {@code value} is a positive number (greater than zero).
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositive(long value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkState(value > 0, errorMessageTemplate, errorMessageArgs);
     }
 
     /**
@@ -358,7 +408,32 @@ public class KiwiPreconditions {
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositiveOrZero(int value) {
-        checkState(value >= 0, "value must be positive or zero");
+        checkPositiveOrZero(value, "value must be positive or zero");
+    }
+
+    /**
+     * Ensures int {@code value} is a positive number (greater than zero) or zero.
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositiveOrZero(int value, String errorMessage) {
+        checkState(value >= 0, errorMessage);
+    }
+
+    /**
+     * Ensures int {@code value} is a positive number (greater than zero) or zero.
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositiveOrZero(int value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkState(value >= 0, errorMessageTemplate, errorMessageArgs);
     }
 
     /**
@@ -369,7 +444,32 @@ public class KiwiPreconditions {
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositiveOrZero(long value) {
-        checkState(value >= 0, "value must be positive or zero");
+        checkPositiveOrZero(value, "value must be positive or zero");
+    }
+
+    /**
+     * Ensures long {@code value} is a positive number (greater than zero) or zero.
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositiveOrZero(long value, String errorMessage) {
+        checkState(value >= 0, errorMessage);
+    }
+
+    /**
+     * Ensures long {@code value} is a positive number (greater than zero) or zero.
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static void checkPositiveOrZero(long value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkState(value >= 0, errorMessageTemplate, errorMessageArgs);
     }
 
     /**
@@ -381,6 +481,33 @@ public class KiwiPreconditions {
      */
     public static int requirePositive(int value) {
         checkPositive(value);
+        return value;
+    }
+
+    /**
+     * Returns the int {@code value} if it is a positive number (greater than zero), throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static int requirePositive(int value, String errorMessage) {
+        checkPositive(value, errorMessage);
+        return value;
+    }
+
+    /**
+     * Returns the int {@code value} if it is a positive number (greater than zero), throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static int requirePositive(int value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkPositive(value, errorMessageTemplate, errorMessageArgs);
         return value;
     }
 
@@ -397,6 +524,33 @@ public class KiwiPreconditions {
     }
 
     /**
+     * Returns the long {@code value} if it is a positive number (greater than zero), throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static long requirePositive(long value, String errorMessage) {
+        checkPositive(value, errorMessage);
+        return value;
+    }
+
+    /**
+     * Returns the long {@code value} if it is a positive number (greater than zero), throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static long requirePositive(long value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkPositive(value, errorMessageTemplate, errorMessageArgs);
+        return value;
+    }
+
+    /**
      * Returns the int value if it is positive or zero, throwing an {@link IllegalStateException} if not positive or zero.
      *
      * @param value the value to check for positivity or zero
@@ -405,6 +559,33 @@ public class KiwiPreconditions {
      */
     public static int requirePositiveOrZero(int value) {
         checkPositiveOrZero(value);
+        return value;
+    }
+
+    /**
+     * Returns the int {@code value} if it is a positive number (greater than zero) or zero, throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static int requirePositiveOrZero(int value, String errorMessage) {
+        checkPositiveOrZero(value, errorMessage);
+        return value;
+    }
+
+    /**
+     * Returns the int {@code value} if it is a positive number (greater than zero) or zero, throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static int requirePositiveOrZero(int value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkPositiveOrZero(value, errorMessageTemplate, errorMessageArgs);
         return value;
     }
 
@@ -421,13 +602,63 @@ public class KiwiPreconditions {
     }
 
     /**
+     * Returns the long {@code value} if it is a positive number (greater than zero) or zero, throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value         the value to check for positivity
+     * @param errorMessage  the error message to put in the exception if not positive
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static long requirePositiveOrZero(long value, String errorMessage) {
+        checkPositiveOrZero(value, errorMessage);
+        return value;
+    }
+
+    /**
+     * Returns the long {@code value} if it is a positive number (greater than zero) or zero, throwing an {@link IllegalStateException} if not positive.
+     *
+     * @param value                 the value to check for positivity
+     * @param errorMessageTemplate  the error message template to use in the exception if not positive
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
+     * @see Preconditions#checkState(boolean, Object)
+     */
+    public static long requirePositiveOrZero(long value, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkPositiveOrZero(value, errorMessageTemplate, errorMessageArgs);
+        return value;
+    }
+
+    /**
      * Ensures given port is valid, between 0 and {@link #MAX_PORT_NUMBER}.
      *
      * @param port the port to check for validity
      * @throws IllegalStateException if port is not valid
      */
     public static void checkValidPort(int port) {
-        checkState(port >= 0 && port <= MAX_PORT_NUMBER, "port must be between 0 and %s", MAX_PORT_NUMBER);
+        checkValidPort(port, "port must be between 0 and %s", MAX_PORT_NUMBER);
+    }
+
+    /**
+     * Ensures given port is valid, between 0 and {@link #MAX_PORT_NUMBER}.
+     *
+     * @param port          the port to check for validity
+     * @param errorMessage  the error message to put in the exception if the port is not valid
+     * @throws IllegalStateException if port is not valid
+     */
+    public static void checkValidPort(int port, String errorMessage) {
+        checkState(port >= 0 && port <= MAX_PORT_NUMBER, errorMessage);
+    }
+
+    /**
+     * Ensures given port is valid, between 0 and {@link #MAX_PORT_NUMBER}.
+     *
+     * @param port                  the port to check for validity
+     * @param errorMessageTemplate  the error message template to use in the exception if port is not valid
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if port is not valid
+     */
+    public static void checkValidPort(int port, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkState(port >= 0 && port <= MAX_PORT_NUMBER, errorMessageTemplate, errorMessageArgs);
     }
 
     /**
@@ -443,13 +674,61 @@ public class KiwiPreconditions {
     }
 
     /**
+     * Returns the given port if it is valid
+     *
+     * @param port          the port to check for validity
+     * @param errorMessage  the error message to put in the exception if the port is not valid
+     * @throws IllegalStateException if port is not valid
+     */
+    public static int requireValidPort(int port, String errorMessage) {
+        checkValidPort(port, errorMessage);
+        return port;
+    }
+
+    /**
+     * Returns the given port if it is valid
+     *
+     * @param port                  the port to check for validity
+     * @param errorMessageTemplate  the error message template to use in the exception if port is not valid
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if port is not valid
+     */
+    public static int requireValidPort(int port, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkValidPort(port, errorMessageTemplate, errorMessageArgs);
+        return port;
+    }
+
+    /**
      * Ensures given port is valid (excluding zero), between 1 and {@link #MAX_PORT_NUMBER}.
      *
      * @param port the port to check for validity
      * @throws IllegalStateException if port is not valid
      */
     public static void checkValidNonZeroPort(int port) {
-        checkState(port > 0 && port <= MAX_PORT_NUMBER, "port must be between 1 and %s", MAX_PORT_NUMBER);
+        checkValidNonZeroPort(port, "port must be between 1 and %s", MAX_PORT_NUMBER);
+    }
+
+    /**
+     * Ensures given port is valid (excluding zero), between 1 and {@link #MAX_PORT_NUMBER}.
+     *
+     * @param port          the port to check for validity
+     * @param errorMessage  the error message to put in the exception if the port is not valid
+     * @throws IllegalStateException if port is not valid
+     */
+    public static void checkValidNonZeroPort(int port, String errorMessage) {
+        checkState(port > 0 && port <= MAX_PORT_NUMBER, errorMessage);
+    }
+
+    /**
+     * Ensures given port is valid (excluding zero), between 1 and {@link #MAX_PORT_NUMBER}.
+     *
+     * @param port                  the port to check for validity
+     * @param errorMessageTemplate  the error message template to use in the exception if port is not valid
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if port is not valid
+     */
+    public static void checkValidNonZeroPort(int port, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkState(port > 0 && port <= MAX_PORT_NUMBER, errorMessageTemplate, errorMessageArgs);
     }
 
     /**
@@ -461,6 +740,31 @@ public class KiwiPreconditions {
      */
     public static int requireValidNonZeroPort(int port) {
         checkValidNonZeroPort(port);
+        return port;
+    }
+
+    /**
+     * Returns the given port if it is valid (excluding zero)
+     *
+     * @param port          the port to check for validity
+     * @param errorMessage  the error message to put in the exception if the port is not valid
+     * @throws IllegalStateException if port is not valid
+     */
+    public static int requireValidNonZeroPort(int port, String errorMessage) {
+        checkValidNonZeroPort(port, errorMessage);
+        return port;
+    }
+
+    /**
+     * Returns the given port if it is valid (excluding zero)
+     *
+     * @param port                  the port to check for validity
+     * @param errorMessageTemplate  the error message template to use in the exception if port is not valid
+     * @param errorMessageArgs      the arguments to populate into the error message template
+     * @throws IllegalStateException if port is not valid
+     */
+    public static int requireValidNonZeroPort(int port, String errorMessageTemplate, Object... errorMessageArgs) {
+        checkValidNonZeroPort(port, errorMessageTemplate, errorMessageArgs);
         return port;
     }
 

--- a/src/test/java/org/kiwiproject/base/KiwiPreconditionsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiPreconditionsTest.java
@@ -343,8 +343,32 @@ class KiwiPreconditionsTest {
         }
 
         @Test
+        void shouldThrowException_WithCustomMessage_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
+        }
+
+        @Test
         void shouldNotThrowException_WhenIntValue_IsPositive() {
             assertThatCode(() -> KiwiPreconditions.checkPositive(1)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessage_WhenIntValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositive(1, "custom error message")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenIntValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositive(1, "custom error message template %s", 42)).doesNotThrowAnyException();
         }
 
         @Test
@@ -352,6 +376,20 @@ class KiwiPreconditionsTest {
             assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1L))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("value must be a positive number");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1L, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1L, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
         }
 
         @Test
@@ -364,6 +402,16 @@ class KiwiPreconditionsTest {
         @Test
         void shouldNotThrowException_WhenLongValue_IsPositive() {
             assertThatCode(() -> KiwiPreconditions.checkPositive(1L)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessage_WhenLongValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositive(1L, "custom error message")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenLongValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositive(1L, "custom error message template %s", 42)).doesNotThrowAnyException();
         }
     }
 
@@ -378,6 +426,20 @@ class KiwiPreconditionsTest {
         }
 
         @Test
+        void shouldThrowException_WithCustomMessage_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
+        }
+
+        @Test
         void shouldNotThrowException_WhenIntValue_IsZero() {
             assertThatCode(() -> KiwiPreconditions.checkPositiveOrZero(0)).doesNotThrowAnyException();
         }
@@ -388,10 +450,34 @@ class KiwiPreconditionsTest {
         }
 
         @Test
+        void shouldNotThrowException_WithCustomMessage_WhenIntValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositiveOrZero(1, "custom error message")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenIntValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositiveOrZero(1, "custom error message template %s", 42)).doesNotThrowAnyException();
+        }
+
+        @Test
         void shouldThrowException_WhenLongValue_IsNegative() {
             assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1L))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("value must be positive or zero");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1L, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1L, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
         }
 
         @Test
@@ -403,6 +489,16 @@ class KiwiPreconditionsTest {
         void shouldNotThrowException_WhenLongValue_IsPositive() {
             assertThatCode(() -> KiwiPreconditions.checkPositiveOrZero(1L)).doesNotThrowAnyException();
         }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessage_WhenLongValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositive(1L, "custom error message")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenLongValue_IsPositive() {
+            assertThatCode(() -> KiwiPreconditions.checkPositive(1L, "custom error message template %s", 42)).doesNotThrowAnyException();
+        }
     }
 
     @Nested
@@ -413,6 +509,20 @@ class KiwiPreconditionsTest {
             assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("value must be a positive number");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
         }
 
         @Test
@@ -428,10 +538,34 @@ class KiwiPreconditionsTest {
         }
 
         @Test
+        void shouldReturnValue_WithCustomMessage_WhenIntValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositive(1, "custom error message")).isEqualTo(1);
+        }
+
+        @Test
+        void shouldReturnValue_WithCustomMessageTemplate_WhenIntValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositive(1, "custom error message template %s", 42)).isEqualTo(1);
+        }
+
+        @Test
         void shouldThrowException_WhenLongValue_IsNegative() {
             assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1L))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("value must be a positive number");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1L, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1L, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
         }
 
         @Test
@@ -444,6 +578,16 @@ class KiwiPreconditionsTest {
         @Test
         void shouldReturnValue_WhenLongValue_IsPositive() {
             assertThat(KiwiPreconditions.requirePositive(1L)).isEqualTo(1L);
+        }
+
+        @Test
+        void shouldReturnValue_WithCustomMessage_WhenLongValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositive(1L, "custom error message")).isEqualTo(1);
+        }
+
+        @Test
+        void shouldReturnValue_WithCustomMessageTemplate_WhenLongValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositive(1L, "custom error message template %s", 42)).isEqualTo(1);
         }
     }
 
@@ -458,6 +602,20 @@ class KiwiPreconditionsTest {
         }
 
         @Test
+        void shouldThrowException_WithCustomMessage_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
+        }
+
+        @Test
         void shouldReturnValue_WhenIntValue_IsZero() {
             assertThat(KiwiPreconditions.requirePositiveOrZero(0)).isZero();
         }
@@ -468,10 +626,34 @@ class KiwiPreconditionsTest {
         }
 
         @Test
+        void shouldReturnValue_WithCustomMessage_WhenIntValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositiveOrZero(1, "custom error message")).isEqualTo(1);
+        }
+
+        @Test
+        void shouldReturnValue_WithCustomMessageTemplate_WhenIntValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositiveOrZero(1, "custom error message template %s", 42)).isEqualTo(1);
+        }
+
+        @Test
         void shouldThrowException_WhenLongValue_IsNegative() {
             assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1L))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("value must be positive or zero");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1L, "custom error message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1L, "custom error message template %s", "42"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom error message template 42");
         }
 
         @Test
@@ -483,6 +665,16 @@ class KiwiPreconditionsTest {
         void shouldReturnValue_WhenLongValue_IsPositive() {
             assertThat(KiwiPreconditions.requirePositiveOrZero(1L)).isEqualTo(1L);
         }
+
+        @Test
+        void shouldReturnValue_WithCustomMessage_WhenLongValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositiveOrZero(1L, "custom error message")).isEqualTo(1);
+        }
+
+        @Test
+        void shouldReturnValue_WithCustomMessageTemplate_WhenLongValue_IsPositive() {
+            assertThat(KiwiPreconditions.requirePositiveOrZero(1L, "custom error message template %s", 42)).isEqualTo(1);
+        }
     }
 
     @Nested
@@ -493,6 +685,20 @@ class KiwiPreconditionsTest {
             assertThatThrownBy(() -> KiwiPreconditions.checkValidPort(-1))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("port must be between 0 and " + KiwiPreconditions.MAX_PORT_NUMBER);
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkValidPort(-1, "custom message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkValidPort(-1, "custom message %s", 42))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message 42");
         }
 
         @Test
@@ -508,6 +714,16 @@ class KiwiPreconditionsTest {
             assertThatCode(() -> KiwiPreconditions.checkValidPort(port)).doesNotThrowAnyException();
         }
 
+        @Test
+        void shouldNotThrowException_WithCustomMessage_WhenPort_IsValid() {
+            assertThatCode(() -> KiwiPreconditions.checkValidPort(0, "custom error message")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenPort_IsValid() {
+            assertThatCode(() -> KiwiPreconditions.checkValidPort(1, "custom error message template %s", 42)).doesNotThrowAnyException();
+        }
+
     }
 
     @Nested
@@ -518,6 +734,20 @@ class KiwiPreconditionsTest {
             assertThatThrownBy(() -> KiwiPreconditions.requireValidPort(-1))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("port must be between 0 and " + KiwiPreconditions.MAX_PORT_NUMBER);
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requireValidPort(-1, "custom message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requireValidPort(-1, "custom message %s", 42))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message 42");
         }
 
         @Test
@@ -533,6 +763,16 @@ class KiwiPreconditionsTest {
             assertThat(KiwiPreconditions.requireValidPort(port)).isEqualTo(port);
         }
 
+        @Test
+        void shouldReturnPort_WithCustomMessage_WhenPort_IsValid() {
+            assertThat(KiwiPreconditions.requireValidPort(0, "custom error message")).isZero();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenPort_IsValid() {
+            assertThat(KiwiPreconditions.requireValidPort(0, "custom error message %s", 42)).isZero();
+        }
+
     }
 
     @Nested
@@ -543,6 +783,20 @@ class KiwiPreconditionsTest {
             assertThatThrownBy(() -> KiwiPreconditions.checkValidNonZeroPort(-1))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("port must be between 1 and " + KiwiPreconditions.MAX_PORT_NUMBER);
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkValidNonZeroPort(-1, "custom message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.checkValidNonZeroPort(-1, "custom message %s", 42))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message 42");
         }
 
         @Test
@@ -565,6 +819,16 @@ class KiwiPreconditionsTest {
             assertThatCode(() -> KiwiPreconditions.checkValidNonZeroPort(port)).doesNotThrowAnyException();
         }
 
+        @Test
+        void shouldNotThrowException_WithCustomMessage_WhenPort_IsValid() {
+            assertThatCode(() -> KiwiPreconditions.checkValidNonZeroPort(1, "custom error message")).doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenPort_IsValid() {
+            assertThatCode(() -> KiwiPreconditions.checkValidNonZeroPort(1, "custom error message template %s", 42)).doesNotThrowAnyException();
+        }
+
     }
 
     @Nested
@@ -575,6 +839,20 @@ class KiwiPreconditionsTest {
             assertThatThrownBy(() -> KiwiPreconditions.requireValidNonZeroPort(-1))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("port must be between 1 and " + KiwiPreconditions.MAX_PORT_NUMBER);
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessage_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requireValidNonZeroPort(-1, "custom message"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message");
+        }
+
+        @Test
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
+            assertThatThrownBy(() -> KiwiPreconditions.requireValidNonZeroPort(-1, "custom message %s", 42))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("custom message 42");
         }
 
         @Test
@@ -595,6 +873,16 @@ class KiwiPreconditionsTest {
         @ValueSource(ints = { 1, MAX_PORT_NUMBER })
         void shouldReturnPort_WhenPort_IsValid(int port) {
             assertThat(KiwiPreconditions.requireValidNonZeroPort(port)).isEqualTo(port);
+        }
+
+        @Test
+        void shouldReturnPort_WithCustomMessage_WhenPort_IsValid() {
+            assertThat(KiwiPreconditions.requireValidNonZeroPort(1, "custom error message")).isOne();
+        }
+
+        @Test
+        void shouldNotThrowException_WithCustomMessageTemplate_WhenPort_IsValid() {
+            assertThat(KiwiPreconditions.requireValidNonZeroPort(1, "custom error message %s", 42)).isOne();
         }
 
     }


### PR DESCRIPTION
Add variants that accept an error message and error message template with arguments for the following methods:

* checkPositive (both int and long)
* checkPositiveOrZero (both int and long)
* requirePositive (both int and long)
* requirePositiveOrZero (both int and long)
* checkValidPort
* checkValidNonZeroPort