### PR TITLE
CodeQL: Fix "Dereferenced variable may be null " in KiwiSecurity

### DIFF
--- a/src/main/java/org/kiwiproject/security/KiwiSecurity.java
+++ b/src/main/java/org/kiwiproject/security/KiwiSecurity.java
@@ -294,7 +294,12 @@ public class KiwiSecurity {
 
     /**
      * Return an {@link Optional} containing a {@link KeyStore} for the given {@link KeyStoreType}, path, and
-     * password, or an empty {@link Optional} if the arguments are (both) null.
+     * password, or an empty {@link Optional} if either path or password is null.
+     * <p>
+     * This method is intended to load an <em>existing</em> key store. If you need to programatically create a new
+     * one, use the {@link KeyStore} API directly.
+     * <p>
+     * If the returned Optional contains a KeyStore, it has been successfully loaded.
      *
      * @param keyStoreType the type of key store
      * @param path         the path to the key store
@@ -303,6 +308,7 @@ public class KiwiSecurity {
      * @throws IllegalArgumentException if keyStoreType is blank
      * @throws SSLContextException      if unable to create a {@link KeyStore}
      * @see KeyStore#getInstance(String)
+     * @see KeyStore#load(java.io.InputStream, char[])
      */
     public static Optional<KeyStore> getKeyStore(KeyStoreType keyStoreType, String path, String password) {
         checkArgumentNotNull(keyStoreType, "keyStoreType cannot be null");
@@ -311,7 +317,12 @@ public class KiwiSecurity {
 
     /**
      * Return an {@link Optional} containing a {@link KeyStore} for the given {@link KeyStoreType}, path, and
-     * password, or an empty {@link Optional} if the arguments are (both) null.
+     * password, or an empty {@link Optional} if either path or password is null.
+     * <p>
+     * This method is intended to load an <em>existing</em> key store. If you need to programatically create a new
+     * one, use the {@link KeyStore} API directly.
+     * <p>
+     * If the returned Optional contains a KeyStore, it has been successfully loaded.
      *
      * @param keyStoreType the type of key store
      * @param path         the path to the key store
@@ -320,11 +331,12 @@ public class KiwiSecurity {
      * @throws IllegalArgumentException if keyStoreType is blank
      * @throws SSLContextException      if unable to create a {@link KeyStore}
      * @see KeyStore#getInstance(String)
+     *  @see KeyStore#load(java.io.InputStream, char[])
      */
     public static Optional<KeyStore> getKeyStore(String keyStoreType, String path, String password) {
-        LOG.trace("Creating {} KeyStore/TrustStore for {}", keyStoreType, path);
-        if (isNull(path) && isNull(password)) {
-            LOG.debug("No keystore specified");
+        LOG.trace("Get and load {} KeyStore/TrustStore for {}", keyStoreType, path);
+        if (isNull(path) || isNull(password)) {
+            LOG.debug("No keystore specified (path and/or password is null)");
             return Optional.empty();
         }
 

--- a/src/test/java/org/kiwiproject/security/KiwiSecurityTest.java
+++ b/src/test/java/org/kiwiproject/security/KiwiSecurityTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.kiwiproject.util.BlankStringArgumentsProvider;
 
@@ -352,17 +353,22 @@ class KiwiSecurityTest {
 
             @Test
             void whenValidStringTypeAndPathAndCredential() {
-                assertThat(KiwiSecurity.getKeyStore("JKS", path, password)).isNotNull();
+                assertThat(KiwiSecurity.getKeyStore("JKS", path, password)).isPresent();
             }
 
             @Test
             void whenValidKeyStoreAndTypeAndCredential() {
-                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password)).isNotNull();
+                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password)).isPresent();
             }
 
-            @Test
-            void whenGivenNullPathAndPassword() {
-                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, null, null)).isEmpty();
+            @ParameterizedTest
+            @CsvSource(value = {
+                "null, null",
+                "/certs/my.jks, null",
+                "null, the_password!"
+            }, nullValues = "null")
+            void whenGivenNullPathOrPassword(String path, String password) {
+                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password)).isEmpty();
             }
         }
 


### PR DESCRIPTION
* Change getKeyStore methods so that they return an empty Optional if either path or password is null.
* Update Javadocs to match new implementation and explain the intent of these methods is to load an existing key store, not create a new one.
* Fix several tests that were asserting that the returned Optional was not null instead of it containing a value.

Fixes #861