### PR TITLE
CodeQL: Fix "Log Injection" in RangeValidator

### DIFF
--- a/src/main/java/org/kiwiproject/validation/RangeValidator.java
+++ b/src/main/java/org/kiwiproject/validation/RangeValidator.java
@@ -120,11 +120,12 @@ public class RangeValidator implements ConstraintValidator<Range, Object> {
     }
 
     private static void logWarning(Object value, Exception e) {
+        var type = isNull(value) ? null : value.getClass().getName();
         if (value instanceof Comparable) {
-            LOG.warn("Error validating Range for value: {} ; considering as invalid", value, e);
+            LOG.warn("Error validating Range for value of type {} (which may not be supported) ; considering as invalid", type, e);
         } else {
-            LOG.warn("Error validating Range for value that does not implement Comparable: {} ; considering as invalid",
-                    value, e);
+            LOG.warn("Error validating Range for value of type {} that does not implement Comparable ; considering as invalid",
+                    type, e);
         }
     }
 }


### PR DESCRIPTION
In logWarning, simply log the type of the object instead of the (user-entered) value. This provides less information, but avoids the log injection problem.

Fixes #881
Fixes #882