### PR TITLE
Overload KiwiSort#of factory method with String direction

### DIFF
--- a/src/main/java/org/kiwiproject/spring/data/KiwiSort.java
+++ b/src/main/java/org/kiwiproject/spring/data/KiwiSort.java
@@ -92,6 +92,44 @@ public class KiwiSort {
      * {@link #ignoringCase()} in a fluent style.
      *
      * @param property  the property the sort is applied to
+     * @param direction the sort direction as a String, which must resolve via {@link Direction#fromString(String)}
+     *                  in the default {@link Locale}
+     * @return a new instance
+     * @throws IllegalArgumentException if property is blank or direction is blank or invalid
+     */
+    public static KiwiSort of(String property, String direction) {
+        return of(property, direction, Locale.getDefault());
+    }
+
+    /**
+     * Create a new instance.
+     * <p>
+     * If you want to specify that the sort is not case-sensitive, you can immediately call the
+     * {@link #ignoringCase()} in a fluent style.
+     *
+     * @param property  the property the sort is applied to
+     * @param direction the sort direction as a String, which must resolve via {@link Direction#fromString(String)}
+     *                  in the given {@link Locale}
+     * @param locale    the Locale to use to uppercase the value
+     * @return a new instance
+     * @throws IllegalArgumentException if property is blank or direction is blank or invalid
+     */
+    public static KiwiSort of(String property, String direction, Locale locale) {
+        checkArgumentNotBlank(property);
+        checkArgumentNotBlank(direction);
+        checkArgumentNotNull(locale);
+
+        var directionEnum = Direction.fromString(direction, locale);
+        return of(property, directionEnum);
+    }
+
+    /**
+     * Create a new instance.
+     * <p>
+     * If you want to specify that the sort is not case-sensitive, you can immediately call the
+     * {@link #ignoringCase()} in a fluent style.
+     *
+     * @param property  the property the sort is applied to
      * @param direction the sort direction
      * @return a new instance
      * @throws IllegalArgumentException if property is blank or direction is null
@@ -109,7 +147,7 @@ public class KiwiSort {
     }
 
     /**
-     * Specifies that the sort is <em>not</em> case sensitive, i.e. it ignores case.
+     * Specifies that the sort is <em>not</em> case-sensitive, i.e. it ignores case.
      *
      * @return this instance, for method chaining
      */

--- a/src/test/java/org/kiwiproject/spring/data/KiwiSortTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/KiwiSortTest.java
@@ -27,12 +27,22 @@ import java.util.stream.Stream;
 class KiwiSortTest {
 
     @Test
-    void shouldCreateNewInstanceUsingFactoryMethod(SoftAssertions softly) {
+    void shouldCreateNewInstanceUsing_DirectionEnumFactoryMethod(SoftAssertions softly) {
         var sort = KiwiSort.of("someProperty", KiwiSort.Direction.DESC);
 
         softly.assertThat(sort.getProperty()).isEqualTo("someProperty");
         softly.assertThat(sort.getDirection()).isEqualTo("DESC");
         softly.assertThat(sort.isAscending()).isFalse();
+        softly.assertThat(sort.isIgnoreCase()).isFalse();
+    }
+
+    @Test
+    void shouldCreateNewInstanceUsing_DirectionStringFactoryMethod(SoftAssertions softly) {
+        var sort = KiwiSort.of("someProperty", "asc");
+
+        softly.assertThat(sort.getProperty()).isEqualTo("someProperty");
+        softly.assertThat(sort.getDirection()).isEqualTo("ASC");
+        softly.assertThat(sort.isAscending()).isTrue();
         softly.assertThat(sort.isIgnoreCase()).isFalse();
     }
 
@@ -43,7 +53,20 @@ class KiwiSortTest {
             " ' ' , DESC",
             " lastName, ",
     })
-    void shouldValidateArgumentsWhenUsingFactoryMethod(String property, KiwiSort.Direction direction) {
+    void shouldValidateArgumentsWhenUsing_DirectionEnumFactoryMethod(String property, KiwiSort.Direction direction) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> KiwiSort.of(property, direction));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            " , ASC",
+            " '' , ASC",
+            " ' ' , DESC",
+            " lastName, ",
+            " lastName, DIAGONALLY",
+    })
+    void shouldValidateArgumentsWhenUsing_DirectionStringFactoryMethod(String property, String direction) {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> KiwiSort.of(property, direction));
     }


### PR DESCRIPTION
Add overloads of KiwiSort#of factory method to accept direction as a
String. Also add an overload to allow caller to specify a Locale for
converting the given String value to uppercase.

Closes #772