### PR TITLE
Add methods to ensure PagingRequest contains pagination properties

### DIFF
--- a/src/main/java/org/kiwiproject/spring/data/PagingParams.java
+++ b/src/main/java/org/kiwiproject/spring/data/PagingParams.java
@@ -1,7 +1,9 @@
 package org.kiwiproject.spring.data;
 
+import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import org.kiwiproject.search.KiwiSearching.PageNumberingScheme;
 import org.springframework.data.domain.Sort;
 
 /**
@@ -35,6 +37,16 @@ public interface PagingParams {
     void setPage(Integer page);
 
     /**
+     * @return the numbering scheme used by this instance
+     */
+    PageNumberingScheme getNumbering();
+
+    /**
+     * @param numbering the numbering scheme this instance should use
+     */
+    void setNumbering(PageNumberingScheme numbering);
+
+    /**
      * @return the page size limit
      */
     Integer getLimit();
@@ -43,6 +55,15 @@ public interface PagingParams {
      * @param limit the page size limit
      */
     void setLimit(Integer limit);
+
+    /**
+     * Check if all pagination properties exist.
+     *
+     * @return true if page, numbering scheme, and limit are all non-null, otherwise false
+     */
+    default boolean hasPaginationProperties() {
+        return nonNull(getPage()) && nonNull(getNumbering()) && nonNull(getLimit());
+    }
 
     /**
      * @return the primary sort property

--- a/src/main/java/org/kiwiproject/spring/data/PagingRequest.java
+++ b/src/main/java/org/kiwiproject/spring/data/PagingRequest.java
@@ -1,8 +1,12 @@
 package org.kiwiproject.spring.data;
 
+import static java.util.Objects.isNull;
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.kiwiproject.search.KiwiSearching.PageNumberingScheme;
 import org.springframework.data.domain.Sort;
 
 import javax.ws.rs.DefaultValue;
@@ -32,7 +36,7 @@ public class PagingRequest implements PagingParams {
     public static final int DEFAULT_MAX_LIMIT = 100;
 
     // IMPLEMENTATION NOTE:
-    // For the @DefaultValue annotations using the Sort.Direction enum, we must use a constant value, meaning
+    // For the @DefaultValue annotations using enums (e.g. Sort.Direction), we must use a constant value, meaning
     // we cannot use the enum and call name(). And unfortunately, you cannot get around it even if you define a
     // private static final String in this or any other class. The compiler error is always:
     // "element value must be a constant expression"
@@ -46,6 +50,13 @@ public class PagingRequest implements PagingParams {
     @QueryParam("page")
     @DefaultValue("0")
     private Integer page = 0;
+
+    /**
+     * The page numbering scheme used by this paging request.
+     */
+    @QueryParam("numbering")
+    @DefaultValue("ZERO_BASED")
+    private PageNumberingScheme numbering = PageNumberingScheme.ZERO_BASED;
 
     /**
      * The page size limit. Default is 100.
@@ -83,4 +94,102 @@ public class PagingRequest implements PagingParams {
     @QueryParam("secondaryDirection")
     @DefaultValue("ASC")
     private Sort.Direction secondaryDirection = Sort.Direction.ASC;
+
+    /**
+     * Create a copy of the given {@link PagingRequest}.
+     *
+     * @param original the object to copy
+     * @return a new instance containing the same values as {@code original}
+     * @throws IllegalArgumentException if {@code original} is {@code null}
+     */
+    public static PagingRequest copyOf(PagingRequest original) {
+        checkArgumentNotNull(original, "PagingRequest to copy must not be null");
+
+        var copy = new PagingRequest();
+        copy.setPage(original.getPage());
+        copy.setNumbering(original.getNumbering());
+        copy.setLimit(original.getLimit());
+        copy.setPrimarySort(original.getPrimarySort());
+        copy.setPrimaryDirection(original.getPrimaryDirection());
+        copy.setSecondarySort(original.getSecondarySort());
+        copy.setSecondaryDirection(original.getSecondaryDirection());
+
+        return copy;
+    }
+
+    /**
+     * Create a copy of this instance.
+     *
+     * @return a new instance containing the same values as {@code this}
+     */
+    public PagingRequest copyOf() {
+        return copyOf(this);
+    }
+
+    /**
+     * Ensure the given {@link PagingRequest} has pagination properties by providing default values for any
+     * null or invalid properties.
+     * <p>
+     * Note specifically that this mutates the {@code request} argument in-place. You can use either the instance or
+     * static {@code withPaginationProperties} method to create a new instance with valid pagination properties to
+     * avoid mutation of the original {@link PagingRequest} instance.
+     *
+     * @param request the {@link PagingRequest} to check; <em>this argument may be mutated in-place</em>
+     * @return true if {@code request} was mutated, otherwise false
+     */
+    public static boolean ensurePaginationProperties(PagingRequest request) {
+        var changed = false;
+
+        var limit = request.getLimit();
+        if (isNull(limit) || limit < 1) {
+            request.setLimit(DEFAULT_MAX_LIMIT);
+            changed = true;
+        }
+
+        if (isNull(request.getNumbering())) {
+            request.setNumbering(PageNumberingScheme.ZERO_BASED);
+            changed = true;
+        }
+
+        var minPage = request.getNumbering().getMinimumPageNumber();
+        var page = request.getPage();
+        if (isNull(page) || page < minPage) {
+            request.setPage(minPage);
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    /**
+     * Ensure the given {@link PagingRequest} has pagination properties by providing default values for any
+     * null or invalid properties, returning the same instance if it is valid, and otherwise returning a new
+     * instance.
+     *
+     * @param request the request to check
+     * @return {@code request} if it contains pagination properties, otherwise a new instance with valid values
+     * for the missing properties
+     */
+    public static PagingRequest withPaginationProperties(PagingRequest request) {
+        checkArgumentNotNull(request, "PagingRequest must not be null");
+
+        if (request.hasPaginationProperties()) {
+            return request;
+        }
+
+        var newRequest = request.copyOf();
+        ensurePaginationProperties(newRequest);
+        return newRequest;
+    }
+
+    /**
+     * Ensure the given {@link PagingRequest} has pagination properties by providing default values for any
+     * null or invalid properties.
+     *
+     * @return this instance if it contains pagination properties, otherwise a new instance with valid values
+     * for the missing properties
+     */
+    public PagingRequest withPaginationProperties() {
+        return withPaginationProperties(this);
+    }
 }

--- a/src/test/java/org/kiwiproject/spring/data/PagingParamsTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingParamsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.kiwiproject.search.KiwiSearching.PageNumberingScheme;
 
 @DisplayName("PagingParams")
 class PagingParamsTest {
@@ -15,6 +16,32 @@ class PagingParamsTest {
     @BeforeEach
     void setUp() {
         pagingParams = new PagingRequest();
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "1, ONE_BASED, 10, true",
+                    "0, ZERO_BASED, 15, true",
+                    "null, null, null, false",
+                    "null, ZERO_BASED, 25, false",
+                    "0, null, 15, false",
+                    "0, ZERO_BASED, null, false",
+                    "null, null, 10, false",
+                    "null, ONE_BASED, null, false",
+                    "1, null, null, false",
+                    "1, null, 50, false",
+            },
+            nullValues = "null"
+    )
+    void shouldHavePaginationProperties(
+            Integer page, PageNumberingScheme numbering, Integer limit, boolean isExpectedToHavePaginationProperties) {
+
+        pagingParams.setPage(page);
+        pagingParams.setNumbering(numbering);
+        pagingParams.setLimit(limit);
+
+        assertThat(pagingParams.hasPaginationProperties()).isEqualTo(isExpectedToHavePaginationProperties);
     }
 
     @ParameterizedTest

--- a/src/test/java/org/kiwiproject/spring/data/PagingRequestTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/PagingRequestTest.java
@@ -1,13 +1,22 @@
 package org.kiwiproject.spring.data;
 
+import static java.util.Objects.isNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.SoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.search.KiwiSearching.PageNumberingScheme;
 import org.springframework.data.domain.Sort;
 
 import javax.ws.rs.BeanParam;
@@ -43,6 +52,7 @@ class PagingRequestTest {
         var pagingRequest = new PagingRequest();
 
         softly.assertThat(pagingRequest.getPage()).isZero();
+        softly.assertThat(pagingRequest.getNumbering()).isEqualTo(PageNumberingScheme.ZERO_BASED);
         softly.assertThat(pagingRequest.getLimit()).isEqualTo(100);
         softly.assertThat(pagingRequest.getPrimarySort()).isNull();
         softly.assertThat(pagingRequest.getPrimaryDirection()).isEqualTo(Sort.Direction.ASC);
@@ -58,6 +68,7 @@ class PagingRequestTest {
                 .get(PagingRequest.class);
 
         softly.assertThat(pagingRequest.getPage()).isZero();
+        softly.assertThat(pagingRequest.getNumbering()).isEqualTo(PageNumberingScheme.ZERO_BASED);
         softly.assertThat(pagingRequest.getLimit()).isEqualTo(PagingRequest.DEFAULT_MAX_LIMIT);
         softly.assertThat(pagingRequest.getPrimaryDirection()).isEqualTo(Sort.Direction.ASC);
         softly.assertThat(pagingRequest.getSecondaryDirection()).isEqualTo(Sort.Direction.ASC);
@@ -78,6 +89,7 @@ class PagingRequestTest {
     void shouldAccept_AllPagingParameters(SoftAssertions softly) {
         var pagingRequest = RESOURCES.client().target("/paging")
                 .queryParam("page", 5)
+                .queryParam("numbering", "ONE_BASED")
                 .queryParam("limit", 25)
                 .queryParam("primarySort", "lastName")
                 .queryParam("primaryDirection", Sort.Direction.DESC.name())
@@ -87,11 +99,203 @@ class PagingRequestTest {
                 .get(PagingRequest.class);
 
         softly.assertThat(pagingRequest.getPage()).isEqualTo(5);
+        softly.assertThat(pagingRequest.getNumbering()).isEqualTo(PageNumberingScheme.ONE_BASED);
         softly.assertThat(pagingRequest.getLimit()).isEqualTo(25);
         softly.assertThat(pagingRequest.getPrimarySort()).isEqualTo("lastName");
         softly.assertThat(pagingRequest.getPrimaryDirection()).isEqualTo(Sort.Direction.DESC);
         softly.assertThat(pagingRequest.getSecondarySort()).isEqualTo("firstName");
         softly.assertThat(pagingRequest.getSecondaryDirection()).isEqualTo(Sort.Direction.ASC);
+    }
+
+    @Test
+    void shouldHandleEmptyPageAndLimitAsDefaults(SoftAssertions softly) {
+        var pagingRequest = RESOURCES.client().target("/paging")
+                .queryParam("page", "")
+                .queryParam("numbering", "")
+                .queryParam("limit", "")
+                .request()
+                .get(PagingRequest.class);
+
+        softly.assertThat(pagingRequest.getPage()).isZero();
+        softly.assertThat(pagingRequest.getNumbering()).isEqualTo(PageNumberingScheme.ZERO_BASED);
+        softly.assertThat(pagingRequest.getLimit()).isEqualTo(PagingRequest.DEFAULT_MAX_LIMIT);
+    }
+
+    @Test
+    void shouldNotAllowNullArgument_ToCopyOf() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> PagingRequest.copyOf(null))
+                .withMessage("PagingRequest to copy must not be null");
+    }
+
+    @Test
+    void shouldCreateCopy() {
+        var original = new PagingRequest();
+        original.setPage(2);
+        original.setNumbering(PageNumberingScheme.ONE_BASED);
+        original.setLimit(20);
+        original.setPrimarySort("lastName");
+        original.setPrimaryDirection(Sort.Direction.DESC);
+        original.setSecondarySort("firstName");
+        original.setSecondaryDirection(Sort.Direction.DESC);
+
+        var copy = PagingRequest.copyOf(original);
+
+        assertThat(copy).usingRecursiveComparison().isEqualTo(original);
+    }
+
+    @Test
+    void shouldCreateCopy_FromInstance() {
+        var original = new PagingRequest();
+        original.setPage(1);
+        original.setNumbering(PageNumberingScheme.ONE_BASED);
+        original.setLimit(10);
+        original.setPrimarySort("age");
+        original.setPrimaryDirection(Sort.Direction.DESC);
+
+        var copy = original.copyOf();
+
+        assertThat(copy).usingRecursiveComparison().isEqualTo(original);
+    }
+
+    @Test
+    void shouldEnsurePaginationProperties_AndChangeNothing_IfHasPaginationProperties() {
+        var request = new PagingRequest();
+        request.setPage(3);
+        request.setNumbering(PageNumberingScheme.ONE_BASED);
+        request.setLimit(15);
+
+        assertThat(PagingRequest.ensurePaginationProperties(request)).isFalse();
+    }
+
+    @Test
+    void shouldEnsurePaginationProperties_AndChangePage_IfMissing() {
+        var request = new PagingRequest();
+        request.setPage(null);
+        request.setNumbering(PageNumberingScheme.ONE_BASED);
+
+        assertThat(PagingRequest.ensurePaginationProperties(request)).isTrue();
+        assertThat(request.getPage()).isOne();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-10, -1})
+    void shouldEnsurePaginationProperties_AndChangePage_IfInvalid(int page) {
+        var request = new PagingRequest();
+        request.setPage(page);
+
+        assertThat(PagingRequest.ensurePaginationProperties(request)).isTrue();
+        assertThat(request.getPage()).isZero();
+    }
+
+    @Test
+    void shouldEnsurePaginationProperties_AndChangeNumbering_IfMissing() {
+        var request = new PagingRequest();
+        request.setNumbering(null);
+
+        assertThat(PagingRequest.ensurePaginationProperties(request)).isTrue();
+        assertThat(request.getNumbering()).isEqualTo(PageNumberingScheme.ZERO_BASED);
+    }
+
+    @Test
+    void shouldEnsurePaginationProperties_AndChangeLimit_IfMissing() {
+        var request = new PagingRequest();
+        request.setLimit(null);
+
+        assertThat(PagingRequest.ensurePaginationProperties(request)).isTrue();
+        assertThat(request.getLimit()).isEqualTo(PagingRequest.DEFAULT_MAX_LIMIT);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-10, -1, 0})
+    void shouldEnsurePaginationProperties_AndChangeLimit_IfInvalid(int limit) {
+        var request = new PagingRequest();
+        request.setLimit(limit);
+
+        assertThat(PagingRequest.ensurePaginationProperties(request)).isTrue();
+        assertThat(request.getLimit()).isEqualTo(PagingRequest.DEFAULT_MAX_LIMIT);
+    }
+
+    @Test
+    void shouldNotAllowNullPagingRequest_To_static_withPaginationProperties() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> PagingRequest.withPaginationProperties(null))
+                .withMessage("PagingRequest must not be null");
+    }
+
+    @Test
+    void shouldReturnSameInstance_When_static_withPaginationProperties_IsGivenPagingRequest_HavingPaginationProperties() {
+        var request = new PagingRequest();
+        request.setPage(1);
+        request.setNumbering(PageNumberingScheme.ONE_BASED);
+        request.setLimit(25);
+
+        assertThat(PagingRequest.withPaginationProperties(request)).isSameAs(request);
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+            value = {
+                    "null, ONE_BASED, 10",
+                    "1, null, 25",
+                    "0, ZERO_BASED, null",
+                    "null, null, null"
+            },
+            nullValues = "null"
+    )
+    void shouldReturnNewInstance_When_static_withPaginationProperties_IsGivenInvalidPagingRequest(
+            Integer page, PageNumberingScheme numbering, Integer limit) {
+
+        var request = new PagingRequest();
+        request.setPage(page);
+        request.setNumbering(numbering);
+        request.setLimit(limit);
+
+        var expectedRequest = buildExpectedPagingRequest(page, numbering, limit);
+
+        assertThat(PagingRequest.withPaginationProperties(request))
+                .usingRecursiveComparison()
+                .isEqualTo(expectedRequest);
+    }
+
+    private static PagingRequest buildExpectedPagingRequest(@Nullable Integer page,
+                                                            @Nullable PageNumberingScheme numbering,
+                                                            @Nullable Integer limit) {
+        var expectedRequest = new PagingRequest();
+
+        var expectedNumbering = isNull(numbering) ? PageNumberingScheme.ZERO_BASED : numbering;
+        expectedRequest.setNumbering(expectedNumbering);
+
+        var expectedPage = isNull(page) ? expectedNumbering.getMinimumPageNumber() : page;
+        expectedRequest.setPage(expectedPage);
+
+        var expectedLimit = isNull(limit) ? PagingRequest.DEFAULT_MAX_LIMIT : limit;
+        expectedRequest.setLimit(expectedLimit);
+        return expectedRequest;
+    }
+
+    @Test
+    void shouldReturnSameInstance_When_withPaginationProperties_IsGivenPagingRequest_HavingPaginationProperties() {
+        var request = new PagingRequest();
+        request.setPage(1);
+        request.setNumbering(PageNumberingScheme.ONE_BASED);
+        request.setLimit(25);
+
+        assertThat(request.withPaginationProperties()).isSameAs(request);
+    }
+
+    @Test
+    void shouldReturnNewInstance_When_withPaginationProperties_IsGivenInvalidPagingRequest() {
+        var request = new PagingRequest();
+        request.setPage(null);
+        request.setNumbering(null);
+        request.setLimit(null);
+
+        var expectedRequest = new PagingRequest();
+
+        assertThat(request.withPaginationProperties())
+                .usingRecursiveComparison()
+                .isEqualTo(expectedRequest);
     }
 
     @Path("/paging")


### PR DESCRIPTION
* Add get/setNumbering with type PageNumberingScheme to PagingParams
* Add default hasPaginationProperties method to PagingParams
* Add numbering property to PagingRequest with ZERO_BASED as the default value (both for new instances and JAX-RS query param)
* Add static and instance copyOf method to provide easy copying
* Add ensurePaginationProperties method which ensures that a PagingRequest contains valid page, numbering, and limit properties, mutating in-place if necessary
* Add static and instance withPaginationProperties methods; these never mutate the PagingRequest and either returns the same instance if it has pagination properties, or returns a new instance with valid pagination properties

Closes #829