### PR TITLE
Add methods to KiwiUrls to convert query strings into multi-valued maps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,12 @@
             <artifactId>assertj-guava</artifactId>
             <version>${assertj-guava.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.assertj</groupId>
+                    <artifactId>assertj-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <jsr305.version>3.0.2</jsr305.version>
 
         <!-- Versions for test dependencies -->
+        <assertj-guava.version>3.4.0</assertj-guava.version>
         <commons-compress.version>1.21</commons-compress.version>
         <embedded-postgres.version>1.3.1</embedded-postgres.version>
         <embed.mongo.version>3.0.0</embed.mongo.version>
@@ -605,6 +606,13 @@
         </dependency>
 
         <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-guava</artifactId>
+            <version>${assertj-guava.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
New methods:

* Multimap<String, String> queryStringToMultimap(String queryString)
* Map<String, List<String>> queryStringToMultivaluedMap(String queryString)

Closes #628