### PR TITLE
Uncomment several assertions in KiwiJacksonDataFormatsTest

### DIFF
--- a/src/test/java/org/kiwiproject/jackson/KiwiJacksonDataFormatsTest.java
+++ b/src/test/java/org/kiwiproject/jackson/KiwiJacksonDataFormatsTest.java
@@ -205,10 +205,10 @@ class KiwiJacksonDataFormatsTest {
 
         @Test
         void shouldReturnFalse_WhenNotYamlContent() {
-//            assertThat(KiwiJacksonDataFormats.isYaml(JSON_US_ASCII_CHARSET, US_ASCII)).isFalse();
-//            assertThat(KiwiJacksonDataFormats.isYaml(XML_US_ASCII_CHARSET, US_ASCII)).isFalse();
+            assertThat(KiwiJacksonDataFormats.isYaml(JSON_US_ASCII_CHARSET, US_ASCII)).isFalse();
+            assertThat(KiwiJacksonDataFormats.isYaml(XML_US_ASCII_CHARSET, US_ASCII)).isFalse();
             assertThat(KiwiJacksonDataFormats.isYaml(YAML_INFORMAL_US_ASCII_CHARSET, US_ASCII)).isFalse();
-//            assertThat(KiwiJacksonDataFormats.isYaml(RANDOM_TEXT, US_ASCII)).isFalse();
+            assertThat(KiwiJacksonDataFormats.isYaml(RANDOM_TEXT, US_ASCII)).isFalse();
         }
     }
 


### PR DESCRIPTION
I have no idea why these were ever merged in still commented out,
but I found them after running an IntelliJ code inspection on the
entire project.