### PR TITLE
Refactor KiwiDropwizardDurations

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurations.java
+++ b/src/main/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurations.java
@@ -11,12 +11,8 @@ import java.time.Duration;
 public class KiwiDropwizardDurations {
 
     public static Duration fromDropwizardDuration(io.dropwizard.util.Duration duration) {
-        var javaDuration = Duration.ofMillis(duration.toMilliseconds());
-
-        if (javaDuration.isZero()) {
-            return Duration.ofNanos(duration.toNanoseconds());
-        }
-
-        return javaDuration;
+        var unit = duration.getUnit();
+        var quantity = duration.getQuantity();
+        return Duration.of(quantity, unit.toChronoUnit());
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurationsTest.java
@@ -2,10 +2,14 @@ package org.kiwiproject.dropwizard.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.TimeUnit;
+
 import io.dropwizard.util.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @DisplayName("KiwiDropwizardDurations")
 class KiwiDropwizardDurationsTest {
@@ -35,6 +39,30 @@ class KiwiDropwizardDurationsTest {
         void shouldConvertZeroValue() {
             assertThat(KiwiDropwizardDurations.fromDropwizardDuration(Duration.seconds(0)))
                     .isEqualTo(java.time.Duration.ofNanos(0));
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "1 nanosecond, 1, NANOSECONDS",
+                "1000 nanoseconds, 1000, NANOSECONDS",
+                "1 microsecond, 1, MICROSECONDS",
+                "500 microseconds, 500, MICROSECONDS",
+                "1 millisecond, 1, MILLISECONDS",
+                "42000 milliseconds, 42000, MILLISECONDS",
+                "1 second, 1, SECONDS",
+                "420 seconds, 420, SECONDS",
+                "84 minutes, 84, MINUTES",
+                "42 hours, 42, HOURS",
+                "1 day, 1, DAYS",
+                "252 days, 252, DAYS",
+        })
+        void shouldConvertToJavaDuration(String durationSpec, long duration, TimeUnit unit) {
+            var dwDuration = Duration.parse(durationSpec);
+
+            var nanos = TimeUnit.NANOSECONDS.convert(duration, unit);
+            var expectedJavaDuration = java.time.Duration.ofNanos(nanos);
+
+            assertThat(KiwiDropwizardDurations.fromDropwizardDuration(dwDuration)).isEqualTo(expectedJavaDuration);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurationsTest.java
@@ -2,6 +2,8 @@ package org.kiwiproject.dropwizard.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
 import io.dropwizard.util.Duration;
@@ -43,24 +45,23 @@ class KiwiDropwizardDurationsTest {
 
         @ParameterizedTest
         @CsvSource({
-                "1 nanosecond, 1, NANOSECONDS",
-                "1000 nanoseconds, 1000, NANOSECONDS",
-                "1 microsecond, 1, MICROSECONDS",
-                "500 microseconds, 500, MICROSECONDS",
-                "1 millisecond, 1, MILLISECONDS",
-                "42000 milliseconds, 42000, MILLISECONDS",
+                "1 nanosecond, 1, NANOS",
+                "1000 nanoseconds, 1000, NANOS",
+                "1 microsecond, 1, MICROS",
+                "500 microseconds, 500, MICROS",
+                "1 millisecond, 1, MILLIS",
+                "42000 milliseconds, 42000, MILLIS",
                 "1 second, 1, SECONDS",
                 "420 seconds, 420, SECONDS",
                 "84 minutes, 84, MINUTES",
                 "42 hours, 42, HOURS",
                 "1 day, 1, DAYS",
-                "252 days, 252, DAYS",
+                "252 days, 252, DAYS"
         })
-        void shouldConvertToJavaDuration(String durationSpec, long duration, TimeUnit unit) {
+        void shouldConvertToJavaDuration(String durationSpec, long duration, ChronoUnit unit) {
             var dwDuration = Duration.parse(durationSpec);
 
-            var nanos = TimeUnit.NANOSECONDS.convert(duration, unit);
-            var expectedJavaDuration = java.time.Duration.ofNanos(nanos);
+            var expectedJavaDuration = java.time.Duration.of(duration, unit);
 
             assertThat(KiwiDropwizardDurations.fromDropwizardDuration(dwDuration)).isEqualTo(expectedJavaDuration);
         }


### PR DESCRIPTION
Change fromDropwizardDuration to use Java Duration's "of" factory
method. This is better the our original implementation because we
are making use of the units that the Dropwizard Duration contains
and are converting using those units.