### PR TITLE
Remove exclusion from assertj-guava in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,13 +177,6 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-guava</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- TODO: Remove this exclusion when back in sync, or ass assertj-guava to kiwi-parent -->
-                <exclusion>
-                    <groupId>org.assertj</groupId>
-                    <artifactId>assertj-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
assertj-guava now depends on the most recent assertj-core version so the exclusion is no longer necessary. If this happens again, we should probably add assertj-guava to kiwi-parent or kiwi-bom.