### PR TITLE
Add null-safe utilities in KiwiDates and KiwiDateTimeConverters

### DIFF
--- a/src/main/java/org/kiwiproject/time/KiwiDateTimeConverters.java
+++ b/src/main/java/org/kiwiproject/time/KiwiDateTimeConverters.java
@@ -1,15 +1,20 @@
 package org.kiwiproject.time;
 
+import static java.util.Objects.isNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.experimental.UtilityClass;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 
 /**
  * A collection of small utility methods to convert between legacy {@link Date} and the Java 8 date/time API classes.
@@ -20,7 +25,7 @@ import java.util.Date;
  * All methods throw {@link IllegalArgumentException} if null values are passed into them.
  *
  * @implNote {@link Date}, according to its JavaDoc, is "intended to reflect coordinated universal time (UTC)"
- * though "it may not do so exactly". The utilities in this class convert arguments to to UTC before converting
+ * though "it may not do so exactly". The utilities in this class convert arguments to UTC before converting
  * to {@link Date} in order to reflect that intention.
  */
 @UtilityClass
@@ -61,6 +66,40 @@ public class KiwiDateTimeConverters {
         checkArgumentNotNull(zonedDateTime);
 
         return Date.from(zonedDateTime.toInstant());
+    }
+
+    /**
+     * Return the {@link Instant} converted from {@code date}, or {@code null} if {@code date} is {@code null}.
+     * <p>
+     * This is a null-safe wrapper around {@link Date#toInstant()}, and is useful in situations when you might
+     * have a {@code null} date.
+     *
+     * @param date the {@link Date} to convert, may be null
+     * @return the converted {@link Instant} or {@code null}
+     * @implNote This method only exists because {@link Date#toInstant()} is an instance method and obviously a
+     * {@link NullPointerException} is thrown if you attempt to call it when the receiver is {@code null}, i.e.
+     * {@code maybeNullDate.toInstant()}.
+     */
+    @Nullable
+    public static Instant toInstantOrNull(@Nullable Date date) {
+        return isNull(date) ? null : date.toInstant();
+    }
+
+    /**
+     * Return the {@link Instant} converted from {@code calendar}, or {@code null} if {@code calendar} is {@code null}.
+     * <p>
+     * This is a null-safe wrapper around {@link Calendar#toInstant()}, and is useful in situations when you might
+     * have a {@code null} calendar.
+     *
+     * @param calendar the {@link Calendar} to convert, may be null
+     * @return the converted {@link Instant} or {@code null}
+     * @implNote This method only exists because {@link Calendar#toInstant()} is an instance method and obviously a
+     * {@link NullPointerException} is thrown if you attempt to call it when the receiver is {@code null}, i.e.
+     * {@code maybeNullCalendar.toInstant()}.
+     */
+    @Nullable
+    public static Instant toInstantOrNull(@Nullable Calendar calendar) {
+        return isNull(calendar) ? null : calendar.toInstant();
     }
 
     /**
@@ -135,5 +174,25 @@ public class KiwiDateTimeConverters {
         checkArgumentNotNull(zoneId);
 
         return date.toInstant().atZone(zoneId);
+    }
+
+    /**
+     * Return the {@link ZonedDateTime} converted from {@code calendar}, or {@code null} if {@code calendar}
+     * is {@code null}.
+     * <p>
+     * This is a null-safe wrapper around {@link GregorianCalendar#toZonedDateTime()}, and is useful in situations
+     * when you might have a {@code null} calendar.
+     *
+     * @param calendar the {@link GregorianCalendar} to convert, may be null
+     * @return the converted {@link ZonedDateTime} or {@code null}
+     * @implNote This method only exists because {@link GregorianCalendar#toZonedDateTime()} is an instance method and
+     * obviously a {@link NullPointerException} is thrown if you attempt to call it when the receiver is
+     * {@code null}, i.e. {@code maybeNullGregorianCalendar.toZonedDateTime()}. Note also that {@code toZonedDateTime}
+     * is only in {@link GregorianCalendar}, not the base {@link Calendar}, which is the reason this accepts a
+     * {@link GregorianCalendar} argument.
+     */
+    @Nullable
+    public static ZonedDateTime toZonedDateTimeOrNull(@Nullable GregorianCalendar calendar) {
+        return isNull(calendar) ? null : calendar.toZonedDateTime();
     }
 }

--- a/src/main/java/org/kiwiproject/time/KiwiDates.java
+++ b/src/main/java/org/kiwiproject/time/KiwiDates.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.time;
 
+import static java.util.Objects.isNull;
 import static org.kiwiproject.time.KiwiInstants.minusDays;
 import static org.kiwiproject.time.KiwiInstants.minusHours;
 import static org.kiwiproject.time.KiwiInstants.minusMinutes;
@@ -12,6 +13,7 @@ import static org.kiwiproject.time.KiwiInstants.plusMonths;
 import static org.kiwiproject.time.KiwiInstants.plusYears;
 
 import lombok.experimental.UtilityClass;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.time.Instant;
 import java.util.Date;
@@ -41,6 +43,22 @@ public class KiwiDates {
      */
     public static Date dateFrom(Instant instant) {
         return Date.from(instant);
+    }
+
+    /**
+     * Return the {@link Date} converted from {@code instant}, or {@code null} if {@code instant} is {@code null}.
+     * <p>
+     * This is a null-safe wrapper around {@link Date#from(Instant)}, and is useful in situations when you might
+     * have a {@code null} instant.
+     *
+     * @param instant the {@link Instant} to convert, may be null
+     * @return the converted {@link Date} or {@code null}
+     * @apiNote This method only exists because {@link Date#from(Instant)} throws {@link NullPointerException} if its
+     * arguments is {@code null}.
+     */
+    @Nullable
+    public static Date dateFromInstantOrNull(@Nullable Instant instant) {
+        return isNull(instant) ? null : dateFrom(instant);
     }
 
     /**

--- a/src/test/java/org/kiwiproject/time/KiwiDateTimeConvertersTest.java
+++ b/src/test/java/org/kiwiproject/time/KiwiDateTimeConvertersTest.java
@@ -1,5 +1,7 @@
 package org.kiwiproject.time;
 
+import static java.util.Calendar.DAY_OF_YEAR;
+import static java.util.Calendar.YEAR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.kiwiproject.time.KiwiDateTimeTestConstants.GUY_FAWKES_AS_DATE;
@@ -26,6 +28,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 
 /**
  * @implNote Uses constants defined in {@link KiwiDateTimeTestConstants}.
@@ -85,6 +90,86 @@ class KiwiDateTimeConvertersTest {
 
             softly.assertThat(KiwiDateTimeConverters.toDate(GUY_FAWKES_AS_ZONED_DATE_TIME_IN_TOKYO))
                     .isEqualTo(GUY_FAWKES_AS_DATE);
+        }
+    }
+
+    @Nested
+    class ToInstantOrNull_UsingDate {
+
+        @Test
+        void shouldReturnNullWhenGivenLiteralNull() {
+            assertThat(KiwiDateTimeConverters.toInstantOrNull((Date) null)).isNull();
+        }
+
+        @SuppressWarnings("ConstantValue")
+        @Test
+        void shouldReturnNullWhenGivenNull() {
+            Date date = null;
+            assertThat(KiwiDateTimeConverters.toInstantOrNull(date)).isNull();
+        }
+
+        @Test
+        void shouldConvertNonNullDate() {
+            var date = new Date();
+            var instant = KiwiDateTimeConverters.toInstantOrNull(date);
+
+            assertThat(instant).isEqualTo(date.toInstant());
+        }
+    }
+
+    @Nested
+    class ToInstantOrNull_UsingCalendar {
+
+        @Test
+        void shouldReturnNullWhenGivenLiteralNullCalendar() {
+            assertThat(KiwiDateTimeConverters.toInstantOrNull((Calendar) null)).isNull();
+        }
+
+        @SuppressWarnings("ConstantValue")
+        @Test
+        void shouldReturnNullWhenGivenNullCalendar() {
+            Calendar calendar = null;
+            assertThat(KiwiDateTimeConverters.toInstantOrNull(calendar)).isNull();
+        }
+
+        @Test
+        void shouldReturnNullWhenGivenLiteralNullGregorianCalendar() {
+            assertThat(KiwiDateTimeConverters.toInstantOrNull((GregorianCalendar) null)).isNull();
+        }
+
+        @SuppressWarnings("ConstantValue")
+        @Test
+        void shouldReturnNullWhenGivenNullGregorianCalendar() {
+            GregorianCalendar calendar = null;
+            assertThat(KiwiDateTimeConverters.toInstantOrNull(calendar)).isNull();
+        }
+
+        @Test
+        void shouldConvertNonNullCalendar() {
+            var calendar = Calendar.getInstance();
+            var instant = KiwiDateTimeConverters.toInstantOrNull(calendar);
+
+            assertThat(instant).isEqualTo(calendar.toInstant());
+        }
+
+        @Test
+        void shouldConvertNonNullGregorianCalendar() {
+            var calendar = new GregorianCalendar();
+            var instant = KiwiDateTimeConverters.toInstantOrNull(calendar);
+
+            assertThat(instant).isEqualTo(calendar.toInstant());
+        }
+
+        @Test
+        void shouldConvertNonNullJapaneseImperialCalendar() {
+            var calendar = new Calendar.Builder()
+                    .setCalendarType("japanese")
+                    .setFields(YEAR, 1, DAY_OF_YEAR, 1)
+                    .build();
+            assertThat(calendar.getCalendarType()).isEqualTo("japanese");  // sanity check
+            var instant = KiwiDateTimeConverters.toInstantOrNull(calendar);
+
+            assertThat(instant).isEqualTo(calendar.toInstant());
         }
     }
 
@@ -217,6 +302,23 @@ class KiwiDateTimeConvertersTest {
 
             softly.assertThat(KiwiDateTimeConverters.toZonedDateTime(GUY_FAWKES_AS_DATE, TOKYO_TIME))
                     .isEqualTo(GUY_FAWKES_AS_ZONED_DATE_TIME_IN_TOKYO);
+        }
+    }
+
+    @Nested
+    class ToZonedDateTimeOrNull {
+
+        @Test
+        void shouldReturnNullWhenGivenNull() {
+            assertThat(KiwiDateTimeConverters.toZonedDateTimeOrNull(null)).isNull();
+        }
+
+        @Test
+        void shouldConvertNonNullGregorianCalendar() {
+            var calendar = new GregorianCalendar();
+            var zonedDateTime = KiwiDateTimeConverters.toZonedDateTimeOrNull(calendar);
+
+            assertThat(zonedDateTime).isEqualTo(calendar.toZonedDateTime());
         }
     }
 }

--- a/src/test/java/org/kiwiproject/time/KiwiDatesTest.java
+++ b/src/test/java/org/kiwiproject/time/KiwiDatesTest.java
@@ -34,6 +34,23 @@ class KiwiDatesTest {
     }
 
     @Nested
+    class DateFromInstantOrNull {
+
+        @Test
+        void shouldReturnNullWhenGivenNull() {
+            assertThat(KiwiDates.dateFromInstantOrNull(null)).isNull();
+        }
+
+        @Test
+        void shouldConvertNonNullInstant() {
+            var instant = Instant.now();
+            var date = KiwiDates.dateFromInstantOrNull(instant);
+
+            assertThat(date).isEqualTo(instant);
+        }
+    }
+
+    @Nested
     class MinuteAdjusters {
 
         private Instant aMinuteAgo;


### PR DESCRIPTION
* Add KiwiDates#dateFromInstantOrNull(Instant)
* Add KiwiDateTimeConverters#toInstantOrNull(Date)
* Add KiwiDateTimeConverters#toInstantOrNull(Calendar)
* Add KiwiDateTimeConverters#toZonedDateTimeOrNull(GregorianCalendar)
* Fix miscellaneous Javadoc error in KiwiDateTimeConverters

Closes #823
Closes #824
Closes #825
Closes #826