### PR TITLE
Remove warning suppressions that are now redundant

### DIFF
--- a/src/main/java/org/kiwiproject/io/KiwiPaths.java
+++ b/src/main/java/org/kiwiproject/io/KiwiPaths.java
@@ -22,7 +22,7 @@ public class KiwiPaths {
      * @return the {@link Path} of the given resource name
      * @see Resources#getResource(String)
      */
-    @SuppressWarnings("UnstableApiUsage") // because Guava's Resources has been around for a long time
+    // because Guava's Resources has been around for a long time
     public static Path pathFromResourceName(String resourceName) {
         try {
             return Paths.get(Resources.getResource(resourceName).toURI());

--- a/src/main/java/org/kiwiproject/jsch/KiwiJSchHelpers.java
+++ b/src/main/java/org/kiwiproject/jsch/KiwiJSchHelpers.java
@@ -51,7 +51,6 @@ public class KiwiJSchHelpers {
         session.setConfig("server_host_key", keyExchangeType);
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     private static boolean hostMatchesKnownHost(String hostOrIpToFind, HostKey hostKey) {
         var knownHost = new KnownHost(hostKey);
         if (InetAddresses.isInetAddress(hostOrIpToFind)) {

--- a/src/main/java/org/kiwiproject/net/CidrRange.java
+++ b/src/main/java/org/kiwiproject/net/CidrRange.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.net;
 
 import com.google.common.net.InetAddresses;
+
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
@@ -12,7 +13,6 @@ import java.nio.ByteBuffer;
  * <a href="https://github.com/edazdarevic/CIDRUtils">https://github.com/edazdarevic/CIDRUtils</a> which has not been
  * updated since 2019 and seems to be unmaintained.
  */
-@SuppressWarnings("UnstableApiUsage")
 public class CidrRange {
 
     private final InetAddress inetAddress;

--- a/src/main/java/org/kiwiproject/net/KiwiInternetAddresses.java
+++ b/src/main/java/org/kiwiproject/net/KiwiInternetAddresses.java
@@ -42,7 +42,6 @@ import java.util.function.Supplier;
  * <p>
  * Last, note that {@link SimpleHostInfo} <em>only contains the host name and host address as a string</em>.
  */
-@SuppressWarnings("UnstableApiUsage")  // Because Guava's InetAddresses is marked @Beta (but has been there a long time)
 @UtilityClass
 @Slf4j
 public class KiwiInternetAddresses {

--- a/src/main/java/org/kiwiproject/net/SimpleHostAndPort.java
+++ b/src/main/java/org/kiwiproject/net/SimpleHostAndPort.java
@@ -18,7 +18,6 @@ import lombok.Getter;
  */
 @EqualsAndHashCode
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@SuppressWarnings("UnstableApiUsage")  // Because Guava's InetAddresses is marked @Beta (but has been there a long time)
 public class SimpleHostAndPort {
 
     @Getter

--- a/src/test/java/org/kiwiproject/internal/Fixtures.java
+++ b/src/test/java/org/kiwiproject/internal/Fixtures.java
@@ -19,7 +19,7 @@ public class Fixtures {
 
     public static String fixture(String resourceName) {
         try {
-            @SuppressWarnings("UnstableApiUsage") var url = Resources.getResource(resourceName);
+            var url = Resources.getResource(resourceName);
             var path = Paths.get(url.toURI());
             return Files.readString(path, StandardCharsets.UTF_8);
         } catch (URISyntaxException | IOException e) {
@@ -28,7 +28,7 @@ public class Fixtures {
     }
 
     public static Path fixturePath(String resourceName) {
-        @SuppressWarnings("UnstableApiUsage") var url = Resources.getResource(resourceName);
+        var url = Resources.getResource(resourceName);
         try {
             return Paths.get(url.toURI());
         } catch (URISyntaxException e) {

--- a/src/test/java/org/kiwiproject/jackson/KiwiJacksonDataFormatsTest.java
+++ b/src/test/java/org/kiwiproject/jackson/KiwiJacksonDataFormatsTest.java
@@ -350,7 +350,6 @@ class KiwiJacksonDataFormatsTest {
      * "Stolen" from {@link io.dropwizard.testing.FixtureHelpers} since they made it private there for whatever
      * reason! Renamed so as not to collide with the fixture method.
      */
-    @SuppressWarnings("UnstableApiUsage")
     private static String fixtureWithCharset(String filename, Charset charset) {
         try {
             return Resources.toString(Resources.getResource(filename), charset).trim();

--- a/src/test/java/org/kiwiproject/json/JsonHelperAdvancedFeaturesTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperAdvancedFeaturesTest.java
@@ -486,7 +486,6 @@ class JsonHelperAdvancedFeaturesTest {
                             Map.of("foo2", "bar2")
                     );
 
-            //noinspection unchecked
             softly.assertThat(newSampleObject.getObjectMap())
                     .containsOnlyKeys("key1", "key2", "key4")
                     .contains(entry("key4", List.of(4.2)));

--- a/src/test/java/org/kiwiproject/net/KiwiInternetAddressesTest.java
+++ b/src/test/java/org/kiwiproject/net/KiwiInternetAddressesTest.java
@@ -22,7 +22,6 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.function.Supplier;
 
-@SuppressWarnings("UnstableApiUsage")
 @DisplayName("KiwiInternetAddresses")
 class KiwiInternetAddressesTest {
 

--- a/src/test/java/org/kiwiproject/security/SecureTestConstants.java
+++ b/src/test/java/org/kiwiproject/security/SecureTestConstants.java
@@ -25,7 +25,6 @@ public class SecureTestConstants {
         LOG.info("Set JKS_FILE_PATH to {}", JKS_FILE_PATH);
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     private static String getJksFilePath() {
         try {
             var uri = Resources.getResource(SecureTestConstants.JKS_FILE_NAME).toURI();


### PR DESCRIPTION
At some point Guava removed the "Beta" designation on both
Resources and InetAddresses, so we can remove a bunch of the
warning suppressions that we had in place.