### PR TITLE
Remove VisibleForTesting from Processes#getPidOrThrow

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/Processes.java
+++ b/src/main/java/org/kiwiproject/base/process/Processes.java
@@ -505,7 +505,6 @@ public class Processes {
         return Pair.of(pid, command);
     }
 
-    @VisibleForTesting
     static Long getPidOrThrow(String pidString) {
         try {
             return Long.valueOf(pidString);


### PR DESCRIPTION
Usage of this package-private method from ProcessHelper in the same package is a valid usage, so removing the VisibleForTesting annotation.

Closes #923