### PR TITLE
Rename "fromResponseBufferingEntity" methods in KiwiResources

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/KiwiResources.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiResources.java
@@ -287,7 +287,7 @@ public class KiwiResources {
 
     /**
      * Convenience wrapper around {@link Response#fromResponse(Response)} that also buffers the response entity by
-     * calling {@link Response#bufferEntity()} on the original response. This returns a {@link Response} instead of a
+     * calling {@link Response#bufferEntity()} on the given response. This returns a {@link Response} instead of a
      * response builder.
      * <p>
      * NOTE: The reason this method exists is due to the note in the Javadoc of {@link Response#fromResponse(Response)}
@@ -302,13 +302,13 @@ public class KiwiResources {
      * @see Response#fromResponse(Response)
      * @see Response#bufferEntity()
      */
-    public static Response fromResponseBufferingEntity(Response originalResponse) {
-        return fromResponseBufferingEntityBuilder(originalResponse).build();
+    public static Response newResponseBufferingEntityFrom(Response originalResponse) {
+        return newResponseBuilderBufferingEntityFrom(originalResponse).build();
     }
 
     /**
      * Convenience wrapper around {@link Response#fromResponse(Response)} that also buffers the response entity by
-     * calling {@link Response#bufferEntity()} on the original response.
+     * calling {@link Response#bufferEntity()} on the given response.
      * <p>
      * NOTE: The reason this method exists is due to the note in the Javadoc of {@link Response#fromResponse(Response)}
      * which states: <em>"Note that if the entity is backed by an un-consumed input stream, the reference to the stream
@@ -322,7 +322,7 @@ public class KiwiResources {
      * @see Response#fromResponse(Response)
      * @see Response#bufferEntity()
      */
-    public static Response.ResponseBuilder fromResponseBufferingEntityBuilder(Response originalResponse) {
+    public static Response.ResponseBuilder newResponseBuilderBufferingEntityFrom(Response originalResponse) {
         var wasBuffered = originalResponse.bufferEntity();
 
         if (!wasBuffered) {

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
@@ -301,7 +301,7 @@ class KiwiResourcesTest {
     }
 
     /**
-     * A test resource class for {@link FromResponseBufferingEntity}
+     * A test resource class for {@link NewResponseBufferingEntityFrom}
      */
     @Path("/from-response")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -335,7 +335,7 @@ class KiwiResourcesTest {
     }
 
     @Nested
-    class FromResponseBufferingEntity {
+    class NewResponseBufferingEntityFrom {
 
         private Client client;
 
@@ -353,7 +353,7 @@ class KiwiResourcesTest {
         void shouldCopyHeaders() {
             var originalResponse = RESOURCES.client().target("/from-response/with-entity").request().get();
 
-            var response = KiwiResources.fromResponseBufferingEntity(originalResponse);
+            var response = KiwiResources.newResponseBufferingEntityFrom(originalResponse);
             assertOkResponse(response);
 
             assertCustomHeaderFirstValue(response, "Header-1", "Value 1");
@@ -364,7 +364,7 @@ class KiwiResourcesTest {
         void shouldBufferEntity() throws IOException {
             var originalResponse = RESOURCES.client().target("/from-response/with-entity").request().get();
 
-            var response = KiwiResources.fromResponseBufferingEntity(originalResponse);
+            var response = KiwiResources.newResponseBufferingEntityFrom(originalResponse);
             assertOkResponse(response);
 
             assertEntity(response);
@@ -377,7 +377,7 @@ class KiwiResourcesTest {
             var wasBuffered = originalResponse.bufferEntity();
             verify(wasBuffered);
 
-            var response = KiwiResources.fromResponseBufferingEntity(originalResponse);
+            var response = KiwiResources.newResponseBufferingEntityFrom(originalResponse);
             assertOkResponse(response);
 
             assertEntity(response);
@@ -406,14 +406,14 @@ class KiwiResourcesTest {
 
             assertThatIllegalStateException()
                     .describedAs("Should not be able to buffer when entity was already consumed")
-                    .isThrownBy(() -> KiwiResources.fromResponseBufferingEntity(originalResponse));
+                    .isThrownBy(() -> KiwiResources.newResponseBufferingEntityFrom(originalResponse));
         }
 
         @Test
         void shouldWorkWhen_OriginalResponse_HasNoEntity() {
             var originalResponse = RESOURCES.client().target("/from-response/no-entity").request().get();
 
-            var response = KiwiResources.fromResponseBufferingEntity(originalResponse);
+            var response = KiwiResources.newResponseBufferingEntityFrom(originalResponse);
             assertOkResponse(response);
 
             assertCustomHeaderFirstValue(response, "Header-A", "Value A");
@@ -439,7 +439,7 @@ class KiwiResourcesTest {
         @Test
         void shouldIgnore_WhenBufferingOutboundResponse_ContainingNoEntity() {
             var originalOutboundResponse = Response.ok().build();
-            var bufferedOutboundResponse = KiwiResources.fromResponseBufferingEntity(originalOutboundResponse);
+            var bufferedOutboundResponse = KiwiResources.newResponseBufferingEntityFrom(originalOutboundResponse);
 
             assertThat(bufferedOutboundResponse.hasEntity()).isFalse();
         }


### PR DESCRIPTION
* Rename fromResponseBufferingEntity to newResponseBufferingEntityFrom
* Rename fromResponseBufferingEntityBuilder to
  newResponseBuilderBufferingEntityFrom

NOTE:
These aren't breaking changes because they are not in any release yet.

Closes #590