### PR TITLE
Add distinctOrEmpty to KiwiLists; internal refactoring

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiLists.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiLists.java
@@ -237,7 +237,7 @@ public class KiwiLists {
      */
     public static <T> List<T> distinct(Collection<T> collection) {
         checkArgument(nonNull(collection), "collection can not be null");
-        return distinctOrNull(collection);
+        return  distinctListFrom(collection);
     }
 
     /**
@@ -248,7 +248,23 @@ public class KiwiLists {
      * @return a new list with only unique elements or null.
      */
     public static <T> List<T> distinctOrNull(Collection<T> collection) {
-        return nonNull(collection) ? collection.stream().distinct().collect(toList()) : null;
+        return nonNull(collection) ? distinctListFrom(collection) : null;
+    }
+
+    /**
+     * Returns a list of the collection elements with duplicates stripped out or an empty list if the input collection
+     * is null (or empty).
+     *
+     * @param collection the collection of values
+     * @param <T>        the type of items in the collection
+     * @return a new list with only unique elements or an empty list
+     */
+    public static <T> List<T> distinctOrEmpty(Collection<T> collection) {
+        return nonNull(collection) ? distinctListFrom(collection) : new ArrayList<>();
+    }
+
+    private static <T> List<T> distinctListFrom(Collection<T> collection) {
+        return collection.stream().distinct().collect(toList());
     }
 
     /**

--- a/src/test/java/org/kiwiproject/collect/KiwiListsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiListsTest.java
@@ -365,6 +365,17 @@ class KiwiListsTest {
         void shouldAllowNull() {
             assertThat(KiwiLists.distinctOrNull(null)).isNull();
         }
+
+        @Test
+        void shouldReturnEmptyList_GivenEmptyList() {
+            assertThat(KiwiLists.distinctOrNull(List.of())).isEmpty();
+        }
+
+        @Test
+        void shouldReturnDistinctList() {
+            assertThat(KiwiLists.distinctOrNull(List.of(42, 42, 42, 84, 126, 126, 336, 336)))
+                    .containsExactly(42, 84, 126, 336);
+        }
     }
 
     @Nested
@@ -374,6 +385,12 @@ class KiwiListsTest {
         @NullAndEmptySource
         void shouldReturnEmptyList_GivenNullOrEmptyCollection(Set<String> strings) {
             assertThat(KiwiLists.distinctOrEmpty(strings)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnDistinctList() {
+            assertThat(KiwiLists.distinctOrEmpty(List.of(42, 42, 84, 84, 126, 336, 336)))
+                    .containsExactly(42, 84, 126, 336);
         }
     }
 

--- a/src/test/java/org/kiwiproject/collect/KiwiListsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiListsTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.junit.jupiter.WhiteBoxTest;
 
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -342,6 +344,7 @@ class KiwiListsTest {
 
         @Test
         void shouldReturnDistinct(SoftAssertions softly) {
+            softly.assertThat(KiwiLists.distinct(newArrayList())).isEmpty();
             softly.assertThat(KiwiLists.distinct(newArrayList(1, 2, 3))).hasSize(3);
             softly.assertThat(KiwiLists.distinct(newArrayList(1, 1, 1))).hasSize(1);
             softly.assertThat(KiwiLists.distinct(newArrayList("a", "b", "b"))).hasSize(2);
@@ -361,6 +364,16 @@ class KiwiListsTest {
         @Test
         void shouldAllowNull() {
             assertThat(KiwiLists.distinctOrNull(null)).isNull();
+        }
+    }
+
+    @Nested
+    class DistinctOrEmpty {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnEmptyList_GivenNullOrEmptyCollection(Set<String> strings) {
+            assertThat(KiwiLists.distinctOrEmpty(strings)).isEmpty();
         }
     }
 


### PR DESCRIPTION
* Add distinctOrEmpty to KiwiLists; it returns an empty list when
  given null input, unlike distinctOrNull
* Refactor the common code to get distinct elements from a collection
  into the private static helper method distinctListFrom