### PR TITLE
Remove reference to specific SLF4J version in RetryLogger javadoc

### DIFF
--- a/src/main/java/org/kiwiproject/retry/RetryLogger.java
+++ b/src/main/java/org/kiwiproject/retry/RetryLogger.java
@@ -7,8 +7,8 @@ import org.slf4j.Logger;
 import org.slf4j.event.Level;
 
 /**
- * Package-private helper class to log attempts at different SLF4J logging levels (since SLF4J 1.7.x does not
- * provide any log methods that accept a {@link Level} object, we unfortunately have to resort to this instead).
+ * Package-private helper class to log attempts at different SLF4J logging levels. SLF4J does not
+ * provide any log methods that accept a {@link Level} object, so we unfortunately have to resort to this instead.
  *
  * @see Logger SLFJ Logger
  * @see Level SLF4J Level


### PR DESCRIPTION
Since we're now using SLF4J 2.x, calling out SLF4J 1.7.x doesn't make sense anymore, especially since the 2.x API still doesn't have any way to provide a Level object dynamically at runtime, either via the traditional API or the new fluent API.