### PR TITLE
Replace deprecated FixtureHelpers with internal Fixtures

### DIFF
--- a/src/test/java/org/kiwiproject/internal/Fixtures.java
+++ b/src/test/java/org/kiwiproject/internal/Fixtures.java
@@ -1,38 +1,143 @@
 package org.kiwiproject.internal;
 
-import com.google.common.io.Resources;
+import static java.util.Objects.nonNull;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.Resources;
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+import org.kiwiproject.net.UncheckedURISyntaxException;
+
+import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * The Dropwizard {@code FixtureHelpers} in dropwizard-testing has a fixture method that returns a String but it does
- * not have a direct analog for the fixturePath method. Note this is in the test sources so it won't be part of an
- * actual kiwi JAR. Also note that kiwi-test contains its own {@code Fixtures} class, however we cannot use that
- * here without creating a cyclic dependency between kiwi and kiwi-test (which depends on kiwi).
+ * Helper methods for working with test fixtures.
+ * <p>
+ * This is copied from the class of the same name in
+ * <a href="https://github.com/kiwiproject/kiwi-test">kiwi-test</a>.
+ * <p>
+ * This library cannot depend on kiwi-test without creating a cyclic
+ * dependency, so this is a less bad solution.
  */
+@UtilityClass
 public class Fixtures {
 
+    /**
+     * Reads the given fixture file from the classpath (e. g. {@code src/test/resources}) and returns its contents
+     * as a UTF-8 string.
+     *
+     * @param resourceName the name/path of to the classpath resource
+     * @return the fixture contents
+     * @throws UncheckedURISyntaxException if the resource name/path is invalid as a URI
+     * @throws UncheckedIOException        if an I/O error occurs
+     */
     public static String fixture(String resourceName) {
+        return fixture(resourceName, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Reads the given fixture file from the classpath (e.g. {@code src/test/resources})
+     * and returns its contents as a string.
+     *
+     * @param resourceName the name/path of to the classpath resource
+     * @param charset      the charset of the fixture file
+     * @return the fixture contents
+     * @throws UncheckedURISyntaxException if the resource name/path is invalid as a URI
+     * @throws UncheckedIOException        if an I/O error occurs; the cause will be the actual {@link IOException}
+     * @implNote As of Java 17, {@link Files#readString(Path, Charset)} throws an {@link Error} instead of
+     * an {@link IOException} in the case of malformed input or unmappable characters. This {@link Error} contains a cause
+     * of {@link IOException}, with actual type of either {@link java.nio.charset.MalformedInputException MalformedInputException}
+     * or {@link java.nio.charset.UnmappableCharacterException UnmappableCharacterException}, both of which are subclasses of
+     * {@link CharacterCodingException}. Before Java 17 (we've tested on 11 and 16), this method threw an
+     * {@link IOException} whose actual type was one of the previously mentioned {@link CharacterCodingException}
+     * subclasses. Its Javadoc clearly states that it throws an {@link IOException} "if an I/O error occurs reading
+     * from the file or a malformed or unmappable byte sequence is read". In our tests of malformed input and unmappable
+     * characters, we see the {@link Error} thrown instead of a {@link CharacterCodingException} on JDK 17 and 18.
+     * This is a bug in the JDK reported as <a href="https://bugs.openjdk.java.net/browse/JDK-8286287">JDK-8286287</a>.
+     * It was fixed by pull request (<a href="https://github.com/openjdk/jdk/pull/8640">8286287: Reading file as UTF-16 causes Error which "shouldn't happen"</a>)
+     * and is scheduled for Java 19. There is also a question on Stack Overflow titled <em>Error which "shouldn't happen" caused
+     * by MalformedInputException when reading file to string with UTF-16</em>. It includes a lot of interesting information
+     * regarding differences between UTF-8 and UTF-16 if you're interested in such things. You can find it
+     * <a href="https://stackoverflow.com/q/72127702">here</a>. As a result, we have included code to handle the
+     * specific case when an {@link Error} is thrown and its cause is a {@link CharacterCodingException}.
+     */
+    @SneakyThrows
+    @SuppressWarnings("java:S1181")  // Suppress Sonar "Throwable and Error should not be caught" warning (see implNote)
+    public static String fixture(String resourceName, Charset charset) {
         try {
             var url = Resources.getResource(resourceName);
-            var path = Paths.get(url.toURI());
-            return Files.readString(path, StandardCharsets.UTF_8);
-        } catch (URISyntaxException | IOException e) {
-            throw new RuntimeException("Error reading fixture: " + resourceName, e);
+            var path = pathFromURL(url);
+            return Files.readString(path, charset);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Error reading fixture: " + resourceName, e);
+        } catch (Error error) {
+            // Special handling for JDK 17 and 18 (see implementation note above). Also, this relies on the "SneakyThrows".
+            throw uncheckedIOExceptionOrOriginalError(error, resourceName);
         }
     }
 
+    /**
+     * This method only exists to permit testing it when building on JDK 11-16, since those throw UncheckedIOException
+     * whereas JDK 17 throws an Error (see above implNote in {@link #fixture(String, Charset)}).
+     *
+     * @param error        the original Error
+     * @param resourceName the resource name, only used when UncheckedIOException is returned
+     * @return the original {@code error} or a new UncheckedIOException
+     */
+    @VisibleForTesting
+    static Throwable uncheckedIOExceptionOrOriginalError(Error error, String resourceName) {
+        var cause = error.getCause();
+        if (nonNull(cause) && cause instanceof CharacterCodingException) {
+            return new UncheckedIOException("Error reading fixture: " + resourceName, (CharacterCodingException) cause);
+        }
+        return error;
+    }
+
+    /**
+     * Resolves the given fixture file name/path as a {@link File}.
+     *
+     * @param resourceName the name/path of to the classpath resource
+     * @return the resource as a {@link File}
+     * @throws UncheckedURISyntaxException if the resource name/path is invalid as a URI
+     */
+    public static File fixtureFile(String resourceName) {
+        return fixturePath(resourceName).toFile();
+    }
+
+    /**
+     * Resolves the given fixture file name/path as a {@link Path}.
+     *
+     * @param resourceName the name/path of to the classpath resource
+     * @return the resource as a {@link Path}
+     * @throws UncheckedURISyntaxException if the resource name/path is invalid
+     */
     public static Path fixturePath(String resourceName) {
         var url = Resources.getResource(resourceName);
+        return pathFromURL(url);
+    }
+
+    /**
+     * @implNote In reality this should never throw, since {@link Resources#getResource(String)} uses
+     * {@link ClassLoader#getResource(String)} under the covers, and that method escapes invalid characters from what
+     * I have seen and tried. For example, {@code file-with>invalid-character.txt} is actually escaped as
+     * {@code file-with%3einvalid-character.txt} which converts to a URI just fine.
+     */
+    @VisibleForTesting
+    static Path pathFromURL(URL url) {
         try {
             return Paths.get(url.toURI());
         } catch (URISyntaxException e) {
-            throw new RuntimeException("Error getting path of fixture: " + resourceName, e);
+            throw new UncheckedURISyntaxException("Error getting path from URL: " + url, e);
         }
     }
 }

--- a/src/test/java/org/kiwiproject/jackson/KiwiJacksonDataFormatsTest.java
+++ b/src/test/java/org/kiwiproject/jackson/KiwiJacksonDataFormatsTest.java
@@ -3,6 +3,7 @@ package org.kiwiproject.jackson;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.internal.Fixtures.fixture;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -10,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.format.DataFormatDetector;
 import com.fasterxml.jackson.dataformat.csv.CsvFactory;
-import com.google.common.io.Resources;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,34 +28,34 @@ class KiwiJacksonDataFormatsTest {
     private static final Charset DEFAULT_CHARSET = Charset.defaultCharset();
 
     private static final String JSON_DEFAULT_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.json", DEFAULT_CHARSET);
+            fixture("KiwiJacksonDataFormatsTest/sample.json", DEFAULT_CHARSET);
     private static final String JSON_UTF8_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.json", UTF_8);
+            fixture("KiwiJacksonDataFormatsTest/sample.json", UTF_8);
     private static final String JSON_US_ASCII_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.json", US_ASCII);
+            fixture("KiwiJacksonDataFormatsTest/sample.json", US_ASCII);
 
     private static final String XML_DEFAULT_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.xml", DEFAULT_CHARSET);
+            fixture("KiwiJacksonDataFormatsTest/sample.xml", DEFAULT_CHARSET);
     private static final String XML_UTF8_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.xml", UTF_8);
+            fixture("KiwiJacksonDataFormatsTest/sample.xml", UTF_8);
     private static final String XML_US_ASCII_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.xml", US_ASCII);
+            fixture("KiwiJacksonDataFormatsTest/sample.xml", US_ASCII);
 
     // YAML files that DO contain the opening --- as specified in the YAML specifications
     private static final String YAML_FORMAL_DEFAULT_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample-formal.yml", DEFAULT_CHARSET);
+            fixture("KiwiJacksonDataFormatsTest/sample-formal.yml", DEFAULT_CHARSET);
     private static final String YAML_FORMAL_UTF8_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample-formal.yml", UTF_8);
+            fixture("KiwiJacksonDataFormatsTest/sample-formal.yml", UTF_8);
     private static final String YAML_FORMAL_US_ASCII_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample-formal.yml", US_ASCII);
+            fixture("KiwiJacksonDataFormatsTest/sample-formal.yml", US_ASCII);
 
     // YAML files that do NOT contain the opening --- as specified in the YAML specifications
     private static final String YAML_INFORMAL_DEFAULT_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample-informal.yml", DEFAULT_CHARSET);
+            fixture("KiwiJacksonDataFormatsTest/sample-informal.yml", DEFAULT_CHARSET);
     private static final String YAML_INFORMAL_UTF8_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample-informal.yml", UTF_8);
+            fixture("KiwiJacksonDataFormatsTest/sample-informal.yml", UTF_8);
     private static final String YAML_INFORMAL_US_ASCII_CHARSET =
-            fixtureWithCharset("KiwiJacksonDataFormatsTest/sample-informal.yml", US_ASCII);
+            fixture("KiwiJacksonDataFormatsTest/sample-informal.yml", US_ASCII);
 
     private static final String RANDOM_TEXT = "Something wicked this way comes";
 
@@ -323,7 +323,7 @@ class KiwiJacksonDataFormatsTest {
 
             @Test
             void shouldDetectFormats_SupportedBy_ProvidedDataFormatDetector() {
-                var sampleCsv = fixtureWithCharset("KiwiJacksonDataFormatsTest/sample.csv", UTF_8);
+                var sampleCsv = fixture("KiwiJacksonDataFormatsTest/sample.csv", UTF_8);
 
                 assertThat(KiwiJacksonDataFormats.detectFormat(sampleCsv, UTF_8, csvOnlyFormatDetector))
                         .hasValue(CsvFactory.FORMAT_NAME_CSV);
@@ -346,15 +346,4 @@ class KiwiJacksonDataFormatsTest {
         );
     }
 
-    /**
-     * "Stolen" from {@link io.dropwizard.testing.FixtureHelpers} since they made it private there for whatever
-     * reason! Renamed so as not to collide with the fixture method.
-     */
-    private static String fixtureWithCharset(String filename, Charset charset) {
-        try {
-            return Resources.toString(Resources.getResource(filename), charset).trim();
-        } catch (IOException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
 }

--- a/src/test/java/org/kiwiproject/jsch/SftpConfigTest.java
+++ b/src/test/java/org/kiwiproject/jsch/SftpConfigTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
 import io.dropwizard.util.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +17,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.internal.Fixtures;
 import org.kiwiproject.validation.ValidationTestHelper;
 import org.opentest4j.AssertionFailedError;
 
@@ -127,7 +127,7 @@ class SftpConfigTest {
 
             @Test
             void shouldAllowOverridingDefaultValues() throws IOException {
-                var json = FixtureHelpers.fixture("SftpConfigTest/config-all-properties.json");
+                var json = Fixtures.fixture("SftpConfigTest/config-all-properties.json");
                 var sftpConfig = DW_OBJECT_MAPPER.readValue(json, SftpConfig.class);
                 assertExplicitlySpecifiedProperties(sftpConfig);
                 assertDefaultValuesOverridden(sftpConfig);
@@ -135,7 +135,7 @@ class SftpConfigTest {
 
             @Test
             void shouldRespectDefaultValues() throws IOException {
-                var json = FixtureHelpers.fixture("SftpConfigTest/config-minimal-properties.json");
+                var json = Fixtures.fixture("SftpConfigTest/config-minimal-properties.json");
                 var sftpConfig = DW_OBJECT_MAPPER.readValue(json, SftpConfig.class);
                 assertExplicitlySpecifiedProperties(sftpConfig);
                 assertDefaultValuesUsed(sftpConfig);

--- a/src/test/java/org/kiwiproject/json/FlexibleJsonModelTest.java
+++ b/src/test/java/org/kiwiproject/json/FlexibleJsonModelTest.java
@@ -1,8 +1,8 @@
 package org.kiwiproject.json;
 
-import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.kiwiproject.internal.Fixtures.fixture;
 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/src/test/java/org/kiwiproject/json/JsonHelperAdvancedFeaturesTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperAdvancedFeaturesTest.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.dropwizard.testing.FixtureHelpers;
 import lombok.Value;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
@@ -24,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.collect.KiwiMaps;
+import org.kiwiproject.internal.Fixtures;
 import org.kiwiproject.json.JsonHelper.MergeOption;
 import org.kiwiproject.json.JsonHelper.OutputFormat;
 
@@ -38,7 +38,7 @@ import java.util.Map;
 @ExtendWith(SoftAssertionsExtension.class)
 class JsonHelperAdvancedFeaturesTest {
 
-    private static final String SAMPLE_JSON = FixtureHelpers.fixture("JsonHelperTests/sample.json");
+    private static final String SAMPLE_JSON = Fixtures.fixture("JsonHelperTests/sample.json");
 
     private JsonHelper jsonHelper;
 
@@ -391,7 +391,7 @@ class JsonHelperAdvancedFeaturesTest {
 
         @Test
         void shouldGetNestedAndArrayPathsInJson(SoftAssertions softly) {
-            var json = FixtureHelpers.fixture("JsonHelperTests/sampleComplexObject.json");
+            var json = Fixtures.fixture("JsonHelperTests/sampleComplexObject.json");
 
             softly.assertThat(jsonHelper.getPath(json, "root.str", String.class))
                     .isEqualTo("string");

--- a/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.format.DataFormatDetector;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.testing.FixtureHelpers;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -34,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.internal.Fixtures;
 import org.kiwiproject.json.JsonHelper.OutputFormat;
 import org.kiwiproject.junit.jupiter.WhiteBoxTest;
 
@@ -252,7 +252,7 @@ class JsonHelperBasicsTest {
 
         @Test
         void shouldSerializeBasicTypes() {
-            var sampleJson = FixtureHelpers.fixture("JsonHelperTests/sample.json");
+            var sampleJson = Fixtures.fixture("JsonHelperTests/sample.json");
             assertThat(jsonHelper.toJson(sampleJson)).isEqualTo(sampleJson);
 
             assertThat(jsonHelper.toJson(1)).isEqualTo("1");
@@ -260,7 +260,7 @@ class JsonHelperBasicsTest {
             assertThat(jsonHelper.toJson(1.2345)).isEqualTo("1.2345");
 
             assertThat(jsonHelper.toJson(List.of("a", "b", "c")))
-                    .isEqualToIgnoringWhitespace(FixtureHelpers.fixture("JsonHelperTests/sampleList.json"));
+                    .isEqualToIgnoringWhitespace(Fixtures.fixture("JsonHelperTests/sampleList.json"));
         }
 
         @Test

--- a/src/test/java/org/kiwiproject/util/YamlTestHelper.java
+++ b/src/test/java/org/kiwiproject/util/YamlTestHelper.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.util;
 
-import io.dropwizard.testing.FixtureHelpers;
 import lombok.experimental.UtilityClass;
+import org.kiwiproject.internal.Fixtures;
 import org.yaml.snakeyaml.Yaml;
 
 @UtilityClass
@@ -9,7 +9,7 @@ public class YamlTestHelper {
 
     public static <T> T loadFromYaml(String filename, Class<T> clazz) {
         var yaml = new Yaml();
-        var yamlConfig = FixtureHelpers.fixture(filename);
+        var yamlConfig = Fixtures.fixture(filename);
         return yaml.loadAs(yamlConfig, clazz);
     }
 }


### PR DESCRIPTION
* Update internal kiwi Fixtures from the one in kiwi-test (i.e. I
  copied it since we can't make kiwi depend on kiwi-test)
* Replace all usages of the deprecated Dropwizard FixtureHelpers
  with kiwi's Fixtures

Closes #777