### PR TITLE
Add WebTargetHelper and "gateway" WebTargetClientHelper

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/client/WebTargetClientHelper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/WebTargetClientHelper.java
@@ -1,0 +1,79 @@
+package org.kiwiproject.jaxrs.client;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import com.google.common.annotations.Beta;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+/**
+ * Use with JAX-RS {@link Client} instances to provide additional functionality via {@link WebTargetHelper}. Each
+ * of the {@code target} methods returns a {@link WebTargetHelper} to allow method chaining. Please see the
+ * documentation in {@link WebTargetHelper} for more explanation.
+ *
+ * @see WebTargetHelper
+ */
+@Beta
+public class WebTargetClientHelper {
+
+    private final Client client;
+
+    private WebTargetClientHelper(Client client) {
+        this.client = requireNotNull(client);
+    }
+
+    /**
+     * Create a new instance with the given {@link Client}.
+     *
+     * @param client the Client to use when building requests
+     * @return a new instance
+     */
+    public static WebTargetClientHelper withClient(Client client) {
+        return new WebTargetClientHelper(client);
+    }
+
+    /**
+     * Build a new web resource target.
+     *
+     * @param uri web resource URI. May contain template parameters. Must not be null
+     * @return a {@link WebTargetHelper} with the target bound to the provided URI
+     * @see Client#target(String)
+     */
+    public WebTargetHelper target(String uri) {
+        return new WebTargetHelper(client.target(uri));
+    }
+
+    /**
+     * Build a new web resource target.
+     *
+     * @param uri web resource URI. Must not be null.
+     * @return a {@link WebTargetHelper} with the target bound to the provided URI.
+     * @see Client#target(URI)
+     */
+    public WebTargetHelper target(URI uri) {
+        return new WebTargetHelper(client.target(uri));
+    }
+
+    /**
+     * Build a new web resource target.
+     *
+     * @param uriBuilder web resource URI represented as URI builder. Must not be null.
+     * @return a {@link WebTargetHelper} with the target bound to the provided URI.
+     */
+    public WebTargetHelper target(UriBuilder uriBuilder) {
+        return new WebTargetHelper(client.target(uriBuilder));
+    }
+
+    /**
+     * Build a new web resource target.
+     *
+     * @param link link to a web resource. Must not be null.
+     * @return a {@link WebTargetHelper} with the target bound to the linked web resource
+     */
+    public WebTargetHelper target(Link link) {
+        return new WebTargetHelper(client.target(link));
+    }
+}

--- a/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
@@ -5,14 +5,14 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.collect.KiwiArrays.isNullOrEmpty;
+import static org.kiwiproject.collect.KiwiLists.isNullOrEmpty;
+import static org.kiwiproject.collect.KiwiMaps.isNullOrEmpty;
 
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.experimental.Delegate;
 import org.apache.commons.lang3.StringUtils;
-import org.kiwiproject.collect.KiwiArrays;
-import org.kiwiproject.collect.KiwiLists;
-import org.kiwiproject.collect.KiwiMaps;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
@@ -153,7 +153,7 @@ public class WebTargetHelper {
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotNull(String name, Object... values) {
-        if (KiwiArrays.isNullOrEmpty(values)) {
+        if (isNullOrEmpty(values)) {
             return this;
         }
 
@@ -168,7 +168,7 @@ public class WebTargetHelper {
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotNull(String name, List<Object> values) {
-        if (KiwiLists.isNullOrEmpty(values)) {
+        if (isNullOrEmpty(values)) {
             return this;
         }
 
@@ -231,7 +231,7 @@ public class WebTargetHelper {
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotBlank(String name, String... values) {
-        if (KiwiArrays.isNullOrEmpty(values)) {
+        if (isNullOrEmpty(values)) {
             return this;
         }
 
@@ -246,7 +246,7 @@ public class WebTargetHelper {
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotBlank(String name, List<String> values) {
-        if (KiwiLists.isNullOrEmpty(values)) {
+        if (isNullOrEmpty(values)) {
             return this;
         }
 
@@ -280,7 +280,7 @@ public class WebTargetHelper {
      * @return this instance
      */
     public WebTargetHelper queryParams(Map<String, Object> parameters) {
-        if (KiwiMaps.isNullOrEmpty(parameters)) {
+        if (isNullOrEmpty(parameters)) {
             return this;
         }
 

--- a/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
@@ -1,0 +1,325 @@
+package org.kiwiproject.jaxrs.client;
+
+import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+import lombok.experimental.Delegate;
+import org.apache.commons.lang3.StringUtils;
+import org.kiwiproject.collect.KiwiArrays;
+import org.kiwiproject.collect.KiwiLists;
+import org.kiwiproject.collect.KiwiMaps;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Use with JAX-RS {@link WebTarget} instances to provide convenient functionality when adding query parameters.
+ * <p>
+ * Usage example (assuming {@link WebTargetClientHelper#withClient(Client) withClient} is statically imported):
+ * <pre>
+ * withClient(client).target("/search")
+ *         .queryParamRequireNotBlank("q", query)
+ *         .queryParamIfNotBlank("sort", sort)
+ *         .queryParamIfNotBlank("page", page)
+ *         .queryParamIfNotBlank("limit", limit)
+ *         .queryParamFilterNotBlank("langs", langs);
+ * </pre>
+ * <h3>Limitations</h3>
+ * This is a <strong>limited</strong> wrapper around {@link WebTarget} that provides enhanced functionality only for
+ * adding query parameters. Only the methods defined in this class are chainable, i.e. once you call a method defined
+ * in the regular {@link Client} interface, you leave the {@link WebTargetHelper} context.
+ * <p>
+ * For example you can <strong>NOT</strong> do this:
+ * <pre>
+ * withClient(client).target("/search")
+ *         .queryParamRequireNotBlank("q", query)
+ *         .queryParam("sort", sort)  // after this, only Client methods are accessible!!! WON'T COMPILE
+ *         .queryParamIfNotBlank("page", page)
+ *         .queryParamIfNotBlank("limit", limit)
+ *         .queryParamFilterNotBlank("langs", langs);
+ * </pre>
+ * With the current basic implementation, this means certain usages will be awkward. For example, when using
+ * both parameter templates and query parameters, the query parameters need to be added first, for the reason
+ * given above about leaving the {@link WebTargetHelper} context. For example:
+ * <pre>
+ * var response = withClient(client).target("/users/{userId}/trades/{tradeId}")
+ *         .queryParamIfNotBlank("displayCurrency", currency)
+ *         .queryParamIfNotNull("showLimitPrice", showLimitPrice)
+ *         .resolveTemplate("userId", userId)  // after this, only Client methods are accessible!!!
+ *         .resolveTemplate("tradeId", tradeId)
+ *         .request()
+ *         .get();
+ * </pre>
+ * One way to get around this restriction is to use methods from {@link WebTarget} as normal, and then wrap it
+ * with a {@link WebTargetHelper} to add query parameters. The above example would then look like:
+ * <pre>
+ * var pathResolvedTarget = client.target("/users/{userId}/trades/{tradeId}")
+ *         .resolveTemplate("userId", userId)
+ *         .resolveTemplate("tradeId", tradeId);
+ *
+ * var response = withWebTarget(pathResolvedTarget)
+ *         .queryParamIfNotBlank("displayCurrency", currency)
+ *         .queryParamIfNotNull("showLimitPrice", showLimitPrice)
+ *         .request()
+ *         .get();
+ * </pre>
+ * This usage allows for full functionality of {@link WebTarget} while still getting the enhanced query parameter
+ * features of this class. It isn't perfect but it works and, in our opinion anyway, doesn't intrude too much on
+ * building JAX-RS requests. In other words, we think it is a decent trade off.
+ *
+ * @implNote Internally this uses Lombok's {@link Delegate}, which is why this class doesn't implement {@link WebTarget}
+ * directly. While this lets us easily delegate method calls to a {@link WebTarget}, it also restricts what we can do
+ * here, and is the primary reason why there are usage restrictions. However, in our general usage this implementation
+ * has been enough for our needs. Nevertheless this is currently marked with the Guava {@link Beta} annotation in case
+ * we change our minds on the implementation.
+ */
+@Beta
+public class WebTargetHelper {
+
+    @Delegate
+    private final WebTarget webTarget;
+
+    /**
+     * Package-private constructor. Used by {@link WebTargetClientHelper}.
+     *
+     * @param webTarget the WebTarget to wrap
+     */
+    WebTargetHelper(WebTarget webTarget) {
+        this.webTarget = requireNotNull(webTarget);
+    }
+
+    /**
+     * @return the wrapped WebTarget
+     */
+    @VisibleForTesting
+    WebTarget wrapped() {
+        return webTarget;
+    }
+
+    /**
+     * Create a new instance with the given {@link WebTarget}.
+     *
+     * @param webTarget the WebTarget to use
+     * @return a new instance
+     */
+    public static WebTargetHelper withWebTarget(WebTarget webTarget) {
+        return new WebTargetHelper(webTarget);
+    }
+
+    /**
+     * Add the required query parameter.
+     *
+     * @param name  the parameter name
+     * @param value the parameter value
+     * @return this instance
+     * @throws IllegalArgumentException if value is null
+     */
+    public WebTargetHelper queryParamRequireNotNull(String name, Object value) {
+        checkArgumentNotNull(value, "value cannot be null for parameter %s", name);
+
+        var newWebTarget = webTarget.queryParam(name, value);
+        return new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Add the given query parameter only if it is not null.
+     *
+     * @param name  the parameter name
+     * @param value the parameter value
+     * @return this instance
+     */
+    public WebTargetHelper queryParamIfNotNull(String name, Object value) {
+        var newWebTarget = this.webTarget.queryParam(name, value);
+
+        return isNull(value) ? this : new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Adds any non-null values to the the given query parameter.
+     *
+     * @param name   the parameter name
+     * @param values one or more parameter values
+     * @return this instance
+     */
+    public WebTargetHelper queryParamFilterNotNull(String name, Object... values) {
+        if (KiwiArrays.isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterNotNull(name, Arrays.stream(values));
+    }
+
+    /**
+     * Adds any non-null values to the the given query parameter.
+     *
+     * @param name   the parameter name
+     * @param values one or more parameter values
+     * @return this instance
+     */
+    public WebTargetHelper queryParamFilterNotNull(String name, List<Object> values) {
+        if (KiwiLists.isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterNotNull(name, values.stream());
+    }
+
+    /**
+     * Adds any non-null values to the the given query parameter.
+     *
+     * @param name   the parameter name
+     * @param stream containing one or more parameter values
+     * @return this instance
+     */
+    public WebTargetHelper queryParamFilterNotNull(String name, Stream<Object> stream) {
+        if (isNull(stream)) {
+            return this;
+        }
+
+        var nonNullValues = stream
+                .filter(Objects::nonNull)
+                .toArray();
+
+        var newWebTarget = webTarget.queryParam(name, nonNullValues);
+        return new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Add the required query parameter.
+     *
+     * @param name  the parameter name
+     * @param value the parameter value
+     * @return this instance
+     * @throws IllegalArgumentException if value is blank
+     */
+    public WebTargetHelper queryParamRequireNotBlank(String name, String value) {
+        checkArgumentNotBlank(value, "value cannot be blank for parameter %s", name);
+
+        var newWebTarget = webTarget.queryParam(name, value);
+        return new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Add the given query parameter only if it is not blank.
+     *
+     * @param name  the parameter name
+     * @param value the parameter value
+     * @return this instance
+     */
+    public WebTargetHelper queryParamIfNotBlank(String name, String value) {
+        var newWebTarget = this.webTarget.queryParam(name, value);
+
+        return isBlank(value) ? this : new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Adds any non-blank values to the the given query parameter.
+     *
+     * @param name   the parameter name
+     * @param values one or more parameter values
+     * @return this instance
+     */
+    public WebTargetHelper queryParamFilterNotBlank(String name, String... values) {
+        if (KiwiArrays.isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterNotBlank(name, Arrays.stream(values));
+    }
+
+    /**
+     * Adds any non-blank values to the the given query parameter.
+     *
+     * @param name   the parameter name
+     * @param values one or more parameter values
+     * @return this instance
+     */
+    public WebTargetHelper queryParamFilterNotBlank(String name, List<String> values) {
+        if (KiwiLists.isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterNotBlank(name, values.stream());
+    }
+
+    /**
+     * Adds any non-blank values to the the given query parameter.
+     *
+     * @param name   the parameter name
+     * @param stream containing one or more parameter values
+     * @return this instance
+     */
+    public WebTargetHelper queryParamFilterNotBlank(String name, Stream<String> stream) {
+        if (isNull(stream)) {
+            return this;
+        }
+
+        var nonBlankValues = stream
+                .filter(StringUtils::isNotBlank)
+                .toArray();
+
+        var newWebTarget = webTarget.queryParam(name, nonBlankValues);
+        return new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Adds non-null query parameters from the given map. All map keys <strong>must</strong> be non-null.
+     *
+     * @param parameters a map representing the query parameters
+     * @return this instance
+     */
+    public WebTargetHelper queryParams(Map<String, Object> parameters) {
+        if (KiwiMaps.isNullOrEmpty(parameters)) {
+            return this;
+        }
+
+        var targetHelper = this;
+        for (var entry : parameters.entrySet()) {
+            targetHelper = targetHelper.queryParamIfNotNull(entry.getKey(), entry.getValue());
+        }
+
+        // NOTE: The above is effectively a foldLeft, which Java Streams does not have. The 3-arg reduce version is a lot
+        // more difficult to understand than a simple loop with a mutable variable that we keep replacing. In addition,
+        // the reduce version cannot be strictly correct,  since we cannot define a combiner function which is "an
+        // associative, non-interfering, stateless function for combining" two WebTargetHelper instances. Instead, we
+        // would require it is only used on a sequential (non-parallel) stream. Regardless, the implementation is less
+        // clear than just a loop with a mutable variable, which is why this is not using the streams API. While the
+        // lovely StreamEx library does have a foldLeft where the seed and accumulator have differing types, it is not
+        // worth adding a hard dependency on that library for one function.
+        // See https://stackoverflow.com/questions/24308146/why-is-a-combiner-needed-for-reduce-method-that-converts-type-in-java-8
+
+        return targetHelper;
+    }
+
+    /**
+     * Adds non-null query parameters from the given multivalued map. All map keys <strong>must</strong> be non-null.
+     *
+     * @param parameters a multivalued representing the query parameters
+     * @return this instance
+     */
+    public WebTargetHelper queryParams(MultivaluedMap<String, Object> parameters) {
+        if (isNull(parameters) || parameters.isEmpty()) {
+            return this;
+        }
+
+        // NOTE: This is effectively a foldLeft, which Java Streams does not have. See explanation in method above.
+        var targetHelper = this;
+        for (var entry : parameters.entrySet()) {
+            targetHelper = targetHelper.queryParamFilterNotNull(entry.getKey(), entry.getValue());
+        }
+
+        return targetHelper;
+    }
+
+}

--- a/src/test/java/org/kiwiproject/jaxrs/client/WebTargetClientHelperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/client/WebTargetClientHelperTest.java
@@ -1,0 +1,86 @@
+package org.kiwiproject.jaxrs.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.jaxrs.client.WebTargetClientHelper.withClient;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+
+@DisplayName("WebTargetClientHelper")
+class WebTargetClientHelperTest {
+
+    private static Client client;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = ClientBuilder.newClient();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        client.close();
+    }
+
+    @Nested
+    class Target {
+
+        @Test
+        void shouldAcceptString() {
+            var newWebTarget = withClient(client)
+                    .target("/search")
+                    .queryParamIfNotBlank("q", "pangram")
+                    .queryParamIfNotBlank("sort", "")
+                    .queryParamIfNotNull("page", null)
+                    .queryParamIfNotNull("limit", null);
+
+            assertThat(newWebTarget.getUri()).hasQuery("q=pangram");
+        }
+
+        @Test
+        void shouldAcceptURI() {
+            var newWebTarget = withClient(client)
+                    .target(URI.create("/search"))
+                    .queryParamIfNotBlank("q", "pangram")
+                    .queryParamIfNotBlank("sort", "")
+                    .queryParamIfNotNull("page", 0)
+                    .queryParamIfNotNull("limit", 10);
+
+            assertThat(newWebTarget.getUri()).hasQuery("q=pangram&page=0&limit=10");
+        }
+
+        @Test
+        void shouldAcceptUriBuilder() {
+            var uriBuilder = UriBuilder.fromPath("/search");
+            var newWebTarget = withClient(client)
+                    .target(uriBuilder)
+                    .queryParamIfNotBlank("q", "pangram")
+                    .queryParamIfNotBlank("sort", "relevance")
+                    .queryParamIfNotNull("page", 0)
+                    .queryParamIfNotNull("limit", 25);
+
+            assertThat(newWebTarget.getUri()).hasQuery("q=pangram&sort=relevance&page=0&limit=25");
+        }
+
+        @Test
+        void shouldAcceptLink() {
+            var link = Link.fromPath("/search").build();
+            var newWebTarget = withClient(client)
+                    .target(link)
+                    .queryParamIfNotBlank("q", "pangram")
+                    .queryParamIfNotBlank("sort", "")
+                    .queryParamIfNotNull("page", null)
+                    .queryParamIfNotNull("limit", 10);
+
+            assertThat(newWebTarget.getUri()).hasQuery("q=pangram&limit=10");
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/jaxrs/client/WebTargetHelperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/client/WebTargetHelperTest.java
@@ -1,0 +1,492 @@
+package org.kiwiproject.jaxrs.client;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.kiwiproject.jaxrs.client.WebTargetHelper.withWebTarget;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.kiwiproject.collect.KiwiMaps;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@DisplayName("WebTargetHelper")
+class WebTargetHelperTest {
+
+    private static Client client;
+
+    private WebTarget originalWebTarget;
+
+    @BeforeAll
+    static void beforeAll() {
+        client = ClientBuilder.newClient();
+    }
+
+    @BeforeEach
+    void setUp() {
+        originalWebTarget = client.target("/path");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        client.close();
+    }
+
+    @Nested
+    class QueryParamRequireNotNull {
+
+        @Test
+        void shouldThrow_WhenGivenNullValue() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() ->
+                            withWebTarget(originalWebTarget)
+                                    .queryParamRequireNotNull("foo", 42)
+                                    .queryParamRequireNotNull("bar", null)
+                                    .queryParamRequireNotNull("baz", null))
+                    .withMessage("value cannot be null for parameter bar");
+
+            // NOTE: Only the first null value encountered will be reported, since there is
+            // no easy and clean way to accumulate errors that I can see. Thus only the 'bar'
+            // parameter is reported in the exception.
+        }
+
+        @Test
+        void shouldAddNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamRequireNotNull("foo", 42)
+                    .queryParamRequireNotNull("bar", 84)
+                    .queryParamRequireNotNull("baz", "glomp");
+
+            assertThat(newWebTarget.getUri()).hasQuery("foo=42&bar=84&baz=glomp");
+        }
+    }
+
+    @Nested
+    class QueryParamIfNotNull {
+
+        @Test
+        void shouldReturnSameInstanceWithNoQuery_WhenGivenOnlyNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamIfNotNull("foo", null)
+                    .queryParamIfNotNull("bar", null)
+                    .queryParamIfNotNull("baz", null);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldAddNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamIfNotNull("q", "pangram")
+                    .queryParamIfNotNull("page", 42)
+                    .queryParamIfNotNull("limit", 25)
+                    .queryParamIfNotNull("sort", null)
+                    .queryParamIfNotNull("sortDir", null);
+
+            assertThat(newWebTarget.getUri()).hasQuery("q=pangram&page=42&limit=25");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterNotNull {
+
+        @Nested
+        class WhenArray {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(Object[] values) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("foo", values);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonNullValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("lottoNumbers", 42, 84, null, null, 252);
+
+                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            }
+        }
+
+        @Nested
+        class WhenList {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(List<Object> values) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("foo", values);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonNullValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("lottoNumbers", newArrayList(42, 84, null, null, 252));
+
+                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            }
+        }
+
+        @Nested
+        class WhenStream {
+
+            @ParameterizedTest
+            @NullSource
+            void shouldReturnSameInstanceWithNoQuery_WhenNull(Stream<Object> values) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("foo", values);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldReturnNewInstance_WhenEmpty() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("foo", Stream.of());
+
+                assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonNullValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull("lottoNumbers", Stream.of(42, 84, null, null, 252));
+
+                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            }
+        }
+    }
+
+    @Nested
+    class QueryParamRequireNotBlank {
+
+        @Test
+        void shouldThrow_WhenGivenNullValue() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() ->
+                            withWebTarget(originalWebTarget)
+                                    .queryParamRequireNotBlank("foo", "42")
+                                    .queryParamRequireNotBlank("bar", "")
+                                    .queryParamRequireNotBlank("baz", ""))
+                    .withMessage("value cannot be blank for parameter bar");
+
+            // NOTE: Only the first null value encountered will be reported, since there is
+            // no easy and clean way to accumulate errors that I can see. Thus only the 'bar'
+            // parameter is reported in the exception.
+        }
+
+        @Test
+        void shouldAddNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamRequireNotBlank("foo", "42")
+                    .queryParamRequireNotBlank("bar", "84")
+                    .queryParamRequireNotBlank("baz", "glomp");
+
+            assertThat(newWebTarget.getUri()).hasQuery("foo=42&bar=84&baz=glomp");
+        }
+    }
+
+    @Nested
+    class QueryParamIfNotBlank {
+
+        @Test
+        void shouldReturnSameInstance_WhenGivenBlank() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamIfNotBlank("foo", "")
+                    .queryParamIfNotBlank("bar", " ")
+                    .queryParamIfNotBlank("misc", null)
+                    .queryParamIfNotBlank("baz", "\t  \n");
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldAddNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamIfNotBlank("q", "what is a pangram")
+                    .queryParamIfNotBlank("client", "")
+                    .queryParamIfNotBlank("lang", "")
+                    .queryParamIfNotBlank("misc", null)
+                    .queryParamIfNotBlank("sort", "relevance")
+                    .queryParamIfNotBlank("sortDir", "asc");
+
+            assertThat(newWebTarget.getUri()).hasQuery("q=what+is+a+pangram&sort=relevance&sortDir=asc");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterNotBlank {
+
+        @Nested
+        class WhenArray {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstance_WhenNullOrEmpty(String[] values) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("foo", values);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonBlankValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("lottoNumbers",
+                                "42", "", "84", null, "  ", null, "252", "\t  \n");
+
+                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            }
+        }
+
+        @Nested
+        class WhenList {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstance_WhenNullOrEmpty(List<String> values) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("foo", values);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonBlankValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("lottoNumbers",
+                                newArrayList("42", "", "84", null, "  ", null, "252", "\t  \n"));
+
+                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            }
+        }
+
+        @Nested
+        class WhenStream {
+
+            @ParameterizedTest
+            @NullSource
+            void shouldReturnSameInstance_WhenNull(Stream<String> values) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("foo", values);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldReturnNewInstance_WhenEmpty() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("foo", Stream.of());
+
+                assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonBlankValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank("lottoNumbers",
+                                Stream.of("42", "", "84", null, "  ", null, "252", "\t  \n"));
+
+                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            }
+        }
+    }
+
+    @Nested
+    class QueryParams {
+
+        @Nested
+        class WhenJavaUtilMap {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstance_WhenNullOrEmpty(Map<String, Object> parameters) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParams(parameters);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldReturnSameInstance_WhenAllValuesAreNull() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParams(KiwiMaps.newHashMap(
+                                "foo", null,
+                                "bar", null,
+                                "baz", null));
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonNullValues() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParams(KiwiMaps.newHashMap(
+                                "foo", null,
+                                "q", "pangram",
+                                "bar", null,
+                                "baz", null,
+                                "limit", 50,
+                                "page", 1));
+
+                // Cannot assume anything about map iteration order
+                assertThat(splitQueryParams(newWebTarget))
+                        .contains("q=pangram")
+                        .contains("limit=50")
+                        .contains("page=1")
+                        .doesNotContain("foo=", "bar=", "baz=");
+            }
+
+            /**
+             * Why is this test here? We do not want to make any assumptions about whether a caller
+             * intends to exclude parameters whose values are blank strings, since query parameters
+             * can be blank. For example, in the query string "{@code q=pangram&sort=&dir=&limit=10}" the
+             * "sort" and "dir" parameters have no value, which might be perfectly valid. If a client
+             * wants to exclude blank values, it should filter them before calling queryParams.
+             */
+            @Test
+            void shouldIncludeBlankStrings() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParams(KiwiMaps.newHashMap(
+                                "foo", "",
+                                "q", "pangram",
+                                "bar", "",
+                                "baz", " ",
+                                "limit", 50,
+                                "page", 1));
+
+                assertThat(splitQueryParams(newWebTarget))
+                        .contains("foo=")
+                        .contains("q=pangram")
+                        .contains("bar=")
+                        .contains("baz=+")
+                        .contains("limit=50")
+                        .contains("page=1");
+            }
+        }
+
+        @Nested
+        class WhenJaxrsMultivaluedMap {
+
+            @ParameterizedTest
+            @NullSource
+            void shouldReturnSameInstance_WhenNull(MultivaluedMap<String, Object> parameters) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParams(parameters);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldReturnSameInstance_WhenEmpty() {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParams(new MultivaluedHashMap<>());
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldReturnSameInstance_WhenAllValuesAreNull() {
+                var multivaluedMap = new MultivaluedHashMap<String, Object>();
+                multivaluedMap.put("ham", null);
+                multivaluedMap.put("eggs", null);
+                multivaluedMap.put("spam", null);
+
+                var newWebTarget = withWebTarget(originalWebTarget).queryParams(multivaluedMap);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldReturnSameInstance_WhenAllValuesAreEmptyLists() {
+                var multivaluedMap = new MultivaluedHashMap<String, Object>();
+                multivaluedMap.put("ham", List.of());
+                multivaluedMap.put("eggs", List.of());
+                multivaluedMap.put("spam", List.of());
+
+                var newWebTarget = withWebTarget(originalWebTarget).queryParams(multivaluedMap);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @Test
+            void shouldIncludeOnlyNonNullValues() {
+                var multivaluedMap = new MultivaluedHashMap<String, Object>();
+                multivaluedMap.put("ln", List.of(42, 84));
+                multivaluedMap.put("fruits", List.of("apple", "orange", "banana"));
+                multivaluedMap.put("foo", List.of());
+                multivaluedMap.put("bar", null);
+                multivaluedMap.put("baz", newArrayList(null, null));
+                multivaluedMap.put("l", List.of("EN"));
+                multivaluedMap.put("cc", List.of("US", "UK"));
+
+                var newWebTarget = withWebTarget(originalWebTarget).queryParams(multivaluedMap);
+
+                // Cannot assume anything about map iteration order
+                assertThat(splitQueryParams(newWebTarget))
+                        .contains("ln=42")
+                        .contains("ln=84")
+                        .contains("fruits=apple")
+                        .contains("fruits=orange")
+                        .contains("fruits=banana")
+                        .contains("l=EN")
+                        .contains("cc=US")
+                        .contains("cc=UK")
+                        .doesNotContain("foo=", "bar=", "baz=");
+            }
+
+            /**
+             * Why is this test here? See explanation above in {@link QueryParams}
+             */
+            @Test
+            void shouldIncludeBlankStrings() {
+                var multivaluedMap = new MultivaluedHashMap<String, Object>();
+                multivaluedMap.put("ln", List.of(42, 84));
+                multivaluedMap.put("misc", List.of("", " ", "  "));
+
+                var newWebTarget = withWebTarget(originalWebTarget).queryParams(multivaluedMap);
+
+                assertThat(splitQueryParams(newWebTarget))
+                        .contains("ln=42")
+                        .contains("ln=84")
+                        .contains("misc=")
+                        .contains("misc=+")
+                        .contains("misc=++");
+            }
+        }
+    }
+
+    private void assertIsOriginalWebTargetAndHasNoQuery(WebTargetHelper newWebTarget) {
+        assertThat(newWebTarget.wrapped()).isSameAs(originalWebTarget);
+        assertThat(newWebTarget.getUri()).hasNoQuery();
+    }
+
+    private void assertNotOriginalWebTargetAndNoQuery(WebTargetHelper newWebTarget) {
+        assertThat(newWebTarget.wrapped()).isNotSameAs(originalWebTarget);
+        assertThat(newWebTarget.getUri()).hasNoQuery();
+    }
+
+    private static String[] splitQueryParams(WebTargetHelper newWebTarget) {
+        return newWebTarget.getUri().getQuery().split("&");
+    }
+}


### PR DESCRIPTION
* WebTargetHelper is the main feature here; it adds enhanced
  functionality for adding JAX-RS query parameters. Can be used
  by itself, or via the gateway WebTargetClient#withClient method
* WebTargetClientHelper is a "gateway" from a JAX-RS Client instance
  to a WebTargetHelper.

Closes #472