### PR TITLE
Make minimumPageNumber public in PageNumberingScheme enum

### DIFF
--- a/src/main/java/org/kiwiproject/search/KiwiSearching.java
+++ b/src/main/java/org/kiwiproject/search/KiwiSearching.java
@@ -8,7 +8,8 @@ import lombok.experimental.UtilityClass;
 
 /**
  * Utilities related to searching and pagination. Supports both zero- and one-based page numbering but the
- * default is one-based. Use the methods that accept
+ * default is one-based. Use the methods that accept {@link PageNumberingScheme} to work with either zero-
+ * or one-based numbering.
  */
 @UtilityClass
 public class KiwiSearching {
@@ -35,7 +36,11 @@ public class KiwiSearching {
         @Getter
         public final String pageNumberError;
 
-        private final int minimumPageNumber;
+        /**
+         * @implNote Allow access through traditional getter method or via public (immutable) field
+         */
+        @Getter
+        public final int minimumPageNumber;
 
         PageNumberingScheme(String pageNumberError, int minimumPageNumber) {
             this.pageNumberError = pageNumberError;

--- a/src/test/java/org/kiwiproject/search/KiwiSearchingTest.java
+++ b/src/test/java/org/kiwiproject/search/KiwiSearchingTest.java
@@ -252,4 +252,20 @@ class KiwiSearchingTest {
             }
         }
     }
+
+    @Nested
+    class PageNumberingSchemeEnum {
+
+        @Test
+        void shouldHaveZeroAsMinimumPage_ForZeroBasedNumbering() {
+            assertThat(PageNumberingScheme.ZERO_BASED.minimumPageNumber).isZero();
+            assertThat(PageNumberingScheme.ZERO_BASED.getMinimumPageNumber()).isZero();
+        }
+
+        @Test
+        void shouldHaveOneAsMinimumPage_ForOneBasedNumbering() {
+            assertThat(PageNumberingScheme.ONE_BASED.minimumPageNumber).isOne();
+            assertThat(PageNumberingScheme.ONE_BASED.getMinimumPageNumber()).isOne();
+        }
+    }
 }


### PR DESCRIPTION
By making this public, other classes can perform calculations while taking this value into account. Otherwise, they would need to hard code a zero or a one, as I found while implementing another issue.

Closes #832