### PR TITLE
Update docs in PagingQuery tests

### DIFF
--- a/src/test/java/org/kiwiproject/spring/data/PagingQueryEmbeddedMongoTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingQueryEmbeddedMongoTest.java
@@ -34,6 +34,16 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import java.util.List;
 import java.util.function.Predicate;
 
+/**
+ * Uses Flapdoodle embedded Mongo which can be found on GitHub
+ * <a href="https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo">here</a>.
+ * <p>
+ * This test is currently only testing against Mongo 4 using {@link Version.Main#V4_0}.
+ * <p>
+ * Note that we also have {@link PagingQueryRealMongoTest} which executes against a real Mongo instance. It
+ * currently requires some manual setup, but allows you to execute the same tests against multiple Mongo
+ * versions, e.g. in Docker containers.
+ */
 @DisplayName("PagingQuery (embedded Mongo)")
 @ExtendWith(SoftAssertionsExtension.class)
 @Slf4j

--- a/src/test/java/org/kiwiproject/spring/data/PagingQueryRealMongoTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingQueryRealMongoTest.java
@@ -33,12 +33,11 @@ import java.util.function.Predicate;
 /**
  * The code in {@link PagingQuery#aggregatePage(Class, AggregationOperation...)} blows up with a NPE whenever executing
  * it using the in-memory {@link de.bwaldvogel.mongo.MongoServer}, which is the only reason this test even exists.
+ * (And I have been unable to figure out exactly why it blows up.)
  * <p>
  * To use this test, you need a "real" MongoDB instance. For now, this test is only enabled when {@code realMongoDB}
  * and {@code realMongoDB.url} system properties are specified and match the expected values. This lets you run the
- * tests locally, even though they won't currently run in our CI environment. Assuming we even keep the aggregatePage
- * method, we'll want to look into using the Flapdoodle embedded Mongo which can be found on GitHub
- * <a href="https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo">here</a>.
+ * tests locally, even though they won't currently run in our CI environment.
  * <p>
  * One easy way is to run a Docker container:
  * {@code docker run -p 27017:27017 --name test-mongo-1 -d mongo:4.0.21}
@@ -55,6 +54,9 @@ import java.util.function.Predicate;
  *     <li>4.2.11</li>
  *     <li>4.4.2</li>
  * </ul>
+ * <p>
+ * Note that we also have {@link PagingQueryEmbeddedMongoTest} which always runs. It uses the Flapdoodle embedded
+ * Mongo which can be found on GitHub <a href="https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo">here</a>.
  */
 @DisplayName("PagingQuery (real MongoDB)")
 @ExtendWith(SoftAssertionsExtension.class)


### PR DESCRIPTION
* Update PagingQueryRealMongoTest to reflect the fact that I
  subsequently added the PagingQueryEmbeddedMongoTest using the
  Flapdoodle embedded Mongo
* Update PagingQueryEmbeddedMongoTest to mention that we also have
  the PagingQueryRealMongoTest if you need to test against a "real"
  Mongo instance.