### PR TITLE
Fix malformed YAML in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     reviewers:
       - "sleberknight"
       - "chrisrohr"
-  open-pull-requests-limit: 10
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The open-pull-requests-limit was incorrectly indented