### PR TITLE
Fully qualify javadoc links to Lombok classes

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiPreconditions.java
+++ b/src/main/java/org/kiwiproject/base/KiwiPreconditions.java
@@ -29,9 +29,9 @@ import java.util.function.Supplier;
  * If you're looking for preconditions related to validating arguments using Jakarta Beans Validation, they
  * are in {@link org.kiwiproject.validation.KiwiValidations KiwiValidations}.
  *
- * @implNote Several methods in this class use Lombok's {@link SneakyThrows} so that they do not need to declare
+ * @implNote Several methods in this class use Lombok's {@link lombok.SneakyThrows} so that they do not need to declare
  * that they throw exceptions of type T, <em>for the case that T is a checked exception</em>. Read more details about
- * how this works in {@link SneakyThrows}. Most notably, this should give you more insight into how the JVM (versus
+ * how this works in {@link lombok.SneakyThrows}. Most notably, this should give you more insight into how the JVM (versus
  * Java the language) actually work: <em>"The JVM does not check for the consistency of the checked exception system;
  * javac does, and this annotation lets you opt out of its mechanism."</em>
  */
@@ -49,7 +49,7 @@ public class KiwiPreconditions {
      * @param expression    a boolean expression
      * @param exceptionType the type of exception to be thrown if {@code expression} is false
      * @param <T>           the type of exception
-     * @implNote This uses Lombok's {@link SneakyThrows} to throw any checked exceptions without declaring them.
+     * @implNote This uses Lombok's {@link lombok.SneakyThrows} to throw any checked exceptions without declaring them.
      */
     @SneakyThrows(Throwable.class)
     public static <T extends Throwable> void checkArgument(boolean expression, Class<T> exceptionType) {
@@ -67,7 +67,7 @@ public class KiwiPreconditions {
      * @param exceptionType the type of exception to be thrown if {@code expression} is false
      * @param errorMessage  the exception message to use if the check fails
      * @param <T>           the type of exception
-     * @implNote This uses Lombok's {@link SneakyThrows} to throw any checked exceptions without declaring them.
+     * @implNote This uses Lombok's {@link lombok.SneakyThrows} to throw any checked exceptions without declaring them.
      */
     @SneakyThrows(Throwable.class)
     public static <T extends Throwable> void checkArgument(boolean expression,
@@ -93,7 +93,7 @@ public class KiwiPreconditions {
      * @param <T>                  the type of exception
      * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
      *                              {@code errorMessageArgs} is null (don't let this happen)
-     * @implNote This uses Lombok's {@link SneakyThrows} to throw any checked exceptions without declaring them.
+     * @implNote This uses Lombok's {@link lombok.SneakyThrows} to throw any checked exceptions without declaring them.
      */
     @SneakyThrows(Throwable.class)
     public static <T extends Throwable> void checkArgument(boolean expression,

--- a/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
@@ -87,7 +87,7 @@ import java.util.stream.Stream;
  * features of this class. It isn't perfect, but it works and, in our opinion anyway, doesn't intrude too much on
  * building JAX-RS requests. In other words, we think it is a decent trade off.
  *
- * @implNote Internally this uses Lombok's {@link Delegate}, which is why this class doesn't implement {@link WebTarget}
+ * @implNote Internally this uses Lombok's {@link lombok.Delegate}, which is why this class doesn't implement {@link WebTarget}
  * directly. While this lets us easily delegate method calls to a {@link WebTarget}, it also restricts what we can do
  * here, and is the primary reason why there are usage restrictions. However, in our general usage this implementation
  * has been enough for our needs. Nevertheless, this is currently marked with the Guava {@link Beta} annotation in case

--- a/src/main/java/org/kiwiproject/jsch/SftpConfig.java
+++ b/src/main/java/org/kiwiproject/jsch/SftpConfig.java
@@ -128,7 +128,7 @@ public class SftpConfig {
      * @param disableStrictHostChecking if true, we will set {@code StrictHostKeyChecking=no}
      * @param timeout                   the SFTP connection timeout
      * @implNote This is intentionally not using Lombok because using {@link lombok.AllArgsConstructor} together
-     * with @{@link Builder} results in an all-args constructor that does not respect {@link lombok.Builder.Default}.
+     * with @{@link lombok.Builder} results in an all-args constructor that does not respect {@link lombok.Builder.Default}.
      * As a result we need to handle the defaults ourselves. This is intended to be used during deserialization
      * from an external configuration file (e.g. a Dropwizard YAML configuration file, or from JSON). Prefer the
      * builder when constructing programmatically.


### PR DESCRIPTION
This will help when we fix javadoc generation so that the javadoc plugin generates javadocs based on de-Lomboked code. This is something that will need to be done in kiwi-parent. Without doing this, javadoc will fail with an error because it can't find the referenced class.