### PR TITLE
Add custom Jackson deserializer ListToCsvStringDeserializer

### DIFF
--- a/src/main/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializer.java
+++ b/src/main/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializer.java
@@ -1,0 +1,82 @@
+package org.kiwiproject.jackson.ser;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.joining;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+import java.io.IOException;
+import java.util.stream.IntStream;
+
+/**
+ * Custom Jackson {@link JsonDeserializer} to examine a node and take different action based on whether it is
+ * a {@link TextNode} or a container node. If it is a TextNode, return the node's text, otherwise collect the
+ * values in the container and join them into a CSV string.
+ * <p>
+ * This implementation does not perform extensive error checking; it assumes the element being deserialized
+ * contains either a TextNode or is a container of TextNode. If a TextNode, it assumes the content is CSV but does
+ * not verify. For example, as a TextNode in YAML:
+ *
+ * <pre>
+ * someProperty: value1,value2,value3
+ * </pre>
+ * <p>
+ * And as a container node:
+ *
+ * <pre>
+ * someProperty:
+ *   - value1
+ *   - value2
+ *   - value3
+ * </pre>
+ * <p>
+ * Both of the above YAML configurations will result in the value "value1,value2,value3".
+ *
+ * @implNote The deserialization requires {@link JsonParser#getCodec()} to return a non-null codec and will throw an
+ * {@link IllegalStateException} if the returned codec is null.
+ */
+public class ListToCsvStringDeserializer extends StdDeserializer<String> {
+
+    @SuppressWarnings("WeakerAccess")
+    public ListToCsvStringDeserializer() {
+        super(String.class);
+    }
+
+    @Override
+    public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        var codec = parser.getCodec();
+        checkState(nonNull(codec),
+                "There is no codec associated with the parser; a codec is required to read the content as a tree");
+
+        var treeNode = codec.readTree(parser);
+
+        if (treeNode.isContainerNode()) {
+            return containerNodeToCsvString(treeNode);
+        }
+
+        return verifyIsTextNode(treeNode).asText();
+    }
+
+    private static String containerNodeToCsvString(TreeNode treeNode) {
+        return IntStream.range(0, treeNode.size())
+                .mapToObj(index -> textNodeToString(treeNode, index))
+                .collect(joining(","));
+    }
+
+    private static String textNodeToString(TreeNode treeNode, int index) {
+        var node = treeNode.get(index);
+        return verifyIsTextNode(node).asText();
+    }
+
+    private static TextNode verifyIsTextNode(TreeNode node) {
+        verify(node instanceof TextNode, "expected node to be TextNode but was: %s", node.getClass().getName());
+        return (TextNode) node;
+    }
+}

--- a/src/test/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializerTest.java
@@ -1,0 +1,110 @@
+package org.kiwiproject.jackson.ser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.internal.Fixtures;
+import org.kiwiproject.json.JsonHelper;
+import org.kiwiproject.yaml.YamlHelper;
+
+@DisplayName("ListToCsvStringDeserializer")
+class ListToCsvStringDeserializerTest {
+
+    @Test
+    void shouldRequireNonNullCodecToReadObjectAsTree() {
+        var deserializer = new ListToCsvStringDeserializer();
+
+        var parser = mock(JsonParser.class);
+        when(parser.getCodec()).thenReturn(null);
+
+        assertThatIllegalStateException()
+                .isThrownBy(() -> deserializer.deserialize(parser, null))
+                .withMessage("There is no codec associated with the parser; a codec is required to read the content as a tree");
+    }
+
+    @Nested
+    class FromYaml {
+
+        @Test
+        void shouldSetFromCsv() {
+            var yaml = testFixture("sample-config-csv-urls.yml");
+            parseYamlAndAssertRegistryUrls(yaml);
+        }
+
+        @Test
+        void shouldSetFromList() {
+            var yaml = testFixture("sample-config-list-of-urls.yml");
+            parseYamlAndAssertRegistryUrls(yaml);
+        }
+
+        private void parseYamlAndAssertRegistryUrls(String yaml) {
+            var sampleConfig = parseYaml(yaml);
+            assertParsedRegistryUrls(sampleConfig);
+        }
+
+        @Test
+        void shouldSetFromSingleElementList() {
+            var yaml = testFixture("sample-config-list-of-one-url.yml");
+            var sampleConfig = parseYaml(yaml);
+            assertThat(sampleConfig.getRegistryConfig().getRegistryUrls())
+                    .isEqualTo("https://eureka-1.acme.com:8761");
+        }
+
+        private SampleAppConfig parseYaml(String yaml) {
+            return new YamlHelper().toObject(yaml, SampleAppConfig.class);
+        }
+    }
+
+    @Nested
+    class FromJson {
+
+        @Test
+        void shouldSetFromCsv() {
+            var json = testFixture("sample-config-csv-urls.json");
+            parseJsonAndAssertRegistryUrls(json);
+        }
+
+        @Test
+        void shouldSetFromList() {
+            var json = testFixture("sample-config-list-of-urls.json");
+            parseJsonAndAssertRegistryUrls(json);
+        }
+
+        private void parseJsonAndAssertRegistryUrls(String json) {
+            var sampleConfig = new JsonHelper().toObject(json, SampleAppConfig.class);
+            assertParsedRegistryUrls(sampleConfig);
+        }
+    }
+
+    private static String testFixture(String fileName) {
+        return Fixtures.fixture("ListToCsvStringDeserializerTest/" + fileName);
+    }
+
+    private static void assertParsedRegistryUrls(SampleAppConfig sampleAppConfig) {
+        assertThat(sampleAppConfig.getRegistryConfig().getRegistryUrls())
+                .isEqualTo("https://eureka-1.acme.com:8761,https://eureka-2.acme.com:8761");
+    }
+
+    @Getter
+    @Setter
+    private static class SampleAppConfig {
+        private RegistryConfig registryConfig;
+    }
+
+    @Getter
+    @Setter
+    private static class RegistryConfig {
+        @JsonDeserialize(using = ListToCsvStringDeserializer.class)
+        private String registryUrls;
+    }
+
+}

--- a/src/test/resources/ListToCsvStringDeserializerTest/sample-config-csv-urls.json
+++ b/src/test/resources/ListToCsvStringDeserializerTest/sample-config-csv-urls.json
@@ -1,0 +1,5 @@
+{
+  "registryConfig": {
+    "registryUrls": "https://eureka-1.acme.com:8761,https://eureka-2.acme.com:8761"
+  }
+}

--- a/src/test/resources/ListToCsvStringDeserializerTest/sample-config-csv-urls.yml
+++ b/src/test/resources/ListToCsvStringDeserializerTest/sample-config-csv-urls.yml
@@ -1,0 +1,4 @@
+---
+
+registryConfig:
+  registryUrls: https://eureka-1.acme.com:8761,https://eureka-2.acme.com:8761

--- a/src/test/resources/ListToCsvStringDeserializerTest/sample-config-list-of-one-url.yml
+++ b/src/test/resources/ListToCsvStringDeserializerTest/sample-config-list-of-one-url.yml
@@ -1,0 +1,5 @@
+---
+
+registryConfig:
+  registryUrls:
+    - https://eureka-1.acme.com:8761

--- a/src/test/resources/ListToCsvStringDeserializerTest/sample-config-list-of-urls.json
+++ b/src/test/resources/ListToCsvStringDeserializerTest/sample-config-list-of-urls.json
@@ -1,0 +1,8 @@
+{
+  "registryConfig": {
+    "registryUrls": [
+      "https://eureka-1.acme.com:8761",
+      "https://eureka-2.acme.com:8761"
+    ]
+  }
+}

--- a/src/test/resources/ListToCsvStringDeserializerTest/sample-config-list-of-urls.yml
+++ b/src/test/resources/ListToCsvStringDeserializerTest/sample-config-list-of-urls.yml
@@ -1,0 +1,6 @@
+---
+
+registryConfig:
+  registryUrls:
+    - https://eureka-1.acme.com:8761
+    - https://eureka-2.acme.com:8761


### PR DESCRIPTION
Copied the original implementation from the service-discovery-client
library in kiwiproject, then made several modifications:

* Extend StdDeserializer instead of JsonDeserializer (per the Jackson
  Javadocs for JsonDeserializer); this required adding a public no-arg
  constructor that calls one of the protected superclass constructors.
* Check that JsonParser#getCodec returns a non-null ObjectCodec; throw
  an IllegalStateException with a useful-ish error message if null.
* Enhance Javadocs to clarify usage, restrictions, and limitations of
  this deserializer.

Closes #608