### PR TITLE
Make Range and FieldRange use an existing message key

### DIFF
--- a/src/main/java/org/kiwiproject/validation/FieldRange.java
+++ b/src/main/java/org/kiwiproject/validation/FieldRange.java
@@ -54,7 +54,7 @@ import java.lang.annotation.Target;
 @Repeatable(FieldRanges.class)
 public @interface FieldRange {
 
-    String message() default "{org.kiwiproject.validation.FieldRange.between.message}";
+    String message() default "{org.kiwiproject.validation.FieldRange.unknownError.message}";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/org/kiwiproject/validation/FieldRangeValidator.java
+++ b/src/main/java/org/kiwiproject/validation/FieldRangeValidator.java
@@ -29,6 +29,7 @@ public class FieldRangeValidator implements ConstraintValidator<FieldRange, Obje
     private static final String TEMPLATE_AFTER_EXCLUSIVE_MIN_MAX_LABELS = "{org.kiwiproject.validation.FieldRange.afterExclusive.message.minMaxLabels}";
     private static final String TEMPLATE_AFTER_INCLUSIVE_MIN_MAX_VALUES = "{org.kiwiproject.validation.FieldRange.afterInclusive.message.minMaxValues}";
     private static final String TEMPLATE_AFTER_INCLUSIVE_MIN_MAX_LABELS = "{org.kiwiproject.validation.FieldRange.afterInclusive.message.minMaxLabels}";
+    private static final String TEMPLATE_UNKNOWN_ERROR = "{org.kiwiproject.validation.FieldRange.unknownError.message}";
 
     private FieldRange fieldRange;
     private String templateBetween;
@@ -49,6 +50,8 @@ public class FieldRangeValidator implements ConstraintValidator<FieldRange, Obje
         this.fieldRange = constraintAnnotation;
 
         var useLabels = isNotBlank(constraintAnnotation.minLabel()) || isNotBlank(constraintAnnotation.maxLabel());
+        LOG.trace("minLabel and/or maxLabel exist, so label-based messages will be used");
+
         this.templateBetween = useLabels ? TEMPLATE_BETWEEN_MIN_MAX_LABELS : TEMPLATE_BETWEEN_MIN_MAX_VALUES;
         this.templateMinOnly = useLabels ? TEMPLATE_MIN_ONLY_MIN_MAX_LABELS : TEMPLATE_MIN_ONLY_MIN_MAX_VALUES;
         this.templateMaxOnly = useLabels ? TEMPLATE_MAX_ONLY_MIN_MAX_LABELS : TEMPLATE_MAX_ONLY_MIN_MAX_VALUES;
@@ -161,7 +164,7 @@ public class FieldRangeValidator implements ConstraintValidator<FieldRange, Obje
     }
 
     private static void addUnknownErrorConstraintViolation(ConstraintValidatorContext context, FieldRange fieldRange) {
-        KiwiValidations.addError(context, "unknown validation error", fieldRange.startField());
+        KiwiValidations.addError(context, TEMPLATE_UNKNOWN_ERROR, fieldRange.startField());
     }
 
     private static void logWarning(Object value, FieldRange fieldRange, Exception e) {

--- a/src/main/java/org/kiwiproject/validation/Range.java
+++ b/src/main/java/org/kiwiproject/validation/Range.java
@@ -24,7 +24,8 @@ import java.lang.annotation.Target;
  * <p>
  * Use {@link #min()} and {@link #max()} to specify the minimum and maximum values allowed in the range. These
  * are <em>inclusive</em> values, e.g. for a range with a minimum of 5 and maximum of 10, the values 5 and 10 are
- * considered as part of the range.
+ * considered as part of the range. A valid range must contain a minimum, a maximum, or both. See the implementation
+ * note below for why this can only be checked at runtime.
  * <p>
  * Use the {@link #minLabel()} and {@link #maxLabel()} to specify custom labels to use in place of the min and max
  * values. This is useful in cases where the min and max are large numbers or when validating date/time values where
@@ -43,6 +44,14 @@ import java.lang.annotation.Target;
  * </ul>
  * While {@code float} and {@code double} are supported, be aware of the possibility for rounding errors when values
  * are near the range bounds. The comparisons use {@link Float#compareTo(Float)} and {@link Double#compareTo(Double)}.
+ *
+ * @implNote A {@link Range} must contain a minimum or a maximum (or both). If no minimum or maximum is supplied, a
+ * {@link IllegalStateException} is thrown at runtime during construction of the {@link RangeValidator}. This is
+ * because this constraint supports various types and not just a single type like Hibernate Validator's {@code Range}
+ * constraint annotation; that annotation supports only numeric types and therefore can set default values for
+ * {@code min} and {@code max}. In contrast, there are no logical defaults which this constraint can provide so the
+ * default must be an empty string for code to compile. The only place to verify a minimum or maximum exists is
+ * therefore when the {@link RangeValidator} is instantiated.
  */
 @Documented
 @Constraint(validatedBy = {RangeValidator.class})
@@ -50,7 +59,7 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 public @interface Range {
 
-    String message() default "{org.kiwiproject.validation.Range.between.message}";
+    String message() default "{org.kiwiproject.validation.Range.between.message.minMaxValues}";
 
     Class<?>[] groups() default {};
 

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -9,6 +9,7 @@ org.kiwiproject.validation.FieldRange.maxOnly.message.minMaxValues=must be below
 org.kiwiproject.validation.FieldRange.maxOnly.message.minMaxLabels=must be below or equal to {maxLabel}
 org.kiwiproject.validation.FieldRange.minOnly.message.minMaxValues=must be equal to or above {min}
 org.kiwiproject.validation.FieldRange.minOnly.message.minMaxLabels=must be equal to or above {minLabel}
+org.kiwiproject.validation.FieldRange.unknownError.message=unknown validation error (type may be unsupported or may not be Comparable)
 org.kiwiproject.validation.FilePath.message=is not a valid file path
 org.kiwiproject.validation.InEnum.message=is not in the list
 org.kiwiproject.validation.IntValue.message=must be convertible to an integer

--- a/src/test/java/org/kiwiproject/validation/FieldRangeValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/FieldRangeValidatorTest.java
@@ -98,13 +98,15 @@ class FieldRangeValidatorTest {
         void shouldBeInvalid_WhenMinMaxForcesConversionToComparable() {
             var today = LocalDate.now();
             var obj = HasUnsupportedType.builder().date1(today).date2(today.plusDays(2)).build();
-            assertViolations(validator, obj, "date1 unknown validation error");
+            assertViolations(validator, obj,
+                    "date1 unknown validation error (type may be unsupported or may not be Comparable)");
         }
 
         @Test
         void shouldBeInvalid_WhenNotComparable() {
             var obj = HasAnIncomparable.builder().ic1(new AnIncomparable()).ic2(new AnIncomparable()).build();
-            assertViolations(validator, obj, "ic1 unknown validation error");
+            assertViolations(validator, obj,
+                    "ic1 unknown validation error (type may be unsupported or may not be Comparable)");
         }
     }
 

--- a/src/test/java/org/kiwiproject/validation/RangeValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/RangeValidatorTest.java
@@ -54,7 +54,7 @@ class RangeValidatorTest {
 
     /**
      * @implNote In these cases, there should be a WARN level log, but we're not going to try to test
-     * that side-effect, and will just rely instead on manual inspection.
+     * that side effect, and will just rely instead on manual inspection.
      */
     @Nested
     class UnsupportedTypes {
@@ -62,13 +62,15 @@ class RangeValidatorTest {
         @Test
         void shouldBeInvalid() {
             var obj = new HasUnsupportedType(LocalDate.now());
-            assertPropertyViolations(validator, obj, "value", "unknown validation error");
+            assertPropertyViolations(validator, obj, "value",
+                    "unknown validation error (type may be unsupported or may not be Comparable)");
         }
 
         @Test
         void shouldBeInvalid_WhenNotComparable() {
             var obj = new HasAnIncomparable(new AnIncomparable());
-            assertPropertyViolations(validator, obj, "value", "unknown validation error");
+            assertPropertyViolations(validator, obj, "value",
+                    "unknown validation error (type may be unsupported or may not be Comparable)");
         }
     }
 
@@ -300,14 +302,14 @@ class RangeValidatorTest {
     @NoArgsConstructor
     @AllArgsConstructor
     static class NullableValue {
-        @Range
+        @Range(min = "0")
         Integer value;
     }
 
     @NoArgsConstructor
     @AllArgsConstructor
     static class NotNullableValue {
-        @Range(allowNull = false)
+        @Range(max = "100", allowNull = false)
         Integer value;
     }
 
@@ -337,7 +339,7 @@ class RangeValidatorTest {
 
     @AllArgsConstructor
     static class HasAnIncomparable {
-        @Range
+        @Range(min = "A")
         AnIncomparable value;
     }
 


### PR DESCRIPTION
* Add custom "unknownError" property to ValidationMessages.properties to be used by both RangeValidator and FieldRangeValidator
* Replace message in FieldRange with new "unknownError" property
* Change FieldRangeValidator to use "unknownError" when adding constraint violations for unknown errors
* Update javadocs in Range to explain that it must have at least a min or max attribute, and why this can only be checked at runtime
* Replace message in Range with a property that actually exists in ValidationMessages.properties
* In RangeValidator#initialize check that a min or max exists; if not throw IllegalStateException
* Minor code cleanup in RangeValidator: cast value to Comparable<Object>
  and remove the (now redundant) 'rawtypes' warning suppression

Closes #930