### PR TITLE
Clarify usage of JAX/Jakarta RS utility classes in Javadoc

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/KiwiResources.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiResources.java
@@ -17,15 +17,18 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Static utilities for use in JAX-RS resource classes.
+ * Static utilities for use in JAX-RS resource classes. Contains utilities for verifying entities (e.g. obtained from
+ * a service or data access class), factories for creating new responses, and for validating query parameters.
  *
  * @apiNote Some methods in this class accept {@link Optional} arguments, which we know is considered a code smell
  * by various people and analysis tools such as IntelliJ's inspections, Sonar, etc. However, we also like to return
  * {@link Optional} from data access code (e.g. a DAO "findById" method where the object might not exist if it was
  * recently deleted). In such cases, we can simply take the Optional returned by those finder methods and pass them
  * directly to the utilities provided here without needing to call additional methods, for example without needing to
- * call {@code orElse(null)}. So, we acknowledge that it is generally not good to accept {@link Optional} arguments
+ * call {@code orElse(null)}. So, we acknowledge that it is generally not good to accept {@link Optional} arguments,
  * but we're trading off convenience in this class against "generally accepted" practice.
+ * @see KiwiResponses
+ * @see KiwiStandardResponses
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @UtilityClass

--- a/src/main/java/org/kiwiproject/jaxrs/KiwiResponses.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiResponses.java
@@ -14,7 +14,15 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * Static utilities related to JAX-RS responses.
+ * Static utilities related to evaluating and acting upon JAX-RS responses. For example, this class contains utilities
+ * to determine whether responses are successful or not, whether they are a specific type of response, and to perform
+ * actions (or throw exceptions) based on success or failure.
+ * <p>
+ * These utilities are intended mainly to be used in classes that make HTTP requests and need to evaluate and/or take
+ * action with the HTTP responses.
+ *
+ * @see KiwiResources
+ * @see KiwiStandardResponses
  */
 @UtilityClass
 @Slf4j
@@ -24,7 +32,7 @@ public class KiwiResponses {
 
     /**
      * Return a media type suitable for use as the value of a corresponding HTTP header. This will consist
-     * of the primary type and and subtype, e.g. {@code application/json}.
+     * of the primary type and subtype, e.g. {@code application/json}.
      *
      * @param response the response object
      * @return Optional that may or may not contain a media type

--- a/src/main/java/org/kiwiproject/jaxrs/KiwiStandardResponses.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiStandardResponses.java
@@ -19,6 +19,8 @@ import java.util.Optional;
  * what should be in responses for common HTTP methods in a REST-based interface using JSON as the primary
  * data format.
  * <p>
+ * These utilities are intended for use within JAX-RS resource classes.
+ * <p>
  * One specific thing to note is that the content type is always set to {@link MediaType#APPLICATION_JSON}, since
  * the primary use case of this class assumes JSON-based REST interfaces. You can change the content type by
  * using the methods that return a response builder and call one of the {@code type()} methods with a
@@ -30,8 +32,10 @@ import java.util.Optional;
  * {@link Optional} from data access code (e.g. a DAO "findById" method where the object might not exist if it was
  * recently deleted). In such cases, we can simply take the Optional returned by those finder methods and pass them
  * directly to the utilities provided here without needing to call additional methods, for example without needing to
- * call {@code orElse(null)}. So, we acknowledge that it is generally not good to accept {@link Optional} arguments
+ * call {@code orElse(null)}. So, we acknowledge that it is generally not good to accept {@link Optional} arguments,
  * but we're trading off convenience in this class against "generally accepted" practice.
+ * @see KiwiResources
+ * @see KiwiResponses
  */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @UtilityClass


### PR DESCRIPTION
Enhance Javadoc in KiwiResources, KiwiResponses, and KiwiStandardResponses
to make it more clear what the intent of each separate class actually is
and why they are actually separate classes, rather than jamming all of
them into one much larger class. Also, fix a few minor grammatical errors.