### PR TITLE
Add fromString factory method to KiwiSort.Direction enum

### DIFF
--- a/src/main/java/org/kiwiproject/spring/data/KiwiSort.java
+++ b/src/main/java/org/kiwiproject/spring/data/KiwiSort.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.Locale;
+
 /**
  * Describes a sort on a specific property that is applied to a result list.
  */
@@ -40,6 +42,41 @@ public class KiwiSort {
 
         Direction(boolean ascending) {
             this.ascending = ascending;
+        }
+
+        /**
+         * Converts the given value to a {@link Direction} in a case-insensitive manner and ignoring leading and
+         * trailing whitespace.
+         * <p>
+         * Uses the default {@link Locale} to convert the value to uppercase.
+         *
+         * @param value the value to convert
+         * @return the {@link Direction} representing the given value
+         * @throws IllegalArgumentException if there is no {@link Direction} that matches after converting to uppercase
+         *                                  and stripping leading and trailing whitespace
+         * @see Locale#getDefault()
+         */
+        public static Direction fromString(String value) {
+            return Direction.fromString(value, Locale.getDefault());
+        }
+
+        /**
+         * Converts the given value to a {@link Direction} in a case-insensitive manner and ignoring leading and
+         * trailing whitespace.
+         * <p>
+         * Uses the given {@link Locale} to convert the value to uppercase.
+         *
+         * @param value  the value to convert
+         * @param locale the Locale to use to uppercase the value
+         * @return the {@link Direction} representing the given value
+         * @throws IllegalArgumentException if there is no {@link Direction} that matches after converting to uppercase
+         *                                  and stripping leading and trailing whitespace
+         */
+        public static Direction fromString(String value, Locale locale) {
+            checkArgumentNotBlank(value, "direction value must not be blank");
+
+            var upperCaseValue = value.strip().toUpperCase(locale);
+            return Direction.valueOf(upperCaseValue);
         }
     }
 

--- a/src/test/java/org/kiwiproject/spring/data/KiwiSortTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/KiwiSortTest.java
@@ -2,14 +2,25 @@ package org.kiwiproject.spring.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.kiwiproject.base.KiwiStrings.f;
 
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.util.BlankStringArgumentsProvider;
+
+import java.util.Locale;
+import java.util.stream.Stream;
 
 @DisplayName("KiwiSort")
 @ExtendWith(SoftAssertionsExtension.class)
@@ -52,5 +63,74 @@ class KiwiSortTest {
         var sort = KiwiSort.of("someProperty", KiwiSort.Direction.DESC);
         var str = sort.toString();
         assertThat(str).isNotBlank();
+    }
+
+    @DisplayName("Direction#fromString")
+    @Nested
+    class DirectionFromString {
+
+        @ParameterizedTest
+        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        void shouldRequireNonBlankValue(String value) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiSort.Direction.fromString(value))
+                    .withMessage("direction value must not be blank");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "a",
+                "ascending",
+                "as",
+                "d",
+                "descending",
+                "des"
+        })
+        void shouldThrowIllegalArgument_ForInvalidValues(String value) {
+            var expectedMessage = getExpectedExceptionMessage(value);
+
+            assertThatIllegalArgumentException()
+                    .describedAs("expecting IllegalArgumentException with same message as from Enum#valueOf")
+                    .isThrownBy(() -> KiwiSort.Direction.fromString(value))
+                    .withMessage(expectedMessage);
+        }
+
+        private String getExpectedExceptionMessage(String invalidValue) {
+            try {
+                KiwiSort.Direction.fromString(invalidValue);
+            } catch (Exception e) {
+                return e.getMessage();
+            }
+
+            throw new IllegalStateException(f("Expected value '%s' to be invalid!", invalidValue));
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.spring.data.KiwiSortTest#directionEnumValues")
+        void shouldCreateFromStringsInDefaultLocale(String value, KiwiSort.Direction expected) {
+            assertThat(KiwiSort.Direction.fromString(value)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @MethodSource("org.kiwiproject.spring.data.KiwiSortTest#directionEnumValues")
+        void shouldCreateFromSpecificLocale(String value, KiwiSort.Direction expected) {
+            assertThat(KiwiSort.Direction.fromString(value, Locale.ENGLISH)).isEqualTo(expected);
+        }
+    }
+
+    static Stream<Arguments> directionEnumValues() {
+        return Stream.of(
+                arguments("asc", KiwiSort.Direction.ASC),
+                arguments(" asc ", KiwiSort.Direction.ASC),
+                arguments("  \r\n\tasc\r\n\t  ", KiwiSort.Direction.ASC),
+                arguments("ASC", KiwiSort.Direction.ASC),
+                arguments("Asc", KiwiSort.Direction.ASC),
+                arguments("AsC", KiwiSort.Direction.ASC),
+                arguments("desc", KiwiSort.Direction.DESC),
+                arguments("\r\ndesc\t \t \r\n", KiwiSort.Direction.DESC),
+                arguments("DESC", KiwiSort.Direction.DESC),
+                arguments("Desc", KiwiSort.Direction.DESC),
+                arguments("DeSc", KiwiSort.Direction.DESC)
+        );
     }
 }


### PR DESCRIPTION
The KiwiSort.Direction#fromString factory method is case-insensitive
and strips any leading or trailing whitespace. It is overloaded to
allow using with the default Locale or a specific one.

Closes #770