### PR TITLE
Deprecate legacy KiwiEnvironment process ID methods (for removal)

### DIFF
--- a/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
@@ -144,13 +144,24 @@ public class DefaultEnvironment implements KiwiEnvironment {
      * <p>
      * This default implementation uses the JMX {@link ManagementFactory#getRuntimeMXBean()} to get the process
      * information in the form {@code pid@hostname}. It then simply splits the string and returns the {@code pid}.
+     *
+     * @deprecated replaced by {@link #currentPid()}
      */
     @Override
+    @Deprecated(since = "1.1.0", forRemoval = true)
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
     public String currentProcessId() {
         return ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated replaced by {@link #tryGetCurrentPid()}
+     */
     @Override
+    @Deprecated(since = "1.1.0", forRemoval = true)
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
     public Optional<Integer> tryGetCurrentProcessId() {
         try {
             String value = currentProcessId();

--- a/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
@@ -149,7 +149,8 @@ public class DefaultEnvironment implements KiwiEnvironment {
      */
     @Override
     @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()",
+            reference = "https://github.com/kiwiproject/kiwi/issues/642")
     public String currentProcessId() {
         return ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
     }
@@ -161,7 +162,8 @@ public class DefaultEnvironment implements KiwiEnvironment {
      */
     @Override
     @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()",
+            reference = "https://github.com/kiwiproject/kiwi/issues/642")
     public Optional<Integer> tryGetCurrentProcessId() {
         try {
             String value = currentProcessId();

--- a/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
@@ -190,7 +190,10 @@ public interface KiwiEnvironment {
      * @return process ID
      * @apiNote Originally defined to return a string due to the implementation using {@link ManagementFactory#getRuntimeMXBean()}
      * to get the process information in the form {@code pid@hostname}
+     * @deprecated replaced by {@link #currentPid()}
      */
+    @Deprecated(since = "1.1.0", forRemoval = true)
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
     String currentProcessId();
 
     /**
@@ -198,7 +201,10 @@ public interface KiwiEnvironment {
      * empty optional is returned.
      *
      * @return am optional containing the process ID, or empty if <em>any</em> problem occurred
+     * @deprecated replaced by {@link #tryGetCurrentPid()}
      */
+    @Deprecated(since = "1.1.0", forRemoval = true)
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
     Optional<Integer> tryGetCurrentProcessId();
 
     /**

--- a/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
@@ -193,7 +193,8 @@ public interface KiwiEnvironment {
      * @deprecated replaced by {@link #currentPid()}
      */
     @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()",
+            reference = "https://github.com/kiwiproject/kiwi/issues/642")
     String currentProcessId();
 
     /**
@@ -204,7 +205,8 @@ public interface KiwiEnvironment {
      * @deprecated replaced by {@link #tryGetCurrentPid()}
      */
     @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()", reference = "https://github.com/kiwiproject/kiwi/issues/642")
+    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()",
+            reference = "https://github.com/kiwiproject/kiwi/issues/642")
     Optional<Integer> tryGetCurrentProcessId();
 
     /**

--- a/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
+++ b/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
@@ -241,6 +241,7 @@ class DefaultEnvironmentTest {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     void testCurrentProcessId() {
         String pid = env.currentProcessId();
@@ -253,6 +254,7 @@ class DefaultEnvironmentTest {
         Integer.parseInt(pid);
     }
 
+    @SuppressWarnings("removal")
     @Test
     void testTryGetCurrentProcessId() {
         Optional<Integer> optionalPid = env.tryGetCurrentProcessId();
@@ -261,6 +263,7 @@ class DefaultEnvironmentTest {
                 .hasValueSatisfying(value -> assertThat(value).isNotNegative());
     }
 
+    @SuppressWarnings("removal")
     @Test
     void testTryGetCurrentProcessId_WhenExceptionThrown() {
         var envSpy = spy(env);


### PR DESCRIPTION
* Deprecate currentProcessId() and tryGetCurrentProcessId() for removal
  in the next major version (2.0.0)

Closes #642