### PR TITLE
Remove EL from custom validator in test

### DIFF
--- a/src/test/java/org/kiwiproject/validation/KiwiValidationsTest.java
+++ b/src/test/java/org/kiwiproject/validation/KiwiValidationsTest.java
@@ -155,7 +155,7 @@ class KiwiValidationsTest {
 
             var violation = violations.stream().findFirst().orElseThrow();
             assertThat(violation.getPropertyPath()).hasToString("name");
-            assertThat(violation.getMessage()).isEqualTo("'The Awesome' will always be regarded as invalid! (sorry)");
+            assertThat(violation.getMessage()).isEqualTo("will always be regarded as invalid! (sorry)");
         }
 
         @Test
@@ -199,7 +199,7 @@ class KiwiValidationsTest {
 
         @Override
         public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
-            KiwiValidations.addError(context, "'${validatedValue}' will always be regarded as invalid! {suffix}");
+            KiwiValidations.addError(context, "will always be regarded as invalid! {suffix}");
 
             return false;
         }


### PR DESCRIPTION
Remove expression language from custom validator in KiwiValidationsTest
to prepare for update to Hibernate Validator 6.2.x when EL is disabled
by default.