### PR TITLE
Fix NPEs in WebTargetHelper for null/empty/blank query parameter names

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
@@ -96,7 +96,7 @@ public class WebTargetHelper {
      * @param webTarget the WebTarget to wrap
      */
     WebTargetHelper(WebTarget webTarget) {
-        this.webTarget = requireNotNull(webTarget);
+        this.webTarget = requireNotNull(webTarget, "webTarget must not be null");
     }
 
     /**
@@ -123,9 +123,10 @@ public class WebTargetHelper {
      * @param name  the parameter name
      * @param value the parameter value
      * @return this instance
-     * @throws IllegalArgumentException if value is null
+     * @throws IllegalArgumentException if name is blank or value is null
      */
     public WebTargetHelper queryParamRequireNotNull(String name, Object value) {
+        checkArgumentNotBlank(name, "name cannot be blank");
         checkArgumentNotNull(value, "value cannot be null for parameter %s", name);
 
         var newWebTarget = webTarget.queryParam(name, value);
@@ -133,27 +134,30 @@ public class WebTargetHelper {
     }
 
     /**
-     * Add the given query parameter only if it is not null.
+     * Add the given query parameter only if name is not blank and value is not null.
      *
      * @param name  the parameter name
      * @param value the parameter value
      * @return this instance
      */
     public WebTargetHelper queryParamIfNotNull(String name, Object value) {
-        var newWebTarget = this.webTarget.queryParam(name, value);
+        if (isBlank(name) || isNull(value)) {
+            return this;
+        }
 
-        return isNull(value) ? this : new WebTargetHelper(newWebTarget);
+        var newWebTarget = this.webTarget.queryParam(name, value);
+        return new WebTargetHelper(newWebTarget);
     }
 
     /**
-     * Adds any non-null values to the the given query parameter.
+     * Adds any non-null values to the the given query parameter. If name is blank, this is a no-op.
      *
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotNull(String name, Object... values) {
-        if (isNullOrEmpty(values)) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
         }
 
@@ -161,14 +165,14 @@ public class WebTargetHelper {
     }
 
     /**
-     * Adds any non-null values to the the given query parameter.
+     * Adds any non-null values to the the given query parameter. If name is blank, this is a no-op.
      *
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotNull(String name, List<Object> values) {
-        if (isNullOrEmpty(values)) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
         }
 
@@ -176,14 +180,14 @@ public class WebTargetHelper {
     }
 
     /**
-     * Adds any non-null values to the the given query parameter.
+     * Adds any non-null values to the the given query parameter. If name is blank, this is a no-op.
      *
      * @param name   the parameter name
      * @param stream containing one or more parameter values
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotNull(String name, Stream<Object> stream) {
-        if (isNull(stream)) {
+        if (isBlank(name) || isNull(stream)) {
             return this;
         }
 
@@ -201,9 +205,10 @@ public class WebTargetHelper {
      * @param name  the parameter name
      * @param value the parameter value
      * @return this instance
-     * @throws IllegalArgumentException if value is blank
+     * @throws IllegalArgumentException if name or value is blank
      */
     public WebTargetHelper queryParamRequireNotBlank(String name, String value) {
+        checkArgumentNotBlank(name, "name cannot be blank");
         checkArgumentNotBlank(value, "value cannot be blank for parameter %s", name);
 
         var newWebTarget = webTarget.queryParam(name, value);
@@ -211,27 +216,30 @@ public class WebTargetHelper {
     }
 
     /**
-     * Add the given query parameter only if it is not blank.
+     * Add the given query parameter only if both name and value are not blank.
      *
      * @param name  the parameter name
      * @param value the parameter value
      * @return this instance
      */
     public WebTargetHelper queryParamIfNotBlank(String name, String value) {
-        var newWebTarget = this.webTarget.queryParam(name, value);
+        if (isBlank(name) || isBlank(value)) {
+            return this;
+        }
 
-        return isBlank(value) ? this : new WebTargetHelper(newWebTarget);
+        var newWebTarget = this.webTarget.queryParam(name, value);
+        return new WebTargetHelper(newWebTarget);
     }
 
     /**
-     * Adds any non-blank values to the the given query parameter.
+     * Adds any non-blank values to the the given query parameter. If name is blank, this is a no-op.
      *
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotBlank(String name, String... values) {
-        if (isNullOrEmpty(values)) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
         }
 
@@ -239,14 +247,14 @@ public class WebTargetHelper {
     }
 
     /**
-     * Adds any non-blank values to the the given query parameter.
+     * Adds any non-blank values to the the given query parameter. If name is blank, this is a no-op.
      *
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotBlank(String name, List<String> values) {
-        if (isNullOrEmpty(values)) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
         }
 
@@ -254,14 +262,14 @@ public class WebTargetHelper {
     }
 
     /**
-     * Adds any non-blank values to the the given query parameter.
+     * Adds any non-blank values to the the given query parameter. If name is blank, this is a no-op.
      *
      * @param name   the parameter name
      * @param stream containing one or more parameter values
      * @return this instance
      */
     public WebTargetHelper queryParamFilterNotBlank(String name, Stream<String> stream) {
-        if (isNull(stream)) {
+        if (isBlank(name) || isNull(stream)) {
             return this;
         }
 

--- a/src/test/java/org/kiwiproject/jaxrs/client/WebTargetHelperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/client/WebTargetHelperTest.java
@@ -48,7 +48,26 @@ class WebTargetHelperTest {
     }
 
     @Nested
+    class WithWebTarget {
+
+        @Test
+        void shouldThrow_WhenGivenNullWebTarget() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> withWebTarget(null))
+                    .withMessage("webTarget must not be null");
+        }
+    }
+
+    @Nested
     class QueryParamRequireNotNull {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldThrow_WhenGivenNullOrEmptyName(String name) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> withWebTarget(originalWebTarget).queryParamRequireNotNull(name, "a value"))
+                    .withMessage("name cannot be blank");
+        }
 
         @Test
         void shouldThrow_WhenGivenNullValue() {
@@ -80,6 +99,16 @@ class WebTargetHelperTest {
     class QueryParamIfNotNull {
 
         @Test
+        void shouldReturnSameInstanceWithNoQuery_WhenGivenNullOrEmptyName() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamIfNotNull("", "value 1")
+                    .queryParamIfNotNull(" ", "value 2")
+                    .queryParamIfNotNull(null, "value 3");
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
         void shouldReturnSameInstanceWithNoQuery_WhenGivenOnlyNullValues() {
             var newWebTarget = withWebTarget(originalWebTarget)
                     .queryParamIfNotNull("foo", null)
@@ -96,7 +125,8 @@ class WebTargetHelperTest {
                     .queryParamIfNotNull("page", 42)
                     .queryParamIfNotNull("limit", 25)
                     .queryParamIfNotNull("sort", null)
-                    .queryParamIfNotNull("sortDir", null);
+                    .queryParamIfNotNull("sortDir", null)
+                    .queryParamIfNotNull("", "en/US");
 
             assertThat(newWebTarget.getUri()).hasQuery("q=pangram&page=42&limit=25");
         }
@@ -107,6 +137,15 @@ class WebTargetHelperTest {
 
         @Nested
         class WhenArray {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull(name, 1, 2, 3);
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
 
             @ParameterizedTest
             @NullAndEmptySource
@@ -131,6 +170,15 @@ class WebTargetHelperTest {
 
             @ParameterizedTest
             @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull(name, List.of(1, 2, 3));
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @ParameterizedTest
+            @NullAndEmptySource
             void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(List<Object> values) {
                 var newWebTarget = withWebTarget(originalWebTarget)
                         .queryParamFilterNotNull("foo", values);
@@ -149,6 +197,15 @@ class WebTargetHelperTest {
 
         @Nested
         class WhenStream {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotNull(name, Stream.of(1, 2, 3));
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
 
             @ParameterizedTest
             @NullSource
@@ -180,6 +237,14 @@ class WebTargetHelperTest {
     @Nested
     class QueryParamRequireNotBlank {
 
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldThrow_WhenGivenNullOrEmptyName(String name) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> withWebTarget(originalWebTarget).queryParamRequireNotBlank(name, "a value"))
+                    .withMessage("name cannot be blank");
+        }
+
         @Test
         void shouldThrow_WhenGivenNullValue() {
             assertThatIllegalArgumentException()
@@ -210,11 +275,23 @@ class WebTargetHelperTest {
     class QueryParamIfNotBlank {
 
         @Test
+        void shouldReturnSameInstanceWithNoQuery_WhenGivenNullOrEmptyName() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamIfNotBlank("", "value 1")
+                    .queryParamIfNotBlank(" ", "value 2")
+                    .queryParamIfNotBlank(null, "value 3");
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
         void shouldReturnSameInstance_WhenGivenBlank() {
             var newWebTarget = withWebTarget(originalWebTarget)
                     .queryParamIfNotBlank("foo", "")
                     .queryParamIfNotBlank("bar", " ")
                     .queryParamIfNotBlank("misc", null)
+                    .queryParamIfNotBlank("", "a value")
+                    .queryParamIfNotBlank(null, "another value")
                     .queryParamIfNotBlank("baz", "\t  \n");
 
             assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
@@ -242,6 +319,15 @@ class WebTargetHelperTest {
 
             @ParameterizedTest
             @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank(name, "a", "b", "c");
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @ParameterizedTest
+            @NullAndEmptySource
             void shouldReturnSameInstance_WhenNullOrEmpty(String[] values) {
                 var newWebTarget = withWebTarget(originalWebTarget)
                         .queryParamFilterNotBlank("foo", values);
@@ -264,6 +350,15 @@ class WebTargetHelperTest {
 
             @ParameterizedTest
             @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank(name, List.of("a", "b", "c"));
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
+
+            @ParameterizedTest
+            @NullAndEmptySource
             void shouldReturnSameInstance_WhenNullOrEmpty(List<String> values) {
                 var newWebTarget = withWebTarget(originalWebTarget)
                         .queryParamFilterNotBlank("foo", values);
@@ -283,6 +378,15 @@ class WebTargetHelperTest {
 
         @Nested
         class WhenStream {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+                var newWebTarget = withWebTarget(originalWebTarget)
+                        .queryParamFilterNotBlank(name, Stream.of("a", "b", "c"));
+
+                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            }
 
             @ParameterizedTest
             @NullSource


### PR DESCRIPTION
* Throw IllegalArgumentException if a null WebTarget is supplied to the
  package-private constructor
* queryParamRequireNotNull now throws IllegalArgumentException if given
  a blank query parameter name
* queryParamIfNotNull and queryParamIfNotBlank methods are now no-ops
  when given blank query parameter name
* queryParamFilterNotNull and queryParamIfNotBlank methods are now
  no-ops if given a blank query parameter name
* queryParamIfNotNull and queryParamIfNotBlank now only call queryParam
  on this.webTarget if name and value are both present; the previous
  behavior was inefficient since it always called queryParam before
  checking the value. Now they only do the work that is actually needed.

Closes #574