### PR TITLE
Suppress deprecation warnings in KiwiDropwizardDurationsTest

### DIFF
--- a/src/test/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurationsTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/util/KiwiDropwizardDurationsTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.time.temporal.ChronoUnit;
 
 @DisplayName("KiwiDropwizardDurations")
+@SuppressWarnings("deprecation")
 class KiwiDropwizardDurationsTest {
 
     @Nested


### PR DESCRIPTION
Clearly, we know that we're using a deprecated method. So, silence the deprecation warning for usage in the tests.