### PR TITLE
Don't assume port 22 is always in use in LocalPortCheckerTest

### DIFF
--- a/src/main/java/org/kiwiproject/net/LocalPortChecker.java
+++ b/src/main/java/org/kiwiproject/net/LocalPortChecker.java
@@ -43,7 +43,7 @@ public class LocalPortChecker {
      * @return an optional containing the first open port, or an empty optional
      */
     public OptionalInt findFirstOpenPortAbove(int port) {
-        checkArgument(port >= 0 && port < MAX_PORT, "Invalid start port");
+        checkArgument(port >= 0 && port < MAX_PORT, "Invalid start port: %s", port);
 
         return IntStream.rangeClosed(port + 1, MAX_PORT)
                 .filter(this::isPortAvailable)


### PR DESCRIPTION
* Instead, just open a ServerSocket on a random port and use its
  port as the "in use" port. Simple and no assumptions.
* Minor update to the failure description in another test to make it
  more clear that we are intentionally halting a test
* Change several tests to use JUnit Jupiter @ParameterizedTest and
  added/updated failure description messages

LocalPortChecker:
* Add port to exception message thrown by findFirstOpenPortAbove method

Fixes #475
Closes #477 