### PR TITLE
CodeQL: Fix "Log Injection" in path validators

### DIFF
--- a/src/main/java/org/kiwiproject/validation/DirectoryPathValidator.java
+++ b/src/main/java/org/kiwiproject/validation/DirectoryPathValidator.java
@@ -2,6 +2,7 @@ package org.kiwiproject.validation;
 
 import static java.util.Objects.isNull;
 import static org.kiwiproject.logging.LazyLogParameterSupplier.lazy;
+import static org.kiwiproject.validation.InternalKiwiValidators.containsNulCharacter;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,8 +49,8 @@ public class DirectoryPathValidator implements ConstraintValidator<DirectoryPath
                     isWritableOrIgnoresEnsureReadable(file);
 
         } catch (Exception e) {
-            var hasNulCharacter = value.contains("\0") ? " Path contains Nul character!" : "";
-            LOG.warn("Exception thrown validating path [{}].{}", value, hasNulCharacter, e);
+            var nulCharacterMessage = containsNulCharacter(value) ? " Path contains Nul character!" : "";
+            LOG.warn("Exception thrown validating path.{}", nulCharacterMessage, e);
             return false;
         }
     }

--- a/src/main/java/org/kiwiproject/validation/FilePathValidator.java
+++ b/src/main/java/org/kiwiproject/validation/FilePathValidator.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.validation;
 
 import static java.util.Objects.isNull;
+import static org.kiwiproject.validation.InternalKiwiValidators.containsNulCharacter;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,7 +32,8 @@ public class FilePathValidator implements ConstraintValidator<FilePath, String> 
             var file = Path.of(value).toFile();
             return file.exists() && file.isFile();
         } catch (Exception e) {
-            LOG.warn("Exception thrown validating path [{}]", value, e);
+            var nulCharacterMessage = containsNulCharacter(value) ? " Path contains Nul character!" : "";
+            LOG.warn("Exception thrown validating path.{}", nulCharacterMessage, e);
             return false;
         }
     }

--- a/src/main/java/org/kiwiproject/validation/InternalKiwiValidators.java
+++ b/src/main/java/org/kiwiproject/validation/InternalKiwiValidators.java
@@ -91,4 +91,8 @@ class InternalKiwiValidators {
         //noinspection unchecked
         return (Comparable<T>) typedValue;
     }
+
+    static boolean containsNulCharacter(String value) {
+        return value.contains("\0");
+    }
 }


### PR DESCRIPTION
Fix log injection in FilePathValidator and DirectoryPathValidator by removing the path from the log message. I can't find something to easily (and with 100% certainty) sanitize the path from all possible badness, so just removing it entirely.

Add message about the Nul character in FilePathValidator just like the DirectortPathValidator has. Extracted Nul character check to package-private method in InternalKiwiValidators.

Fixes #880
Fixes #883