### PR TITLE
Update to Spring Data 3.2.4 and Mongo 4.2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         java_version: ['11', '16']
     steps:
       # Check out the project
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,12 @@
         <jsch.version>0.1.55</jsch.version>
         <metrics-jdbi3.version>4.1.25</metrics-jdbi3.version>
         <metrics-jetty9.version>4.1.25</metrics-jetty9.version>
+        <!-- Note: the mongo version should match the one that Spring Data Mongo depends on -->
+        <mongodb.version>4.2.3</mongodb.version>
         <postgresql.version>42.2.23</postgresql.version>
         <retrying-again.version>1.0.0</retrying-again.version>
         <spring.version>5.3.9</spring.version>
-        <spring-data-mongodb.version>2.2.13.RELEASE</spring-data-mongodb.version>
+        <spring-data-mongodb.version>3.2.4</spring-data-mongodb.version>
         <stax2-api.version>4.2.1</stax2-api.version>
         <stax-ex.version>1.8.3</stax-ex.version>
         <!--
@@ -559,6 +561,14 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <!-- The mongo driver to use is optional in Spring Data's POM. You have to choose either the mongodb-driver-sync
+             or the mongodb-driver-reactivestreams as the driver. -->
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongodb.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/kiwiproject/mongo/MongoClientWrapper.java
+++ b/src/main/java/org/kiwiproject/mongo/MongoClientWrapper.java
@@ -3,19 +3,22 @@ package org.kiwiproject.mongo;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 
 import com.google.common.annotations.Beta;
-import com.mongodb.DB;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import lombok.Getter;
 
 import java.io.Closeable;
 
 /**
- * A wrapper around a {@link MongoClient} that also provides {@link MongoDatabase} and {@link DB} instances
+ * A wrapper around a {@link MongoClient} that also provides {@link MongoDatabase} instance
  * for a specific database, which is specified in the constructor.
+ *
+ * @deprecated with no replacement since we no longer support the older Mongo 3.x versions and our code must
+ * therefore use only the new Mongo APIs (i.e. {@code com.mongodb.DB} doesn't exist in the Mongo 4.x drivers).
  */
 @Beta
+@Deprecated(forRemoval = true, since = "0.26.0")
 public class MongoClientWrapper implements Closeable {
 
     /**
@@ -30,33 +33,19 @@ public class MongoClientWrapper implements Closeable {
     @Getter
     private final MongoDatabase mongoDatabase;
 
-    private final DB db;
-
     /**
-     * Create a new instance with the given Mongo connection URI. Uses {@code databaseName} to get both
-     * {@link MongoDatabase} and {@link DB} instances, which are available from this instance via their
-     * getter methods.
+     * Create a new instance with the given Mongo connection URI. Uses {@code databaseName} to get
+     * a {@link MongoDatabase} instance, which is available from this instance via the getter method.
      *
      * @param mongoUri     the Mongo connection URI
      * @param databaseName the database associated with this instance
      */
-    @SuppressWarnings("deprecation")
     public MongoClientWrapper(String mongoUri, String databaseName) {
         checkArgumentNotBlank(mongoUri, "mongoUri cannot be blank");
         checkArgumentNotBlank(databaseName, "databaseName cannot be blank");
 
-        mongoClient = new MongoClient(new MongoClientURI(mongoUri));
-        mongoDatabase = mongoClient.getDatabase(databaseName);
-        db = mongoClient.getDB(databaseName);
-    }
-
-    /**
-     * Return the (deprecated) {@link DB} instance for clients that have not yet migrated to {@link MongoDatabase}.
-     *
-     * @return the DB instance associated with this instance (as specified in the constructor)
-     */
-    public DB getDB() {
-        return db;
+        this.mongoClient = MongoClients.create(mongoUri);
+        mongoDatabase = this.mongoClient.getDatabase(databaseName);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -592,8 +592,11 @@ public class KiwiUrls {
     }
 
     /**
-     * Converts a Map of String of Strings into one (potentially long) string of key/value parameters (each key/value
-     * parameter is separated by an '=' character), with each parameter pair separated by an '&amp;' character.
+     * Converts a Map containing String keys and values into one (potentially long) string of key/value parameters
+     * (each key/value parameter is separated by an '=' character), with each parameter pair separated by an '&amp;'
+     * character.
+     * <p>
+     * Note specifically that this method does <strong>not</strong> URL encode the parameters.
      *
      * @param parameters the map of the parameters to create the query string from
      * @return a concatenated query string

--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -574,8 +574,16 @@ public class KiwiUrls {
     }
 
     /**
-     * Converts a query string (comprised of key/value pairs separated by '&amp;' characters) into a Map of String of
-     * Strings
+     * Converts a query string (comprised of key/value pairs separated by '&amp;' characters) into a Map whose keys
+     * are the parameter names and values are the parameter values.
+     * <p>
+     * Note specifically that this method does <strong>not</strong> decode the query string parameters. It splits on
+     * literal &amp; characters to obtain the key/value pairs and then on the literal {@code =} to get the name and
+     * value of each pair.
+     * <p>
+     * Also note that if a parameter has multiple values, only the <em>first</em> one is returned, e.g. the value of
+     * "topping" in the query string {@code topping=pepperoni&topping=banana+pepper&topping=sausage} will always be
+     * "pepperoni".
      *
      * @param queryString the query string to create the map from
      * @return a map of the query params
@@ -588,7 +596,7 @@ public class KiwiUrls {
 
         return Arrays.stream(queryString.split("&"))
                 .map(keyValue -> keyValue.split("="))
-                .collect(toMap(splat -> splat[0], splat -> splat[1]));
+                .collect(toMap(splat -> splat[0], splat -> splat[1], (value1, value2) -> value1));
     }
 
     /**

--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -294,9 +294,9 @@ public class KiwiUrls {
     }
 
     /**
-     * Extract all of the relevant sections from the given {@code uri}.
+     * Extract all the relevant sections from the given {@code uri}.
      * <p>
-     * As an example, if given https://news.bbc.co.uk:8080/a-news-article" this would return the following:
+     * As an example, if given "https://news.bbc.co.uk:8080/a-news-article" this would return the following:
      * <ul>
      * <li>scheme = "https"</li>
      * <li>subDomainName = "news"</li>
@@ -496,7 +496,7 @@ public class KiwiUrls {
 
     /**
      * Searches the {@code commaDelimitedUrls} for its domains, and if found, replaces all entries with
-     * {@code replacmentDomain}. The {@code commaDelimitedUrls} can be a standalone URL.
+     * {@code replacementDomain}. The {@code commaDelimitedUrls} can be a standalone URL.
      *
      * @param commaDelimitedUrls the comma delimited URLs to search
      * @param replacementDomain  the domain to replace if found
@@ -534,7 +534,7 @@ public class KiwiUrls {
 
     /**
      * Replace {@code expectedDomain} in {@code url} with {@code replacementDomain} if and only if {@code url}'s domain
-     * is equal to {@code expectedDomain}. If the given {@code url} has no domain, or is not the expected domain, b
+     * is equal to {@code expectedDomain}. If the given {@code url} has no domain, or is not the expected domain, be
      * lenient and just return the original URL.
      */
     private static String replaceDomain(URL url, String expectedDomain, String replacementDomain) {

--- a/src/main/java/org/kiwiproject/spring/context/MongoRepositoryContext.java
+++ b/src/main/java/org/kiwiproject/spring/context/MongoRepositoryContext.java
@@ -10,7 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.support.MongoRepositoryFactory;
 
@@ -123,7 +123,7 @@ public class MongoRepositoryContext {
      * @return a new MongoTemplate instance
      */
     public static MongoTemplate initializeMongoTemplate(String mongoUri) {
-        var mongoDbFactory = new SimpleMongoClientDbFactory(mongoUri);
+        var mongoDbFactory = new SimpleMongoClientDatabaseFactory(mongoUri);
 
         var mongoTemplate = new MongoTemplate(mongoDbFactory);
         mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);

--- a/src/test/java/org/kiwiproject/mongo/MongoClientWrapperTest.java
+++ b/src/test/java/org/kiwiproject/mongo/MongoClientWrapperTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.kiwiproject.junit.jupiter.MongoServerExtension;
 import org.kiwiproject.spring.util.MongoTestHelpers;
 
+@SuppressWarnings("removal")
 @DisplayName("MongoClientWrapper")
 class MongoClientWrapperTest {
 
@@ -47,13 +48,6 @@ class MongoClientWrapperTest {
         var mongoDatabase = clientWrapper.getMongoDatabase();
         assertThat(mongoDatabase).isNotNull();
         assertThat(mongoDatabase.getName()).isEqualTo(databaseName);
-    }
-
-    @Test
-    void shouldHaveDB() {
-        var db = clientWrapper.getDB();
-        assertThat(db).isNotNull();
-        assertThat(db.getName()).isEqualTo(databaseName);
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/net/KiwiUrlsTest.java
+++ b/src/test/java/org/kiwiproject/net/KiwiUrlsTest.java
@@ -8,6 +8,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -412,6 +413,13 @@ class KiwiUrlsTest {
                         entry("moveFailed", ".error"),
                         entry("readLock", "changed")
                 );
+    }
+
+    @RepeatedTest(10)
+    void testQueryStringToMap_OnlyReturnsOneValue_ForParametersWithMultipleValues() {
+        var parameters = KiwiUrls.queryStringToMap("topping=pepperoni&topping=banana+pepper&topping=sausage");
+
+        assertThat(parameters).containsExactly(entry("topping", "pepperoni"));
     }
 
     @Test

--- a/src/test/java/org/kiwiproject/spring/data/KiwiSpringMongoQueriesTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/KiwiSpringMongoQueriesTest.java
@@ -32,7 +32,7 @@ import org.kiwiproject.spring.data.KiwiSpringMongoQueries.PartialMatchType;
 import org.kiwiproject.time.KiwiInstants;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.query.Criteria;
 
 import java.time.Instant;
@@ -56,7 +56,7 @@ class KiwiSpringMongoQueriesTest {
     @BeforeAll
     static void beforeAll() {
         var connectionString = MONGO_SERVER_EXTENSION.getConnectionString();
-        var mongoClientDbFactory = new SimpleMongoClientDbFactory(connectionString);
+        var mongoClientDbFactory = new SimpleMongoClientDatabaseFactory(connectionString);
         mongoTemplate = new MongoTemplate(mongoClientDbFactory);
     }
 

--- a/src/test/java/org/kiwiproject/spring/data/PagingQueryEmbeddedMongoTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingQueryEmbeddedMongoTest.java
@@ -50,7 +50,7 @@ import java.util.function.Predicate;
 @Slf4j
 class PagingQueryEmbeddedMongoTest {
 
-    // Currently only testing against Mongo 4.0
+    // Currently, only testing against Mongo 4.0
     private static final Version.Main MONGODB_VERSION = Version.Main.V4_0;
 
     private static MongodExecutable mongodExecutable;

--- a/src/test/java/org/kiwiproject/spring/data/PagingQueryRealMongoTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingQueryRealMongoTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.kiwiproject.search.KiwiSearching;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -86,7 +86,7 @@ class PagingQueryRealMongoTest {
                 mongoUri, databaseName);
         LOG.info("Mongo connection string: {}", connectionString);
 
-        var dbFactory = new SimpleMongoClientDbFactory(connectionString);
+        var dbFactory = new SimpleMongoClientDatabaseFactory(connectionString);
         mongoTemplate = new MongoTemplate(dbFactory);
     }
 

--- a/src/test/java/org/kiwiproject/spring/util/MongoTestHelpers.java
+++ b/src/test/java/org/kiwiproject/spring/util/MongoTestHelpers.java
@@ -6,7 +6,7 @@ import de.bwaldvogel.mongo.MongoServer;
 import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
 import lombok.experimental.UtilityClass;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 
 @UtilityClass
 public class MongoTestHelpers {
@@ -24,7 +24,7 @@ public class MongoTestHelpers {
 
     public static MongoTemplate newMongoTemplate(MongoServer mongoServer) {
         var connectionString = MongoTestHelpers.mongoConnectionString(mongoServer);
-        var factory = new SimpleMongoClientDbFactory(connectionString);
+        var factory = new SimpleMongoClientDatabaseFactory(connectionString);
         return new MongoTemplate(factory);
     }
 }


### PR DESCRIPTION
* Bump spring-data-mongodb from 2.2.13 to 3.2.4
* Add mongodb-driver-sync dependency since the mongo drivers are
  optional in spring-data-mongodb, so you have to choose one explicitly
* Add new mongodb version property to the POM, along with a note that
  it should match the mongo version used by spring-data-mongodb
* Fix all the things that broke/would not compile with the new versions
* Deprecate MongoClientWrapper since it doesn't make sense or add any
  value anymore