### PR TITLE
Change KiwiUrls#toQueryString to permit generic type for map values

### DIFF
--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -600,7 +600,7 @@ public class KiwiUrls {
     }
 
     /**
-     * Converts a Map containing String keys and values into one (potentially long) string of key/value parameters
+     * Converts a Map containing String keys and V values into one (potentially long) string of key/value parameters
      * (each key/value parameter is separated by an '=' character), with each parameter pair separated by an '&amp;'
      * character.
      * <p>
@@ -610,7 +610,7 @@ public class KiwiUrls {
      * @return a concatenated query string
      * @see #queryStringToMap(String) queryStringToMap(String) for the inverse operation
      */
-    public static String toQueryString(Map<String, String> parameters) {
+    public static <V> String toQueryString(Map<String, V> parameters) {
         if (isNullOrEmpty(parameters)) {
             return "";
         }


### PR DESCRIPTION
* Update KiwiUrls#toQueryString so the Map parameter is defined as
  Map<String, V> where V is a generic type parameter
* Restructure existing testToQueryStringXxx methods into a nested
  test class containing all its tests

Closes #622