### PR TITLE
Add KiwiJerseyClients utility class for Jersey Client instances

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/client/KiwiJerseyClients.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/KiwiJerseyClients.java
@@ -1,0 +1,140 @@
+package org.kiwiproject.jaxrs.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import lombok.experimental.UtilityClass;
+import org.glassfish.jersey.client.ClientProperties;
+
+import javax.ws.rs.client.Client;
+import java.time.Duration;
+
+/**
+ * Static utilities related to <em>Jersey</em> {@link Client} instances. If these methods are used with a JAX-RS
+ * implementation other than Jersey, you should not expect anything to work. Some might fail silently, others could
+ * throw unexpected exceptions, etc.
+ * <p>
+ * <em>We do not check</em> to make sure the {@link Client} instances are in fact Jersey client instances; we expect if
+ * you are using a class named {@code KiwiJerseyClients} you understand this, and if not then, as they say, all bets are
+ * off.
+ */
+@UtilityClass
+public class KiwiJerseyClients {
+
+    /**
+     * Set connect timeout.
+     *
+     * @param client  the Jersey {@link Client} instance
+     * @param timeout the timeout as a Dropwizard {@link io.dropwizard.util.Duration}
+     * @return the provided Client instance
+     */
+    public static Client connectTimeout(Client client, io.dropwizard.util.Duration timeout) {
+        checkTimeoutNotNull(timeout);
+        return connectTimeout(client, timeout.toMilliseconds());
+    }
+
+    /**
+     * Set connect timeout.
+     *
+     * @param client  the Jersey {@link Client} instance
+     * @param timeout the timeout as a Java {@link Duration}
+     * @return the provided Client instance
+     */
+    public static Client connectTimeout(Client client, Duration timeout) {
+        checkTimeoutNotNull(timeout);
+        return connectTimeout(client, timeout.toMillis());
+    }
+
+    /**
+     * Set connect timeout.
+     *
+     * @param client        the Jersey {@link Client} instance
+     * @param timeoutMillis the {@code long} timeout in milliseconds
+     * @return the provided Client instance
+     */
+    public static Client connectTimeout(Client client, long timeoutMillis) {
+        checkTimeout(timeoutMillis);
+        return connectTimeout(client, Math.toIntExact(timeoutMillis));
+    }
+
+    /**
+     * Set connect timeout.
+     *
+     * @param client        the Jersey {@link Client} instance
+     * @param timeoutMillis the {@code int} timeout in milliseconds
+     * @return the provided Client instance
+     * @see ClientProperties#CONNECT_TIMEOUT
+     */
+    public static Client connectTimeout(Client client, int timeoutMillis) {
+        client.property(ClientProperties.CONNECT_TIMEOUT, timeoutMillis);
+        return client;
+    }
+
+    /**
+     * Set read timeout.
+     *
+     * @param client  the Jersey {@link Client} instance
+     * @param timeout the timeout as a Dropwizard {@link io.dropwizard.util.Duration}
+     * @return the provided Client instance
+     */
+    public static Client readTimeout(Client client, io.dropwizard.util.Duration timeout) {
+        checkTimeoutNotNull(timeout);
+        return readTimeout(client, timeout.toMilliseconds());
+    }
+
+    /**
+     * Set read timeout.
+     *
+     * @param client  the Jersey {@link Client} instance
+     * @param timeout the timeout as a Java {@link Duration}
+     * @return the provided Client instance
+     */
+    public static Client readTimeout(Client client, Duration timeout) {
+        checkTimeoutNotNull(timeout);
+        return readTimeout(client, timeout.toMillis());
+    }
+
+    private static void checkTimeoutNotNull(Object timeout) {
+        checkArgumentNotNull(timeout, "timeout must not be null");
+    }
+
+    /**
+     * Set read timeout.
+     *
+     * @param client        the Jersey {@link Client} instance
+     * @param timeoutMillis the {@code long} timeout in milliseconds
+     * @return the provided Client instance
+     */
+    public static Client readTimeout(Client client, long timeoutMillis) {
+        checkTimeout(timeoutMillis);
+        return readTimeout(client, Math.toIntExact(timeoutMillis));
+    }
+
+    /**
+     * Set read timeout.
+     *
+     * @param client        the Jersey {@link Client} instance
+     * @param timeoutMillis the {@code int} timeout in milliseconds
+     * @return the provided Client instance
+     * @see ClientProperties#READ_TIMEOUT
+     */
+    public static Client readTimeout(Client client, int timeoutMillis) {
+        client.property(ClientProperties.READ_TIMEOUT, timeoutMillis);
+        return client;
+    }
+
+    /**
+     * Check the given timeout, in milliseconds, to be used for a Jersey connect and/or read timeout.
+     *
+     * @param timeoutMillis the timeout to check, in milliseconds
+     * @throws IllegalArgumentException if the given number of milliseconds is greater than {@link Integer#MAX_VALUE}
+     * @see ClientProperties#CONNECT_TIMEOUT
+     * @see ClientProperties#READ_TIMEOUT
+     */
+    public static void checkTimeout(long timeoutMillis) {
+        checkArgument(timeoutMillis <= Integer.MAX_VALUE,
+                "timeout must be convertible to an int but %s is more than Integer.MAX_VALUE." +
+                        " See Jersey API docs for CONNECT_TIMEOUT and READ_TIMEOUT in ClientProperties",
+                timeoutMillis);
+    }
+}

--- a/src/test/java/org/kiwiproject/jaxrs/client/KiwiJerseyClientsTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/client/KiwiJerseyClientsTest.java
@@ -1,0 +1,236 @@
+package org.kiwiproject.jaxrs.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.ws.rs.client.Client;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+
+@DisplayName("KiwiJerseyClients")
+class KiwiJerseyClientsTest {
+
+    private static final long TOO_BIG_TIMEOUT = 1L + Integer.MAX_VALUE;
+
+    private Client client;
+
+    @BeforeEach
+    void setUp() {
+        client = JerseyClientBuilder.createClient();
+    }
+
+    @Nested
+    class ConnectTimeout {
+
+        @Nested
+        class DropwizardDuration {
+
+            @Test
+            void shouldNotAllowNullArgument() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.connectTimeout(client, (io.dropwizard.util.Duration) null));
+            }
+
+            @Test
+            void shouldNotAllowTimeoutsExceedingMaxInteger() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.connectTimeout(client, io.dropwizard.util.Duration.milliseconds(TOO_BIG_TIMEOUT)));
+            }
+
+            @Test
+            void shouldSetConnectTimeout() {
+                var updatedClient = KiwiJerseyClients.connectTimeout(client, io.dropwizard.util.Duration.seconds(5));
+
+                assertTimeout(client, updatedClient, ClientProperties.CONNECT_TIMEOUT, 5_000);
+            }
+        }
+
+        @Nested
+        class JavaDuration {
+
+            @Test
+            void shouldNotAllowNullArgument() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.connectTimeout(client, (Duration) null));
+            }
+
+            @Test
+            void shouldNotAllowTimeoutsExceedingMaxInteger() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.connectTimeout(client, Duration.ofMillis(TOO_BIG_TIMEOUT)));
+            }
+
+            @Test
+            void shouldSetConnectTimeout() {
+                var updatedClient = KiwiJerseyClients.connectTimeout(client, Duration.ofSeconds(10));
+
+                assertTimeout(client, updatedClient, ClientProperties.CONNECT_TIMEOUT, 10_000);
+            }
+        }
+
+        @Nested
+        class JavaLong {
+
+            @Test
+            void shouldNotAllowTimeoutsExceedingMaxInteger() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.connectTimeout(client, TOO_BIG_TIMEOUT));
+            }
+
+            @Test
+            void shouldSetConnectTimeout() {
+                var timeout = 3_500L;
+                var updatedClient = KiwiJerseyClients.connectTimeout(client, timeout);
+
+                assertTimeout(client, updatedClient, ClientProperties.CONNECT_TIMEOUT, (int) timeout);
+            }
+        }
+
+        @Nested
+        class JavaInt {
+
+            @Test
+            void shouldAcceptMaxIntegerAsTimeout() {
+                assertThatCode(() -> KiwiJerseyClients.connectTimeout(client, Integer.MAX_VALUE))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldSetConnectTimeout() {
+                var timeout = 4_200;
+                var updatedClient = KiwiJerseyClients.connectTimeout(client, timeout);
+
+                assertTimeout(client, updatedClient, ClientProperties.CONNECT_TIMEOUT, timeout);
+            }
+        }
+    }
+
+    @Nested
+    class ReadTimeout {
+
+        @Nested
+        class DropwizardDuration {
+
+            @Test
+            void shouldNotAllowNullArgument() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.readTimeout(client, (io.dropwizard.util.Duration) null));
+            }
+
+            @Test
+            void shouldNotAllowTimeoutsExceedingMaxInteger() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.readTimeout(client, io.dropwizard.util.Duration.milliseconds(TOO_BIG_TIMEOUT)));
+            }
+
+            @Test
+            void shouldSetReadTimeout() {
+                var updatedClient = KiwiJerseyClients.readTimeout(client, io.dropwizard.util.Duration.seconds(7));
+
+                assertTimeout(client, updatedClient, ClientProperties.READ_TIMEOUT, 7_000);
+            }
+        }
+
+        @Nested
+        class JavaDuration {
+
+            @Test
+            void shouldNotAllowNullArgument() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.readTimeout(client, (Duration) null));
+            }
+
+            @Test
+            void shouldNotAllowTimeoutsExceedingMaxInteger() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.readTimeout(client, Duration.ofMillis(TOO_BIG_TIMEOUT)));
+            }
+
+            @Test
+            void shouldSetReadTimeout() {
+                var updatedClient = KiwiJerseyClients.readTimeout(client, Duration.ofSeconds(3));
+
+                assertTimeout(client, updatedClient, ClientProperties.READ_TIMEOUT, 3_000);
+            }
+        }
+
+        @Nested
+        class JavaLong {
+
+            @Test
+            void shouldNotAllowTimeoutsExceedingMaxInteger() {
+                assertThatIllegalArgumentException().isThrownBy(() ->
+                        KiwiJerseyClients.readTimeout(client, TOO_BIG_TIMEOUT));
+            }
+
+            @Test
+            void shouldSetReadTimeout() {
+                var timeout = 1_500L;
+                var updatedClient = KiwiJerseyClients.readTimeout(client, timeout);
+
+                assertTimeout(client, updatedClient, ClientProperties.READ_TIMEOUT, (int) timeout);
+            }
+        }
+
+        @Nested
+        class JavaInt {
+
+            @Test
+            void shouldAcceptMaxIntegerAsTimeout() {
+                assertThatCode(() -> KiwiJerseyClients.readTimeout(client, Integer.MAX_VALUE))
+                        .doesNotThrowAnyException();
+            }
+
+            @Test
+            void shouldSetReadTimeout() {
+                var timeout = 4_000;
+                var updatedClient = KiwiJerseyClients.readTimeout(client, timeout);
+
+                assertTimeout(client, updatedClient, ClientProperties.READ_TIMEOUT, timeout);
+            }
+        }
+    }
+
+    @Nested
+    class CheckTimeout {
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.jaxrs.client.KiwiJerseyClientsTest#invalidTimeouts")
+        void shouldThrowIllegalArgumentExceptionForTimeoutsOverMaxInteger(long timeout) {
+            assertThatIllegalArgumentException().isThrownBy(() -> KiwiJerseyClients.checkTimeout(timeout))
+                    .withMessageStartingWith("timeout must be convertible to an int but %d is more than Integer.MAX_VALUE", timeout);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static Stream<Long> invalidTimeouts() {
+        return Stream.generate(() -> (long) Integer.MAX_VALUE + randomPositiveInt())
+                .limit(25);
+    }
+
+    private static int randomPositiveInt() {
+        return ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE);
+    }
+
+    private static void assertTimeout(Client originalClient, Client updatedClient, String timeoutProperty, int expectedTimeout) {
+        assertThat(updatedClient)
+                .describedAs("updatedClient should be same instance as originalClient")
+                .isSameAs(originalClient);
+
+        var actualTimeout = updatedClient.getConfiguration().getProperty(timeoutProperty);
+        assertThat(actualTimeout)
+                .describedAs("%s was not the expected value", timeoutProperty)
+                .isEqualTo(expectedTimeout);
+    }
+}


### PR DESCRIPTION
* Contains overloaded connectTimeout and readTimeout methods to set
  the connect and read timeouts, respectively, on a Jersey Client
* Exposes checkTimeout method since sometimes we want to validate the
  timeout directly.

Closes #557