### PR TITLE
Re-enable testScheduleCleanup_WithScheduledExecutor_UsingMultipleConcurrentCleaners_IntegrationTest on all platforms

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/config/TimeBasedDirectoryCleanerConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/config/TimeBasedDirectoryCleanerConfigTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.dropwizard.config;
 
 import static com.google.common.base.Preconditions.checkState;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_MAC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.awaitility.Awaitility.await;
@@ -153,7 +154,7 @@ class TimeBasedDirectoryCleanerConfigTest {
             testHelper.createDirectoriesWithFiles(1, 100);
 
             var cleaner1 = cleanerConfig.scheduleCleanupUsing(executorService1);
-            new DefaultEnvironment().sleepQuietly(400);
+            addDelayOnMacOS();
             var cleaner2 = cleanerConfig.scheduleCleanupUsing(executorService2);
 
             testHelper.createDirectoriesWithFiles(101, 200);
@@ -181,6 +182,13 @@ class TimeBasedDirectoryCleanerConfigTest {
         } finally {
             shutdownAndAwaitTermination(executorService1);
             shutdownAndAwaitTermination(executorService2);
+        }
+    }
+
+    private static void addDelayOnMacOS() {
+        // Add a slight delay on macOS to avoid the issues seen in #143
+        if (IS_OS_MAC) {
+            new DefaultEnvironment().sleepQuietly(400);
         }
     }
 

--- a/src/test/java/org/kiwiproject/dropwizard/config/TimeBasedDirectoryCleanerConfigTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/config/TimeBasedDirectoryCleanerConfigTest.java
@@ -26,11 +26,10 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.dropwizard.metrics.health.TimeBasedDirectoryCleanerHealthCheck;
 import org.kiwiproject.io.TimeBasedDirectoryCleaner;
 import org.kiwiproject.io.TimeBasedDirectoryCleanerTestHelper;
@@ -136,7 +135,6 @@ class TimeBasedDirectoryCleanerConfigTest {
      */
     @ParameterizedTest
     @ValueSource(ints = { 500, 2000 })
-    @EnabledOnOs(OS.LINUX)
     void testScheduleCleanup_WithScheduledExecutor_UsingMultipleConcurrentCleaners_IntegrationTest(int totalFileCount) throws InterruptedException {
         assertThat(TimeBasedDirectoryCleaner.capacityOfRecentDeleteErrors())
                 .describedAs("Assumption of cleaner error queue capacity of 500 is invalid; @ValueSource values need to be adjusted")
@@ -155,6 +153,7 @@ class TimeBasedDirectoryCleanerConfigTest {
             testHelper.createDirectoriesWithFiles(1, 100);
 
             var cleaner1 = cleanerConfig.scheduleCleanupUsing(executorService1);
+            new DefaultEnvironment().sleepQuietly(400);
             var cleaner2 = cleanerConfig.scheduleCleanupUsing(executorService2);
 
             testHelper.createDirectoriesWithFiles(101, 200);


### PR DESCRIPTION
The concurrent cleaners need to be created with a small buffer in between.  See #143 for details

Fixes #143