### PR TITLE
Code and javadoc cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiStrings.java
+++ b/src/main/java/org/kiwiproject/base/KiwiStrings.java
@@ -234,7 +234,9 @@ public final class KiwiStrings {
      * {@link com.google.common.base.Strings} class as
      * {{@link com.google.common.base.Strings#lenientFormat(String, Object...)}}. However, it only accepts {@code %s}
      * as the replacement placeholder. For performance comparisons of the JDK {@link String#format(String, Object...)}
-     * method, see http://stackoverflow.com/questions/12786902/performance-javas-string-format
+     * method, see <a href="http://stackoverflow.com/questions/12786902/performance-javas-string-format">Performance: Java's String.format [duplicate]</a>
+     * on Stack Overflow as well as
+     * <a href="https://stackoverflow.com/questions/513600/should-i-use-javas-string-format-if-performance-is-important">Should I use Java's String.format() if performance is important?</a>
      *
      * @param template a non-null string containing 0 or more {@code %s} or {@code {}} placeholders.
      * @param args     the arguments to be substituted into the message template. Arguments are converted

--- a/src/main/java/org/kiwiproject/regex/MatchSpliterator.java
+++ b/src/main/java/org/kiwiproject/regex/MatchSpliterator.java
@@ -20,7 +20,8 @@ import java.util.stream.StreamSupport;
  * Gratefully included here in Kiwi courtesy of Philipp Wagner from his "A Spliterator for MatchResults in Java"
  * blog entry. Slightly modified to check arguments and add an instance {@code stream} method.
  * <p>
- * Original blog post: https://bytefish.de/blog/matcher_spliterator/
+ * Original blog post: <a href="https://bytefish.de/blog/matcher_spliterator/">A Spliterator for MatchResults in Java</a>
+ * by Philipp Wagner.
  */
 public class MatchSpliterator extends Spliterators.AbstractSpliterator<MatchResult> {
 

--- a/src/test/java/org/kiwiproject/base/OptionalsTest.java
+++ b/src/test/java/org/kiwiproject/base/OptionalsTest.java
@@ -71,5 +71,7 @@ class OptionalsTest {
                         () -> new MyCustomException("bad things..."))
         ).isExactlyInstanceOf(MyCustomException.class)
                 .hasMessage("bad things...");
+
+        assertThat(called).isFalse();
     }
 }

--- a/src/test/java/org/kiwiproject/concurrent/AsyncExceptionTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncExceptionTest.java
@@ -45,10 +45,7 @@ class AsyncExceptionTest {
 
         CompletableFuture<String> typedFuture = ex.getFuture();
 
-        assertThat(typedFuture)
-                .hasFailedWithThrowableThat()
-                .isExactlyInstanceOf(RuntimeException.class)
-                .hasMessage("this didn't work!");
+        assertThat(typedFuture).isSameAs(future);
     }
 
     private static CompletableFuture<String> newFailingCompletableFutureWithStringType() {

--- a/src/test/java/org/kiwiproject/io/TimeBasedDirectoryCleanerTestHelper.java
+++ b/src/test/java/org/kiwiproject/io/TimeBasedDirectoryCleanerTestHelper.java
@@ -50,8 +50,8 @@ public class TimeBasedDirectoryCleanerTestHelper {
     }
 
     public List<File> filesInTempFolder() throws IOException {
-       return Files.list(cleanerPath)
-                .map(Path::toFile)
-               .collect(toList());
+        try (var paths = Files.list(cleanerPath)) {
+            return paths.map(Path::toFile).collect(toList());
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiMultivaluedMapsTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiMultivaluedMapsTest.java
@@ -32,10 +32,10 @@ class KiwiMultivaluedMapsTest {
 
         /**
          * @implNote As of AssertJ 3.20.0, the implementation of containsOnly was changed significantly in PR
-         * https://github.com/assertj/assertj-core/pull/2167/ and as a result broke this test when it used containsOnly
-         * to verify the map entries. Long story short, it is caused by the new AssertJ implementation cloning the
-         * MultivaluedMap in a way that it flattens it to a single-valued Map, and the values (which are List) are
-         * wrapped inside another List, so the comparison completely fails.
+         * <a href="https://github.com/assertj/assertj-core/pull/2167/">2167</a> and as a result broke this test when
+         * it used containsOnly to verify the map entries. Long story short, it is caused by the new AssertJ
+         * implementation cloning the MultivaluedMap in a way that it flattens it to a single-valued Map, and the
+         * values (which are List) are wrapped inside another List, so the comparison completely fails.
          */
         @Test
         void shouldCreateMultivaluedMap() {
@@ -69,10 +69,10 @@ class KiwiMultivaluedMapsTest {
 
         /**
          * @implNote As of AssertJ 3.20.0, the implementation of containsOnly was changed significantly in PR
-         * https://github.com/assertj/assertj-core/pull/2167/ and as a result broke this test when it used containsOnly
-         * to verify the map entries. Long story short, it is caused by the new AssertJ implementation cloning the
-         * MultivaluedMap in a way that it flattens it to a single-valued Map, and the values (which are List) are
-         * wrapped inside another List, so the comparison completely fails.
+         * <a href="https://github.com/assertj/assertj-core/pull/2167/">2167</a> and as a result broke this test when
+         * it used containsOnly to verify the map entries. Long story short, it is caused by the new AssertJ
+         * implementation cloning the MultivaluedMap in a way that it flattens it to a single-valued Map, and the
+         * values (which are List) are wrapped inside another List, so the comparison completely fails.
          */
         @Test
         void shouldCreateMultivaluedMap_WithOnlyOneValuePerKey() {

--- a/src/test/java/org/kiwiproject/reflect/KiwiReflectionTest.java
+++ b/src/test/java/org/kiwiproject/reflect/KiwiReflectionTest.java
@@ -1201,7 +1201,8 @@ class KiwiReflectionTest {
         private final String title;
     }
 
-    @SuppressWarnings("unused")  // fields are not used
+    // Suppress several warnings since the fields are not used, and one of the static fields is intentionally not final
+    @SuppressWarnings({"unused", "FieldMayBeFinal"})
     @AllArgsConstructor
     @Getter
     static class NoFieldObj {

--- a/src/test/java/org/kiwiproject/util/GithubWorkflowCacheTest.java
+++ b/src/test/java/org/kiwiproject/util/GithubWorkflowCacheTest.java
@@ -49,7 +49,9 @@ class GithubWorkflowCacheTest {
     private static void logFilesInDirectory(Path directory) throws IOException {
         if (Files.exists(directory) && Files.isDirectory(directory)) {
             LOG.info("Listing directory {}:", directory);
-            Files.list(directory).forEach(path -> LOG.info("{}", path.toAbsolutePath()));
+            try (var paths = Files.list(directory)) {
+                paths.forEach(path -> LOG.info("{}", path.toAbsolutePath()));
+            }
         } else {
             LOG.warn("Directory {} was not found!", directory.toAbsolutePath());
         }


### PR DESCRIPTION
* Replace usages of deprecated AssertJ 'hasFailedWithThrowableThat'
  in AsyncExceptionTest and AsyncTest
* Convert links specified as plain text to HTML links in javadoc
  of KiwiStrings, MatchSpliterator, KiwiMultivaluedMapsTest
* Use try-with-resources when using Files#list to stream over the Paths
  in a directory in TimeBasedDirectoryCleanerTestHelper and
  GithubWorkflowCacheTest
* Fix write-only local variable in OptionalsTest; add assertion to
  verify the correct code path was called by Optionals
* Suppress "field may be final" warning in KiwiReflectionTest; it is
  intentionally not final