### PR TITLE
Use provided Lombok dependency inherited from kiwi-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
     </parent>
 
     <artifactId>kiwi</artifactId>
@@ -53,7 +53,6 @@
         <jboss-logging.version>3.4.1.Final</jboss-logging.version>
         <joda-time.version>2.10.7</joda-time.version>
         <jsch.version>0.1.55</jsch.version>
-        <lombok.version>1.18.18</lombok.version>
         <metrics-jdbi3.version>4.1.16</metrics-jdbi3.version>
         <postgresql.version>42.2.18</postgresql.version>
         <metrics-jetty9.version>4.1.16</metrics-jetty9.version>
@@ -469,13 +468,6 @@
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
             <version>${jsch.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
* Update to kiwi-parent 0.7.0 (which has the most recent Lombok version)
* Remove lombok dependency so we use the one in kiwi-parent

Closes #498