### PR TITLE
Add new methods to KiwiEntities to read entity with default message

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/KiwiEntities.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiEntities.java
@@ -1,11 +1,15 @@
 package org.kiwiproject.jaxrs;
 
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * Static utilities related to reading entities from a {@link Response}.
@@ -22,6 +26,31 @@ public class KiwiEntities {
      */
     public static Optional<String> safeReadEntity(Response response) {
         return safeReadEntity(response, String.class);
+    }
+
+    /**
+     * Read an entity as a String from the given response. If it cannot be read, return a default message.
+     *
+     * @param response       the response object
+     * @param defaultMessage a default message to return if the response entity cannot be read (can be null)
+     * @return the response entity as a String or the given default message
+     */
+    public static String safeReadEntity(Response response, @Nullable String defaultMessage) {
+        return safeReadEntity(response).orElse(defaultMessage);
+    }
+
+    /**
+     * Read an entity as a String from the given response. If it cannot be read, call the given {@link Supplier} to
+     * get the default message.
+     *
+     * @param response               the response object
+     * @param defaultMessageSupplier supplies a default message if the response entity cannot be read
+     *                               (the Supplier can return null, but the Supplier itself must not be null)
+     * @return the response entity as a String or the message supplied by the given Supplier
+     */
+    public static String safeReadEntity(Response response, Supplier<String> defaultMessageSupplier) {
+        checkArgumentNotNull(defaultMessageSupplier, "defaultMessageSupplier must not be null");
+        return safeReadEntity(response).orElseGet(defaultMessageSupplier);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiEntitiesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiEntitiesTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import java.util.Map;
@@ -40,6 +41,50 @@ class KiwiEntitiesTest {
 
             Optional<String> entity = KiwiEntities.safeReadEntity(response);
             assertThat(entity).isEmpty();
+        }
+    }
+
+    @Nested
+    class SafeReadEntityAsStringWithDefaultMessage {
+
+        @Test
+        void shouldGetEntity_WhenReadSucceeds() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenReturn("the entity");
+
+            var entity = KiwiEntities.safeReadEntity(response, "default message");
+            assertThat(entity).isEqualTo("the entity");
+        }
+
+        @Test
+        void shouldReturnDefaultMessage_WhenReadFails() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenThrow(new ProcessingException("oops"));
+
+            var entity = KiwiEntities.safeReadEntity(response, "default message");
+            assertThat(entity).isEqualTo("default message");
+        }
+    }
+
+    @Nested
+    class SafeReadEntityAsStringWithDefaultMessageSupplier {
+
+        @Test
+        void shouldGetEntity_WhenReadSucceeds() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenReturn("the entity");
+
+            var entity = KiwiEntities.safeReadEntity(response, () -> "default message");
+            assertThat(entity).isEqualTo("the entity");
+        }
+
+        @Test
+        void shouldReturnDefaultMessage_WhenReadFails() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenThrow(new ProcessingException("oops"));
+
+            var entity = KiwiEntities.safeReadEntity(response, () -> "default message");
+            assertThat(entity).isEqualTo("default message");
         }
     }
 


### PR DESCRIPTION
* Add overloaded safeReadEntity methods that accept a default message
  and a Supplier of a default message

Closes #584