### PR TITLE
Change DefaultEnvironment#currentProcessId implementation

### DIFF
--- a/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
@@ -2,7 +2,6 @@ package org.kiwiproject.base;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.lang.management.ManagementFactory;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -142,9 +141,6 @@ public class DefaultEnvironment implements KiwiEnvironment {
 
     /**
      * {@inheritDoc}
-     * <p>
-     * This default implementation uses the JMX {@link ManagementFactory#getRuntimeMXBean()} to get the process
-     * information in the form {@code pid@hostname}. It then simply splits the string and returns the {@code pid}.
      *
      * @deprecated replaced by {@link #currentPid()}
      */
@@ -153,7 +149,7 @@ public class DefaultEnvironment implements KiwiEnvironment {
     @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()",
             reference = "https://github.com/kiwiproject/kiwi/issues/642")
     public String currentProcessId() {
-        return ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
+        return String.valueOf(currentPid());
     }
 
     /**

--- a/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
+++ b/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
@@ -267,7 +267,7 @@ class DefaultEnvironmentTest {
     @Test
     void testTryGetCurrentProcessId_WhenExceptionThrown() {
         var envSpy = spy(env);
-        doThrow(new IllegalArgumentException())
+        doThrow(new UnsupportedOperationException("no pid for you!"))
                 .when(envSpy)
                 .currentProcessId();
 


### PR DESCRIPTION
* Change implementation of the deprecated currentProcessId method
  to use the new currentPid() method instead of the old and brittle
  way using the RuntimeMXBean. Even though this is deprecated, might
  as well have a more solid implementation until it is removed.

Closes #639