### PR TITLE
Don't assume default Mongo port is open in PagingQueryEmbeddedMongoTest

### DIFF
--- a/src/test/java/org/kiwiproject/spring/data/PagingQueryEmbeddedMongoTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingQueryEmbeddedMongoTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.kiwiproject.net.LocalPortChecker;
 import org.kiwiproject.search.KiwiSearching;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -61,7 +62,10 @@ class PagingQueryEmbeddedMongoTest {
     @BeforeAll
     static void beforeAll() throws Exception {
         var ip = "localhost";
-        var port = 27017;
+
+        // Attempt to get the default Mongo port (27017), or get first available port above it
+        var port = new LocalPortChecker().findFirstOpenPortAbove(27016).orElseThrow();
+        LOG.info("Using port {}", port);
 
         var mongoConfig = MongodConfig.builder()
                 .version(MONGODB_VERSION)


### PR DESCRIPTION
* Change PagingQueryEmbeddedMongoTest so that it doesn't just assume the
  default Mongo port (27017) is open and attempt to start the embedded
  Mongo server anyway. Instead, use LocalPortChecker to find the first
  port available starting with 27017. This will allow the test to run
  if there is actually a local Mongo server running.