### PR TITLE
Add factory method to create SimpleRetryer instances

### DIFF
--- a/src/main/java/org/kiwiproject/retry/SimpleRetryerConfig.java
+++ b/src/main/java/org/kiwiproject/retry/SimpleRetryerConfig.java
@@ -13,8 +13,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * Configuration class that can be used to configure {@link SimpleRetryer} instances. This is
  * intended for usage with external configurations, e.g. a YAML configuration file, that will
- * be validated once instantiated. When constructing programmatically, prefer creating directly
- * via {@code SimpleRetryer.builder()}.
+ * be validated once instantiated. You can construct {@link SimpleRetryer} instances directly
+ * from this instance using {@link #newRetryer}.
+ * <p>
+ * When constructing programmatically, prefer creating directly via {@code SimpleRetryer.builder()}.
  */
 @Getter
 @Setter
@@ -34,4 +36,17 @@ public class SimpleRetryerConfig {
 
     @NotNull
     Level logLevelForSubsequentAttempts = SimpleRetryer.DEFAULT_RETRY_LOG_LEVEL;
+
+    /**
+     * Construct a new instance using the values in this configuration.
+     */
+    public SimpleRetryer newRetryer() {
+        return SimpleRetryer.builder()
+                .maxAttempts(maxAttempts)
+                .retryDelayTime(retryDelayTime)
+                .retryDelayUnit(retryDelayUnit)
+                .commonType(commonType)
+                .logLevelForSubsequentAttempts(logLevelForSubsequentAttempts)
+                .build();
+    }
 }

--- a/src/test/java/org/kiwiproject/retry/SimpleRetryerConfigTest.java
+++ b/src/test/java/org/kiwiproject/retry/SimpleRetryerConfigTest.java
@@ -212,4 +212,38 @@ class SimpleRetryerConfigTest {
         @Valid
         private SimpleRetryerConfig retryerConfig;
     }
+
+    @Nested
+    class NewRetryer {
+
+        @Test
+        void shouldCreateNewInstances() {
+            var config = new SimpleRetryerConfig();
+            config.setMaxAttempts(5);
+            config.setLogLevelForSubsequentAttempts(Level.DEBUG);
+
+            var retryer = config.newRetryer();
+
+            assertAll(
+                () -> assertThat(retryer.maxAttempts).isEqualTo(config.getMaxAttempts()),
+                () -> assertThat(retryer.retryDelayTime).isEqualTo(config.getRetryDelayTime()),
+                () -> assertThat(retryer.retryDelayUnit).isEqualTo(config.getRetryDelayUnit()),
+                () -> assertThat(retryer.commonType).isEqualTo(config.getCommonType()),
+                () -> assertThat(retryer.logLevelForSubsequentAttempts).isEqualTo(config.getLogLevelForSubsequentAttempts())
+            );
+        }
+
+        @Test
+        void shouldCreateUniqueInstances() {
+            var config = new SimpleRetryerConfig();
+
+            var retryer1 = config.newRetryer();
+            var retryer2 = config.newRetryer();
+            var retryer3 = config.newRetryer();
+
+            assertThat(retryer1)
+                    .isNotSameAs(retryer2)
+                    .isNotSameAs(retryer3);
+        }
+    }
 }


### PR DESCRIPTION
Add an instance factory method in SimpleRetryerConfig that lets you easily create a new SimpleRetryer instance using the configured values.

Closes #804