### PR TITLE
Bump kiwi-bom from 0.19.0 to 0.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi-bom.version>0.18.0</kiwi-bom.version>
+        <kiwi-bom.version>0.19.1</kiwi-bom.version>
 
         <!-- Versions for provided dependencies -->
         <retrying-again.version>1.0.12</retrying-again.version>


### PR DESCRIPTION
Fixes the problem with the 0.19.0 kiwi-bom version in which logback-classic and logback-core were not both on 1.4.1