### PR TITLE
A little more code cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/KillTimeoutAction.java
+++ b/src/main/java/org/kiwiproject/base/process/KillTimeoutAction.java
@@ -22,5 +22,5 @@ public enum KillTimeoutAction {
     /**
      * An exception ({@link IllegalStateException}) will be thrown after timeout
      */
-    THROW_EXCEPTION;
+    THROW_EXCEPTION
 }

--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -461,7 +461,7 @@ public class KiwiUrls {
     public static OptionalInt extractPortFrom(String url) {
         var optionalPort = findGroupInUrl(url, PORT_GROUP);
 
-        var port = optionalPort.map(Integer::parseInt)
+        int port = optionalPort.map(Integer::parseInt)
                 .orElseGet(() -> extractSchemeFrom(url).map(KiwiUrls::defaultPortForScheme).orElse(UNKNOWN_PORT));
 
         if (port > 0) {

--- a/src/test/java/org/kiwiproject/jsch/JSchSlf4jLoggerTest.java
+++ b/src/test/java/org/kiwiproject/jsch/JSchSlf4jLoggerTest.java
@@ -69,7 +69,7 @@ class JSchSlf4jLoggerTest {
 
             assertThat(logger.isEnabled(999)).isFalse();
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput).contains("Was passed invalid level: 999");
         }
 
@@ -99,7 +99,7 @@ class JSchSlf4jLoggerTest {
 
             logger.log(-1, "test DEBUG message");
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput)
                     .contains("Was passed invalid level: -1")
                     .contains(" (Message the caller wanted to log: test DEBUG message)");
@@ -111,7 +111,7 @@ class JSchSlf4jLoggerTest {
 
             logAtAllLevels();
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput).contains(
                     "test DEBUG message",
                     "test INFO message",
@@ -127,7 +127,7 @@ class JSchSlf4jLoggerTest {
 
             logAtAllLevels();
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput).contains(
                     "test DEBUG message",
                     "test INFO message",
@@ -144,7 +144,7 @@ class JSchSlf4jLoggerTest {
 
             logAtAllLevels();
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput).contains(
                     "test WARN message",
                     "test WARN message",
@@ -161,7 +161,7 @@ class JSchSlf4jLoggerTest {
 
             logAtAllLevels();
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput).contains(
                     "test WARN message",
                     "test WARN message",
@@ -177,7 +177,7 @@ class JSchSlf4jLoggerTest {
 
             logAtAllLevels();
 
-            var logOutput = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+            var logOutput = outputStream.toString(StandardCharsets.UTF_8);
             assertThat(logOutput).contains(
                     "test ERROR message",
                     "test FATAL message")


### PR DESCRIPTION
* Remove unnecessary semicolon in KillTimeoutAction enum
* Convert a 'var' (which was hiding the wrapper type Integer) to int
  (IntelliJ found that, not me...)
* Replace inefficient conversion of OutputStream to a String in
  JSchSlf4jLoggerTest. Instead of getting the byte array and then
  calling String's constructor, there is a toString(Charset) method
  that was added to OutputStream in JDK 10 to directly convert to
  a String from the stream. This avoids the overhead of doing an
  OutputStream#toByteArray, which performs an array copy operation.