### PR TITLE
Add KiwiTypeReferences containing common TypeReference constants

### DIFF
--- a/src/main/java/org/kiwiproject/jackson/KiwiTypeReferences.java
+++ b/src/main/java/org/kiwiproject/jackson/KiwiTypeReferences.java
@@ -1,0 +1,51 @@
+package org.kiwiproject.jackson;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utilities/constants for common types of Jackson {@link TypeReference} objects.
+ */
+@UtilityClass
+public class KiwiTypeReferences {
+
+    public static final TypeReference<Map<String, Object>> MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<Map<String, Object>>> LIST_OF_MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<String>> LIST_OF_STRING_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<Integer>> LIST_OF_INTEGER_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<Long>> LIST_OF_LONG_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<Double>> LIST_OF_DOUBLE_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<Float>> LIST_OF_FLOAT_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<List<Boolean>> LIST_OF_BOOLEAN_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+
+    public static final TypeReference<Set<String>> SET_OF_STRING_TYPE_REFERENCE =
+            new TypeReference<>() {
+            };
+}

--- a/src/main/java/org/kiwiproject/json/JsonHelper.java
+++ b/src/main/java/org/kiwiproject/json/JsonHelper.java
@@ -13,6 +13,7 @@ import static org.kiwiproject.collect.KiwiLists.first;
 import static org.kiwiproject.collect.KiwiLists.isNotNullOrEmpty;
 import static org.kiwiproject.collect.KiwiLists.isNullOrEmpty;
 import static org.kiwiproject.collect.KiwiMaps.newHashMap;
+import static org.kiwiproject.jackson.KiwiTypeReferences.MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -71,9 +72,6 @@ import java.util.stream.Stream;
  */
 @Slf4j
 public class JsonHelper {
-
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
-    };
 
     private static final Pattern ARRAY_INDEX_PATTERN = Pattern.compile("\\[(\\d+)]");
 
@@ -459,7 +457,7 @@ public class JsonHelper {
         }
 
         try {
-            return objectMapper.readValue(json, MAP_TYPE_REFERENCE);
+            return objectMapper.readValue(json, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
         } catch (JsonProcessingException e) {
             throw new RuntimeJsonException(e);
         }
@@ -621,7 +619,7 @@ public class JsonHelper {
      * @return a new map instance
      */
     public Map<String, Object> convertToMap(Object fromObject) {
-        return convertToMap(fromObject, MAP_TYPE_REFERENCE);
+        return convertToMap(fromObject, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
     }
 
     /**

--- a/src/main/java/org/kiwiproject/yaml/YamlHelper.java
+++ b/src/main/java/org/kiwiproject/yaml/YamlHelper.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.nonNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+import static org.kiwiproject.jackson.KiwiTypeReferences.MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -22,9 +23,6 @@ import java.util.Map;
  * be available at runtime.
  */
 public class YamlHelper {
-
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
-    };
 
     private final ObjectMapper objectMapper;
 
@@ -146,7 +144,7 @@ public class YamlHelper {
      * @throws IllegalArgumentException if the YAML is blank or null
      */
     public Map<String, Object> toMap(String yaml) {
-        return toMap(yaml, MAP_TYPE_REFERENCE);
+        return toMap(yaml, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/jackson/KiwiTypeReferencesTest.java
+++ b/src/test/java/org/kiwiproject/jackson/KiwiTypeReferencesTest.java
@@ -1,0 +1,113 @@
+package org.kiwiproject.jackson;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import lombok.Value;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.json.JsonHelper;
+
+import java.util.List;
+import java.util.Map;
+
+@DisplayName("KiwiTypeReferences")
+class KiwiTypeReferencesTest {
+
+    private static final JsonHelper JSON_HELPER = JsonHelper.newDropwizardJsonHelper();
+
+    @Value
+    private static class Car {
+        String make;
+        String model;
+        int year;
+        double miles;
+        String bodyStyle;
+    }
+
+    @Test
+    void shouldSupportMapOfStringToObject() {
+        var modelS = new Car("Tesla", "S", 2015, 20_500.42, "sedan");
+        var json = JSON_HELPER.toJson(modelS);
+
+        var modelSMap = JSON_HELPER.toObject(json, KiwiTypeReferences.MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
+
+        assertThat(modelSMap).containsOnly(
+                entry("make", "Tesla"),
+                entry("model", "S"),
+                entry("year", 2015),
+                entry("miles", 20_500.42),
+                entry("bodyStyle", "sedan")
+        );
+    }
+
+    @Test
+    void shouldSupportListOfStringObjectMaps() {
+        var modelS = new Car("Tesla", "S", 2015, 20_500.42, "sedan");
+        var modelX = new Car("Tesla", "X", 2019, 14_542.84, "SUV");
+        var json = JSON_HELPER.toJson(List.of(modelS, modelX));
+
+        var carsList = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
+
+        assertThat(carsList).containsOnly(
+                Map.of("make", "Tesla", "model", "S", "year", 2015, "miles", 20_500.42, "bodyStyle", "sedan"),
+                Map.of("make", "Tesla", "model", "X", "year", 2019, "miles", 14_542.84, "bodyStyle", "SUV")
+        );
+    }
+
+    @Test
+    void shouldSupportListOfStrings() {
+        var json = JSON_HELPER.toJson(List.of("Model 3", "Model S", "Model X", "Model Y"));
+
+        var models = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_STRING_TYPE_REFERENCE);
+        assertThat(models).containsExactly("Model 3", "Model S", "Model X", "Model Y");
+    }
+
+    @Test
+    void shouldSupportListOfIntegers() {
+        var json = JSON_HELPER.toJson(List.of(2015, 2013, 2020, 2019));
+
+        var years = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_INTEGER_TYPE_REFERENCE);
+        assertThat(years).containsExactly(2015, 2013, 2020, 2019);
+    }
+
+    @Test
+    void shouldSupportListOfLongs() {
+        var json = JSON_HELPER.toJson(List.of(2015, 2013, 2020, 2019));
+
+        var years = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_LONG_TYPE_REFERENCE);
+        assertThat(years).containsExactly(2015L, 2013L, 2020L, 2019L);
+    }
+
+    @Test
+    void shouldSupportListOfDoubles() {
+        var json = JSON_HELPER.toJson(List.of(20_500.42, 14_542.84, 6_900.42));
+
+        var miles = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_DOUBLE_TYPE_REFERENCE);
+        assertThat(miles).containsExactly(20_500.42, 14_542.84, 6_900.42);
+    }
+
+    @Test
+    void shouldSupportListOfFloats() {
+        var json = JSON_HELPER.toJson(List.of(20_500.42, 14_542.84, 6_900.42));
+
+        var miles = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_FLOAT_TYPE_REFERENCE);
+        assertThat(miles).containsExactly(20_500.42F, 14_542.84F, 6_900.42F);
+    }
+
+    @Test
+    void shouldSupportListOfBooleans() {
+        var json = JSON_HELPER.toJson(List.of(true, false, false, true));
+
+        var bools = JSON_HELPER.toObject(json, KiwiTypeReferences.LIST_OF_BOOLEAN_TYPE_REFERENCE);
+        assertThat(bools).containsExactly(true, false, false, true);
+    }
+
+    @Test
+    void shouldSupportSetOfStrings() {
+        var json = JSON_HELPER.toJson(List.of("sedan", "sedan", "SUV", "sedan", "SUV", "SUV", "sedan"));
+
+        var bodyStyles = JSON_HELPER.toObject(json, KiwiTypeReferences.SET_OF_STRING_TYPE_REFERENCE);
+        assertThat(bodyStyles).containsExactlyInAnyOrder("sedan", "SUV");
+    }
+}

--- a/src/test/java/org/kiwiproject/json/JsonHelperAdvancedFeaturesTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperAdvancedFeaturesTest.java
@@ -3,6 +3,8 @@ package org.kiwiproject.json;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.kiwiproject.jackson.KiwiTypeReferences.LIST_OF_STRING_TYPE_REFERENCE;
+import static org.kiwiproject.jackson.KiwiTypeReferences.MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -37,9 +39,6 @@ import java.util.Map;
 class JsonHelperAdvancedFeaturesTest {
 
     private static final String SAMPLE_JSON = FixtureHelpers.fixture("JsonHelperTests/sample.json");
-
-    private static final TypeReference<List<String>> LIST_OF_STRING_TYPE_REF = new TypeReference<>() {
-    };
 
     private JsonHelper jsonHelper;
 
@@ -339,7 +338,7 @@ class JsonHelperAdvancedFeaturesTest {
             var map = Map.of("array", List.of("a", "b", "c"));
             var json = jsonHelper.getObjectMapper().writeValueAsString(map);
 
-            assertThat(jsonHelper.getPath(json, "array", LIST_OF_STRING_TYPE_REF))
+            assertThat(jsonHelper.getPath(json, "array", LIST_OF_STRING_TYPE_REFERENCE))
                     .containsExactly("a", "b", "c");
         }
 
@@ -356,9 +355,7 @@ class JsonHelperAdvancedFeaturesTest {
             softly.assertThat(jsonHelper.getPath(inputObject, "objectVar", Object.class))
                     .isEqualTo(sampleObject.getObjectVar());
 
-            var targetStringListType = new TypeReference<List<String>>() {
-            };
-            softly.assertThat(jsonHelper.getPath(inputObject, "stringList", targetStringListType))
+            softly.assertThat(jsonHelper.getPath(inputObject, "stringList", LIST_OF_STRING_TYPE_REFERENCE))
                     .isEqualTo(sampleObject.getStringList());
 
             var targetObjectListType = new TypeReference<List<Object>>() {
@@ -366,9 +363,7 @@ class JsonHelperAdvancedFeaturesTest {
             softly.assertThat(jsonHelper.getPath(inputObject, "objectList", targetObjectListType))
                     .isEqualTo(sampleObject.getObjectList());
 
-            var targetMapType = new TypeReference<Map<String, Object>>() {
-            };
-            softly.assertThat(jsonHelper.getPath(inputObject, "objectMap", targetMapType))
+            softly.assertThat(jsonHelper.getPath(inputObject, "objectMap", MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE))
                     .isEqualTo(sampleObject.getObjectMap());
         }
 

--- a/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.kiwiproject.collect.KiwiMaps.newLinkedHashMap;
+import static org.kiwiproject.jackson.KiwiTypeReferences.LIST_OF_MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE;
+import static org.kiwiproject.jackson.KiwiTypeReferences.MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -568,8 +570,7 @@ class JsonHelperBasicsTest {
             var jasonJson = jsonHelper.toJsonFromKeyValuePairs("firstName", "Jason", "lastName", "Whatever", "age", 27);
             var json = "[" + bobJson + "," + jasonJson + "]";
 
-            var people = jsonHelper.toObjectList(json, new TypeReference<List<Map<String, Object>>>() {
-            });
+            var people = jsonHelper.toObjectList(json, LIST_OF_MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
 
             assertThat(people)
                     .containsOnlyOnce(
@@ -663,8 +664,7 @@ class JsonHelperBasicsTest {
         @ParameterizedTest
         @NullAndEmptySource
         void shouldReturnNull_GivenTypeReference_AndNullOrEmptyInput(String value) {
-            var people = jsonHelper.toMap(value, new TypeReference<Map<String, Object>>() {
-            });
+            var people = jsonHelper.toMap(value, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
 
             assertThat(people).isNull();
         }
@@ -672,8 +672,7 @@ class JsonHelperBasicsTest {
         @ParameterizedTest
         @ValueSource(strings = {" ", "  ", "\t", " \n "})
         void shouldReturnNull_GivenTypeReference_AndBlankInput(String value) {
-            var people = jsonHelper.toMap(value, new TypeReference<Map<String, Object>>() {
-            });
+            var people = jsonHelper.toMap(value, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
 
             assertThat(people).isNull();
         }
@@ -682,9 +681,7 @@ class JsonHelperBasicsTest {
         void shouldThrow_GivenTypeReference_AndBadJson() {
             var json = "BAD_JSON_INPUT";
 
-            var targetMapType = new TypeReference<Map<String, Object>>() {
-            };
-            assertThatThrownBy(() -> jsonHelper.toMap(json, targetMapType))
+            assertThatThrownBy(() -> jsonHelper.toMap(json, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE))
                     .isExactlyInstanceOf(RuntimeJsonException.class)
                     .hasCauseExactlyInstanceOf(JsonParseException.class);
         }

--- a/src/test/java/org/kiwiproject/yaml/YamlHelperTest.java
+++ b/src/test/java/org/kiwiproject/yaml/YamlHelperTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.kiwiproject.collect.KiwiMaps.newLinkedHashMap;
+import static org.kiwiproject.jackson.KiwiTypeReferences.MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -85,8 +86,7 @@ class YamlHelperTest {
                     "john", john
             ));
 
-            var map = new YAMLMapper().readValue(yaml, new TypeReference<Map<String, Object>>() {
-            });
+            var map = new YAMLMapper().readValue(yaml, MAP_OF_STRING_TO_OBJECT_TYPE_REFERENCE);
 
             assertThat(map).containsOnlyKeys("bob", "john");
 


### PR DESCRIPTION
* Add KiwiTypeReferences "constants class" for common Jackson
  TypeReferences
* Retrofit JsonHelper and YamlHelper with KiwiTypeReferences constants
* Retrofit several tests with KiwiTypeReferences constants