### PR TITLE
Add method to Processes to return OptionalLong if pid is not supported

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/Processes.java
+++ b/src/main/java/org/kiwiproject/base/process/Processes.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -204,6 +205,28 @@ public class Processes {
     public static long processId(Process process) {
         checkArgumentNotNull(process);
         return process.pid();
+    }
+
+    /**
+     * Get a process id, or "pid", if it is available from the {@link Process} implementation, wrapped inside
+     * an OptionalLong. If the pid is not available for whatever reason, return an empty OptionalLong.
+     *
+     * @param process the process to obtain the process id (pid) from
+     * @return an OptionalLong containing the process if of {@code process} or an empty OptionalLong if the
+     * {@link Process} implementation does not support getting the pid for whatever reason.
+     * @implNote the {@link Process#pid()} method says it can throw {@link UnsupportedOperationException} if the
+     * "implementation does not support this operation" but does not specify under what circumstances that can
+     * happen, and I have not been able to find this information using Google, Bing, or DuckDuckGo. This method
+     * logs a warning along with the exception, so if this occurs check your logs for the possible reason.
+     */
+    public static OptionalLong processIdOrEmpty(Process process) {
+        checkArgumentNotNull(process);
+        try {
+            return OptionalLong.of(process.pid());
+        } catch (UnsupportedOperationException e) {
+            LOG.warn("The JDK cannot get the PID of the given Process. Check stack trace for a possible reason", e);
+            return OptionalLong.empty();
+        }
     }
 
     /**

--- a/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
+++ b/src/test/java/org/kiwiproject/base/process/ProcessesTest.java
@@ -84,6 +84,27 @@ class ProcessesTest {
         assertThat(Processes.processId(process)).isEqualTo(process.pid());
     }
 
+    @Nested
+    class ProcessIdOrEmpty {
+
+        @Test
+        void shouldReturnOptionalContainingPid_WhenPidIsAvailable() {
+            var pid = 12345L;
+            var process = mock(Process.class);
+            when(process.pid()).thenReturn(pid);
+
+            assertThat(Processes.processIdOrEmpty(process)).hasValue(pid);
+        }
+
+        @Test
+        void shouldReturnEmptyOptionalContainingPid_WhenProcess_ThrowsUnsupportedOperationException() {
+            var process = mock(Process.class);
+            when(process.pid()).thenThrow(new UnsupportedOperationException("No pid for you!"));
+
+            assertThat(Processes.processIdOrEmpty(process)).isEmpty();
+        }
+    }
+
     @Test
     void testKillInternal_WhenProcessIsKilledCleanlyBeforeTimeout() throws InterruptedException {
         var pid = 2970L;


### PR DESCRIPTION
* Add processIdOrEmpty to Processes, returning OptionalLong which will
 be empty if Process#pid() throws UnsupportedOperationException for any
 reason.

Closes #518