### PR TITLE
Misc. code cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/KillTimeoutAction.java
+++ b/src/main/java/org/kiwiproject/base/process/KillTimeoutAction.java
@@ -1,7 +1,5 @@
 package org.kiwiproject.base.process;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -9,7 +7,6 @@ import java.util.concurrent.TimeUnit;
  *
  * @see Processes#kill(long, KillSignal, long, TimeUnit, KillTimeoutAction)
  */
-@Slf4j
 public enum KillTimeoutAction {
 
     /**

--- a/src/main/java/org/kiwiproject/config/EndpointConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/EndpointConfiguration.java
@@ -28,8 +28,6 @@ import java.util.function.Predicate;
 @Setter
 public class EndpointConfiguration {
 
-    private static final String DOMAIN_SPLIT_CHAR = ",";
-
     /**
      * Use this to uniquely identify an endpoint within a {@link SecureEndpointsConfiguration}, or to provide
      * a way to find an {@link EndpointConfiguration} in any collection of them, e.g. using a

--- a/src/main/java/org/kiwiproject/net/CidrRange.java
+++ b/src/main/java/org/kiwiproject/net/CidrRange.java
@@ -1,8 +1,6 @@
 package org.kiwiproject.net;
 
 import com.google.common.net.InetAddresses;
-import lombok.extern.slf4j.Slf4j;
-
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -15,7 +13,6 @@ import java.nio.ByteBuffer;
  * updated since 2019 and seems to be unmaintained.
  */
 @SuppressWarnings("UnstableApiUsage")
-@Slf4j
 public class CidrRange {
 
     private final InetAddress inetAddress;

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiStandardResponsesIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiStandardResponsesIntegrationTest.java
@@ -27,6 +27,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;
@@ -203,9 +204,8 @@ class KiwiStandardResponsesIntegrationTest {
     }
 
     private static void assertResponseEntityMapHasErrorsKey(Response response) {
-        var entity = response.readEntity(Map.class);
+        var entity = response.readEntity(new GenericType<Map<String, Object>>() {});
 
-        //noinspection unchecked
         assertThat(entity).containsKey("errors");
     }
 

--- a/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
@@ -555,7 +555,7 @@ class JsonHelperBasicsTest {
             });
 
             assertThat(people)
-                    .usingElementComparatorOnFields("firstName", "lastName", "age")
+                    .usingRecursiveFieldByFieldElementComparatorOnFields("firstName", "lastName", "age")
                     .containsOnlyOnce(
                             new Person("Bob", "Smith", 34),
                             new Person("Jason", "Whatever", 27)

--- a/src/test/java/org/kiwiproject/reflect/KiwiReflectionTest.java
+++ b/src/test/java/org/kiwiproject/reflect/KiwiReflectionTest.java
@@ -1201,6 +1201,7 @@ class KiwiReflectionTest {
         private final String title;
     }
 
+    @SuppressWarnings("unused")  // fields are not used
     @AllArgsConstructor
     @Getter
     static class NoFieldObj {

--- a/src/test/java/org/kiwiproject/spring/data/KiwiPagingTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/KiwiPagingTest.java
@@ -9,7 +9,6 @@ import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.second;
 
 import com.google.common.collect.Streams;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @DisplayName("KiwiPaging")
-@Slf4j
 class KiwiPagingTest {
 
     @Nested


### PR DESCRIPTION
* Remove Lombok Sl4j annotation in classes that don't use the Logger
  (KillTimeoutAction, CidrRange, and KiwiPagingTest)
* Remove unused private constant from EndpointConfiguration
* Use GenericType in KiwiStandardResponsesIntegrationTest when reading
   the response entity, which makes the unchecked warning
   suppression unnecessary
* Replace deprecated AssertJ usingElementComparatorOnFields with
  usingRecursiveFieldByFieldElementComparatorOnFields
* Add an unused warning suppression to one of the classes inside
  KiwiReflectionTest, because the fields are never accessed directly
  or via reflection (the test is asking for non-static fields)