### PR TITLE
Bump GitHub cache action version from 2.1.4 to 2.1.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Cache all the things
       - name: Cache SonarCloud packages
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2.1.5
         if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -37,14 +37,14 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache Maven packages
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2.1.5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
       - name: Cache Embedded Mongo files
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v2.1.5
         with:
           path: ~/.embedmongo
           key: ${{ runner.os }}-embedmongo


### PR DESCRIPTION
Saw this updated on Dropwizard here:
https://github.com/dropwizard/dropwizard/pull/3872

Also see https://github.com/actions/cache/releases/tag/v2.1.5