### PR TITLE
Remove deprecated methods from KiwiEnvironment

### DIFF
--- a/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
@@ -14,7 +14,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -136,38 +135,6 @@ public class DefaultEnvironment implements KiwiEnvironment {
         } catch (Exception e) {
             LOG.trace("Unable to get current process ID", e);
             return OptionalLong.empty();
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated replaced by {@link #currentPid()}
-     */
-    @Override
-    @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()",
-            reference = "https://github.com/kiwiproject/kiwi/issues/642")
-    public String currentProcessId() {
-        return String.valueOf(currentPid());
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated replaced by {@link #tryGetCurrentPid()}
-     */
-    @Override
-    @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()",
-            reference = "https://github.com/kiwiproject/kiwi/issues/642")
-    public Optional<Integer> tryGetCurrentProcessId() {
-        try {
-            String value = currentProcessId();
-            return Optional.of(Integer.parseInt(value));
-        } catch (Exception e) {
-            LOG.trace("Unable to get current process ID", e);
-            return Optional.empty();
         }
     }
 

--- a/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.base;
 
-import java.lang.management.ManagementFactory;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Clock;
@@ -12,7 +11,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -182,33 +180,6 @@ public interface KiwiEnvironment {
      * @see ProcessHandle#pid()
      */
     OptionalLong tryGetCurrentPid();
-
-    /**
-     * Returns the process ID of the currently executing JVM. This method does not perform any error checking. Use
-     * {@link #tryGetCurrentProcessId()} for a safer version, which returns the result as an integer (wrapped in an
-     * optional).
-     *
-     * @return process ID
-     * @apiNote Originally defined to return a string due to the implementation using {@link ManagementFactory#getRuntimeMXBean()}
-     * to get the process information in the form {@code pid@hostname}
-     * @deprecated replaced by {@link #currentPid()}
-     */
-    @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "currentPid()",
-            reference = "https://github.com/kiwiproject/kiwi/issues/642")
-    String currentProcessId();
-
-    /**
-     * Tries to obtain the process ID of the currently executing JVM. If any problem occurs, it is caught and an
-     * empty optional is returned.
-     *
-     * @return am optional containing the process ID, or empty if <em>any</em> problem occurred
-     * @deprecated replaced by {@link #tryGetCurrentPid()}
-     */
-    @Deprecated(since = "1.1.0", forRemoval = true)
-    @KiwiDeprecated(since = "1.1.0", removeAt = "2.0.0", replacedBy = "tryGetCurrentPid()",
-            reference = "https://github.com/kiwiproject/kiwi/issues/642")
-    Optional<Integer> tryGetCurrentProcessId();
 
     /**
      * Sleep for the given number of milliseconds.

--- a/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
+++ b/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
@@ -28,7 +28,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -239,40 +238,6 @@ class DefaultEnvironmentTest {
             var optionalPid = envSpy.tryGetCurrentPid();
             assertThat(optionalPid).isEmpty();
         }
-    }
-
-    @SuppressWarnings("removal")
-    @Test
-    void testCurrentProcessId() {
-        String pid = env.currentProcessId();
-        assertThat(pid).isNotNull();
-        assertIsNumeric(pid);
-    }
-
-    private void assertIsNumeric(String pid) throws NumberFormatException {
-        //noinspection ResultOfMethodCallIgnored
-        Integer.parseInt(pid);
-    }
-
-    @SuppressWarnings("removal")
-    @Test
-    void testTryGetCurrentProcessId() {
-        Optional<Integer> optionalPid = env.tryGetCurrentProcessId();
-        assertThat(optionalPid)
-                .isPresent()
-                .hasValueSatisfying(value -> assertThat(value).isNotNegative());
-    }
-
-    @SuppressWarnings("removal")
-    @Test
-    void testTryGetCurrentProcessId_WhenExceptionThrown() {
-        var envSpy = spy(env);
-        doThrow(new UnsupportedOperationException("no pid for you!"))
-                .when(envSpy)
-                .currentProcessId();
-
-        Optional<Integer> optionalPid = envSpy.tryGetCurrentProcessId();
-        assertThat(optionalPid).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Remove currentProcessId() and tryGetCurrentProcessId() methods from KiwiEnvironment
and its sole implementation, DefaultEnvironment. These were deprecated in version
1.1.0 for removal at version 2.0.0.

Closes #702