### PR TITLE
Sonar cleanup for new 'var' rule

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiObjects.java
+++ b/src/main/java/org/kiwiproject/base/KiwiObjects.java
@@ -81,12 +81,12 @@ public class KiwiObjects {
      */
     @SafeVarargs
     public static <T> Optional<T> firstSuppliedNonNull(Supplier<T> first, Supplier<T> second, Supplier<T>... rest) {
-        T firstT = first.get();
+        var firstT = first.get();
         if (nonNull(firstT)) {
             return Optional.of(firstT);
         }
 
-        T secondT = second.get();
+        var secondT = second.get();
         if (nonNull(secondT)) {
             return Optional.of(secondT);
         }

--- a/src/main/java/org/kiwiproject/base/Versions.java
+++ b/src/main/java/org/kiwiproject/base/Versions.java
@@ -143,7 +143,7 @@ public class Versions {
     }
 
     private static int indexOfFirstUnequalOrLastCommonSegment(String[] leftParts, String[] rightParts) {
-        int pos = 0;
+        var pos = 0;
         while (pos < leftParts.length && pos < rightParts.length && leftParts[pos].equals(rightParts[pos])) {
             pos++;
         }

--- a/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
+++ b/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
@@ -278,7 +278,7 @@ public class ProcessHelper {
      */
     @VisibleForTesting
     Optional<Long> findChildProcessIdInternal(long parentProcessId, ProcessHelper processHelper) {
-        Process process = launchPgrepWithParentPidFlag(parentProcessId, processHelper);
+        var process = launchPgrepWithParentPidFlag(parentProcessId, processHelper);
         List<String> lines = readLinesFromInputStreamOf(process);
 
         if (lines.isEmpty()) {
@@ -309,7 +309,7 @@ public class ProcessHelper {
      */
     @VisibleForTesting
     Collection<Long> findChildProcessIdsInternal(long parentProcessId, ProcessHelper processHelper) {
-        Process process = launchPgrepWithParentPidFlag(parentProcessId, processHelper);
+        var process = launchPgrepWithParentPidFlag(parentProcessId, processHelper);
         Stream<String> stream = streamLinesFromInputStreamOf(process);
 
         return stream.map(Long::valueOf).collect(toList());

--- a/src/main/java/org/kiwiproject/base/process/Processes.java
+++ b/src/main/java/org/kiwiproject/base/process/Processes.java
@@ -307,7 +307,7 @@ public class Processes {
      */
     public static Process launch(List<String> command) {
         try {
-            return launchInternal(command);
+            return launchProcessInternal(command);
         } catch (IOException e) {
             throw new UncheckedIOException("Error launching command: " + command, e);
         }
@@ -349,7 +349,7 @@ public class Processes {
     public static List<Long> pgrep(String user, String commandLine) {
         try {
             List<String> command = buildPgrepCommand(user, commandLine);
-            Process process = launchInternal(command);
+            var process = launchProcessInternal(command);
 
             return streamLinesFromInputStreamOf(process)
                     .map(Long::valueOf)
@@ -418,7 +418,7 @@ public class Processes {
     public static List<String> pgrepList(String user, String commandLine) {
         try {
             List<String> command = buildPgrepListCommand(user, commandLine);
-            Process process = launchInternal(command);
+            var process = launchProcessInternal(command);
 
             return readLinesFromInputStreamOf(process);
         } catch (IOException e) {
@@ -543,7 +543,7 @@ public class Processes {
      */
     public static int kill(long processId, String signal, long timeout, TimeUnit unit, KillTimeoutAction action) {
         try {
-            Process killProcess = launchInternal("kill", KillSignal.withLeadingDash(signal), String.valueOf(processId));
+            var killProcess = launchProcessInternal("kill", KillSignal.withLeadingDash(signal), String.valueOf(processId));
 
             return killInternal(processId, killProcess, timeout, unit, action);
         } catch (IOException e) {
@@ -551,11 +551,11 @@ public class Processes {
         }
     }
 
-    private static Process launchInternal(String... commandLine) throws IOException {
-        return launchInternal(Lists.newArrayList(commandLine));
+    private static Process launchProcessInternal(String... commandLine) throws IOException {
+        return launchProcessInternal(Lists.newArrayList(commandLine));
     }
 
-    private static Process launchInternal(List<String> command) throws IOException {
+    private static Process launchProcessInternal(List<String> command) throws IOException {
         return new ProcessBuilder(command).start();
     }
 

--- a/src/main/java/org/kiwiproject/collect/KiwiMaps.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiMaps.java
@@ -118,8 +118,8 @@ public class KiwiMaps {
     @SuppressWarnings("unchecked")
     private static <K, V> void populate(Map<K, V> map, Object... items) {
         for (var i = 0; i < items.length; i += 2) {
-            K key = (K) items[i];
-            V value = (V) items[i + 1];
+            var key = (K) items[i];
+            var value = (V) items[i + 1];
             map.put(key, value);
         }
     }

--- a/src/main/java/org/kiwiproject/collect/KiwiProperties.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiProperties.java
@@ -88,7 +88,7 @@ public class KiwiProperties {
      */
     public static Properties newProperties(Map<String, String> map) {
         requireNonNull(map);
-        Properties properties = new Properties();
+        var properties = new Properties();
         properties.putAll(map);
         return properties;
     }

--- a/src/main/java/org/kiwiproject/concurrent/TryLocker.java
+++ b/src/main/java/org/kiwiproject/concurrent/TryLocker.java
@@ -164,7 +164,7 @@ public class TryLocker {
     private <T> T getWithLockOrNull(Supplier<T> withLockSupplier) {
         checkArgumentNotNull(withLockSupplier);
 
-        boolean gotLock = false;
+        var gotLock = false;
         T result = null;
         try {
             gotLock = lock.tryLock(lockWaitTime, lockWaitTimeUnit);

--- a/src/main/java/org/kiwiproject/hibernate/usertype/AbstractArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/AbstractArrayUserType.java
@@ -8,7 +8,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.usertype.UserType;
 
 import java.io.Serializable;
-import java.sql.Array;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -74,7 +73,7 @@ public abstract class AbstractArrayUserType implements UserType {
             statement.setNull(index, SQL_TYPES[0]);
         } else {
             var castObject = (Object[]) value;
-            Array sqlArray = session.connection().createArrayOf(databaseTypeName(), castObject);
+            var sqlArray = session.connection().createArrayOf(databaseTypeName(), castObject);
             statement.setArray(index, sqlArray);
         }
     }

--- a/src/main/java/org/kiwiproject/jsch/SftpConnector.java
+++ b/src/main/java/org/kiwiproject/jsch/SftpConnector.java
@@ -7,7 +7,6 @@ import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
-import com.jcraft.jsch.Channel;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
@@ -122,7 +121,7 @@ public class SftpConnector {
             session.connect();
 
             LOG.debug("Session connected: {}", session.isConnected());
-            Channel channel = session.openChannel("sftp");
+            var channel = session.openChannel("sftp");
 
             LOG.debug("Attempt openChannel using timeout: {} millis", config.getTimeout().toMilliseconds());
             channel.connect(Ints.checkedCast(config.getTimeout().toMilliseconds()));

--- a/src/main/java/org/kiwiproject/jsch/SftpTransfers.java
+++ b/src/main/java/org/kiwiproject/jsch/SftpTransfers.java
@@ -153,10 +153,10 @@ public class SftpTransfers {
         connector.runCommand(channel -> {
             changeToRemoteDirectory(channel, remotePath);
 
-            Path localPath = localPathSupplier.apply(remotePath, remoteFilename);
+            var localPath = localPathSupplier.apply(remotePath, remoteFilename);
             ensureLocalDirectoryExists(localPath);
 
-            try (InputStream inputStream = channel.get(remoteFilename)) {
+            try (var inputStream = channel.get(remoteFilename)) {
                 var resolvedLocalPath = localPath.resolve(localFilenameSupplier.apply(remotePath, remoteFilename));
                 Files.copy(inputStream, resolvedLocalPath, StandardCopyOption.REPLACE_EXISTING);
             }
@@ -182,7 +182,7 @@ public class SftpTransfers {
         return connector.runCommandWithResponse(channel -> {
             changeToRemoteDirectory(channel, remotePath);
 
-            try (InputStream inputStream = channel.get(remoteFilename)) {
+            try (var inputStream = channel.get(remoteFilename)) {
                 var streamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
                 var stringWriter = new StringWriter();
                 streamReader.transferTo(stringWriter);

--- a/src/main/java/org/kiwiproject/retry/SimpleRetries.java
+++ b/src/main/java/org/kiwiproject/retry/SimpleRetries.java
@@ -152,7 +152,7 @@ public class SimpleRetries {
         return currentAttempt -> {
             RetryLogger.logAttempt(LOG, level, currentAttempt, ATTEMPT_MSG_TEMPLATE, currentAttempt, maxAttempts, type);
 
-            T object = safeGetOrNull(currentAttempt, maxAttempts, type, level, supplier);
+            var object = safeGetOrNull(currentAttempt, maxAttempts, type, level, supplier);
 
             if (isNull(object) && currentAttempt < maxAttempts) {
                 environment.sleepQuietly(retryDelay, retryDelayUnit);
@@ -330,7 +330,7 @@ public class SimpleRetries {
 
         List<Pair<T, Exception>> results = new ArrayList<>();
 
-        for (int currentAttempt = 1; currentAttempt <= maxAttempts; currentAttempt++) {
+        for (var currentAttempt = 1; currentAttempt <= maxAttempts; currentAttempt++) {
             Pair<T, Exception> resultOrError =
                     resultOrErrorPair(currentAttempt, maxAttempts, retryDelay, retryDelayUnit, environment, type, level, supplier);
 


### PR DESCRIPTION
* Updated all the places Sonar flagged for LVTI. Some places weren't
  a big deal (e.g. int pos -> var pos) but it also makes our codebase
  more consistent, since we prefer LVTI where we can and where the type
  is obvious, combined with good names of variables.
* In Processes, renamed launchInternal to launchProcessInternal to
  make the return type more clear with the LVTI.