### PR TITLE
Fix Sonar issue: InterruptedException should not be ignored

### DIFF
--- a/src/main/java/org/kiwiproject/concurrent/AsyncException.java
+++ b/src/main/java/org/kiwiproject/concurrent/AsyncException.java
@@ -1,20 +1,25 @@
 package org.kiwiproject.concurrent;
 
+import static java.util.Objects.nonNull;
+
 import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 /**
  * A subclass {@link RuntimeException} used to indicate problems in asynchronous code.
+ * <p>
+ * The cause will generally be an {@link InterruptedException} or one of the checked exceptions thrown by Java's
+ * futures, specifically either {@link java.util.concurrent.TimeoutException} or
+ * {@link java.util.concurrent.ExecutionException}
  *
- * @implNote Sadly, we cannot make the {@link CompletableFuture} generic. It will not compile, and the compiler
+ * @implNote Sadly, we cannot make this class generic, i.e. {@code AsyncException<T>}. It will not compile; the compiler
  * reports the following error: "a generic class may not extend java.lang.Throwable". However, we can fake it
  * by declaring {@link #getFuture()} in a generic manner (and suppressing the unchecked warning). This means you
  * could still receive a {@link ClassCastException} at runtime if you attempt a cast to an invalid type.
  */
-@SuppressWarnings({"rawtypes", "java:S3740"})
 public class AsyncException extends RuntimeException {
 
-    private final transient CompletableFuture future;
+    private final transient CompletableFuture<?> future;
 
     /**
      * Construct instance with given message and future.
@@ -22,7 +27,7 @@ public class AsyncException extends RuntimeException {
      * @param message the exception message
      * @param future  the {@link CompletableFuture} that caused the error, may be null
      */
-    public AsyncException(String message, @Nullable CompletableFuture future) {
+    public AsyncException(String message, @Nullable CompletableFuture<?> future) {
         super(message);
         this.future = future;
     }
@@ -34,20 +39,35 @@ public class AsyncException extends RuntimeException {
      * @param cause   the original cause of the exception
      * @param future  the {@link CompletableFuture} that caused the error, may be null
      */
-    public AsyncException(String message, Throwable cause, @Nullable CompletableFuture future) {
+    public AsyncException(String message, Throwable cause, @Nullable CompletableFuture<?> future) {
         super(message, cause);
         this.future = future;
     }
 
     /**
-     * The future which causes the exception. May be null.
+     * Does this AsyncException contain a future?
+     *
+     * @return true if this instance contains a CompletableFuture
+     * @apiNote When a single asynchronous operation is performed and there is only one future, then callers can
+     * expect this to contain a CompletableFuture and return true. When multiple futures are acted upon (e.g. waiting
+     * for all to complete), callers should expect this instance not to contain a CompletableFuture and this method
+     * to return false.
+     */
+    public boolean hasFuture() {
+        return nonNull(future);
+    }
+
+    /**
+     * The future which causes the exception. May be null. Use {@link #hasFuture()} to check if this instance
+     * contains a future.
      *
      * @param <T> the generic type of the CompletableFuture
      * @return the future causing this exception, or null
+     * @throws ClassCastException if the type you assign you is not the actual type
      */
     @SuppressWarnings("unchecked")
     @Nullable
     public <T> CompletableFuture<T> getFuture() {
-        return future;
+        return (CompletableFuture<T>) future;
     }
 }

--- a/src/test/java/org/kiwiproject/concurrent/AsyncExceptionTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncExceptionTest.java
@@ -26,6 +26,7 @@ class AsyncExceptionTest {
 
         assertThat(ex.getMessage()).isEqualTo("boom!");
         assertThat(ex.getCause()).isSameAs(cause);
+        assertThat(ex.hasFuture()).isTrue();
         assertThat(ex.getFuture()).isSameAs(future);
     }
 
@@ -33,6 +34,7 @@ class AsyncExceptionTest {
     void shouldPermitNullFuture() {
         var ex = new AsyncException("kabloom!", null);
         assertThat(ex.getFuture()).isNull();
+        assertThat(ex.hasFuture()).isFalse();
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -227,7 +227,7 @@ class AsyncTest {
 
             assertThatThrownBy(() -> Async.waitFor(future, 5, TimeUnit.MILLISECONDS))
                     .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("Timeout occurred: maximum wait specified as 5 MILLISECONDS")
+                    .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
                     .hasCauseInstanceOf(TimeoutException.class);
 
             assertThat(task.getCurrentCount()).isZero();
@@ -274,7 +274,7 @@ class AsyncTest {
             var futures = List.of(future1, future2, future3);
             assertThatThrownBy(() -> Async.waitForAll(futures, 5, TimeUnit.MILLISECONDS))
                     .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("Timeout occurred: maximum wait specified as 5 MILLISECONDS")
+                    .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
                     .hasCauseInstanceOf(TimeoutException.class);
 
             assertThat(task1.getCurrentCount()).isZero();
@@ -325,7 +325,7 @@ class AsyncTest {
             var futures = List.of(future1, future2, future3);
             assertThatThrownBy(() -> Async.waitForAllIgnoringType(futures, 5, TimeUnit.MILLISECONDS))
                     .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("Timeout occurred: maximum wait specified as 5 MILLISECONDS")
+                    .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
                     .hasCauseInstanceOf(TimeoutException.class);
 
             assertThat(task1.getCurrentCount()).isZero();
@@ -351,7 +351,7 @@ class AsyncTest {
             assertThat(futureWithTimeout)
                     .hasFailedWithThrowableThat()
                     .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("Timeout occurred: maximum wait specified as 5 MILLISECONDS")
+                    .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
                     .hasCauseInstanceOf(TimeoutException.class);
 
             var thrown = catchThrowable(futureWithTimeout::get);
@@ -360,7 +360,7 @@ class AsyncTest {
                     .hasCauseExactlyInstanceOf(AsyncException.class);
 
             var cause = thrown.getCause();
-            assertThat(cause).hasMessage("Timeout occurred: maximum wait specified as 5 MILLISECONDS");
+            assertThat(cause).hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)");
         }
     }
 


### PR DESCRIPTION
I am not sure why Sonar is just now reporting this, given that the
rule (java:S2142) has been around since Jan 27, 2016. In any case,
Sonar flagged several places in Async where we were not properly
handling InterruptedException. This fixes those places, and in addition
changes the generic Exception to the detailed types that can be thrown
(ExecutionException and/ot TimeoutException) to make the code more
clear.

Also, replaced logAndThrowAsyncException with newAsyncException which
instantiates a new AsyncException. This makes the code in withMaxTimeout
less awkward since it doesn't need to have the "return null" statement
anymore, which was previously needed b/c the compiler was not able to
determine that logAndThrowAsyncException (always) throws an exception
and thus required the (never reachable) return statement.

Cleaned up the javadoc in AsyncException, as well as making the private
CompletableFuture field and constructor parameter have a wildcard
generic so that the 'rawtypes' and 'java:S3740' warning suppressions
can be removed.

Added a hasFuture method to AsyncException as a convenience method for
callers to use to check if the instance contains a future.