### PR TITLE
Add convenience methods to KiwiSort and KiwiSort.Direction

### DIFF
--- a/src/main/java/org/kiwiproject/spring/data/KiwiSort.java
+++ b/src/main/java/org/kiwiproject/spring/data/KiwiSort.java
@@ -3,6 +3,7 @@ package org.kiwiproject.spring.data;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
@@ -60,8 +61,19 @@ public class KiwiSort {
 
             return direction;
         }
+
+        /**
+         * Convenience method to allow checking if this {@link Direction} is descending.
+         *
+         * @return true if this sort is descending, false if ascending
+         */
+        public boolean isDescending() {
+            return !ascending;
+        }
     }
 
+    @JsonIgnore
+    private Direction directionObject;
     private String direction;  // this is intentionally a string, for JSON serialization purposes
     private String property;
     private boolean ignoreCase;
@@ -128,6 +140,7 @@ public class KiwiSort {
 
         var sort = new KiwiSort();
         sort.setProperty(property);
+        sort.setDirectionObject(direction);
         sort.setDirection(direction.name());
         sort.setAscending(direction.isAscending());
         sort.setIgnoreCase(false);
@@ -142,5 +155,14 @@ public class KiwiSort {
     public KiwiSort ignoringCase() {
         setIgnoreCase(true);
         return this;
+    }
+
+    /**
+     * Convenience method to allow checking if this {@link KiwiSort} is descending.
+     *
+     * @return true if this sort is descending, false if ascending
+     */
+    public boolean isDescending() {
+        return !ascending;
     }
 }


### PR DESCRIPTION
* Add isDescending() to KiwiSort.Direction enum
* Add a Direction property named directionObject to KiwiSort to allow
  code to easily get the direction as the enum instead of a String.
  But, ignore it when serializing to JSON, since the serialized
  value is just the enum constant's name, e.g. "ASC" or "DESC", which
  it already has via the direction property
* Add isDescending() to KiwiSort

Closes #779