### PR TITLE
Add ability to launch processes with a working directory

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
+++ b/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
@@ -8,6 +8,8 @@ import static org.kiwiproject.io.KiwiIO.streamLinesFromInputStreamOf;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.annotation.Nullable;
+import java.io.File;
 import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.List;
@@ -59,6 +61,18 @@ public class ProcessHelper {
      */
     public Process launch(List<String> command) {
         return Processes.launch(command);
+    }
+
+    /**
+     * Launches a new process using the specified {@code workingDirectory} and {@code command}.
+     *
+     * @param workingDirectory the working directory to use
+     * @param command          the list containing the program and its arguments
+     * @return the new {@link Process}
+     * @see Processes#launch(File, List)
+     */
+    public Process launch(@Nullable File workingDirectory, List<String> command) {
+        return Processes.launch(workingDirectory, command);
     }
 
     /**


### PR DESCRIPTION
* Add overloads of Processes#launch and ProcessHelper#launch that
  accept a File representing the working directory and a List that
  contains the command. Did not overload the launch methods that accept
  varargs because there can be ambiguity as to which method is called.
  For example, launch(null, "git", "status") is ambiguous since both
  launch(String...) and launch(File, String...) can apply and that
  would force ugly casts, etc.
* Update javadocs for Processes#waitForExit noting that we do not
  destroy the Process if the timeout occurs before the process exits

Closes #739