### PR TITLE
Make KiwiPreconditions methods accept same message template placeholders

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiPreconditions.java
+++ b/src/main/java/org/kiwiproject/base/KiwiPreconditions.java
@@ -523,13 +523,16 @@ public class KiwiPreconditions {
      * Ensures int {@code value} is a positive number (greater than zero).
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositive(int value, String errorMessageTemplate, Object... errorMessageArgs) {
-        checkState(value > 0, errorMessageTemplate, errorMessageArgs);
+        if (value <= 0) {
+            throw newIllegalStateException(errorMessageTemplate, errorMessageArgs);
+        }
     }
 
     /**
@@ -559,13 +562,16 @@ public class KiwiPreconditions {
      * Ensures long {@code value} is a positive number (greater than zero).
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
-     * @param errorMessageArgs     the arguments to populate into the error message template
+     * @param errorMessageTemplate a template for the exception message if value is not positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
+     * @param errorMessageArgs     the arguments to be substituted into the message template
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositive(long value, String errorMessageTemplate, Object... errorMessageArgs) {
-        checkState(value > 0, errorMessageTemplate, errorMessageArgs);
+        if (value <= 0) {
+            throw newIllegalStateException(errorMessageTemplate, errorMessageArgs);
+        }
     }
 
     /**
@@ -595,13 +601,16 @@ public class KiwiPreconditions {
      * Ensures int {@code value} is a positive number (greater than zero) or zero.
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not zero or positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositiveOrZero(int value, String errorMessageTemplate, Object... errorMessageArgs) {
-        checkState(value >= 0, errorMessageTemplate, errorMessageArgs);
+        if (value < 0) {
+            throw newIllegalStateException(errorMessageTemplate, errorMessageArgs);
+        }
     }
 
     /**
@@ -631,13 +640,16 @@ public class KiwiPreconditions {
      * Ensures long {@code value} is a positive number (greater than zero) or zero.
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not zero or positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
      * @see Preconditions#checkState(boolean, Object)
      */
     public static void checkPositiveOrZero(long value, String errorMessageTemplate, Object... errorMessageArgs) {
-        checkState(value >= 0, errorMessageTemplate, errorMessageArgs);
+        if (value < 0) {
+            throw newIllegalStateException(errorMessageTemplate, errorMessageArgs);
+        }
     }
 
     /**
@@ -670,7 +682,8 @@ public class KiwiPreconditions {
      * Returns the int {@code value} if it is a positive number (greater than zero), throwing an {@link IllegalStateException} if not positive.
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @return the given value if positive
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
@@ -711,7 +724,8 @@ public class KiwiPreconditions {
      * Returns the long {@code value} if it is a positive number (greater than zero), throwing an {@link IllegalStateException} if not positive.
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @return the given value if positive
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
@@ -752,7 +766,8 @@ public class KiwiPreconditions {
      * Returns the int {@code value} if it is a positive number (greater than zero) or zero, throwing an {@link IllegalStateException} if not positive.
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not zero or positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @return the given value if positive or zero
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
@@ -793,7 +808,8 @@ public class KiwiPreconditions {
      * Returns the long {@code value} if it is a positive number (greater than zero) or zero, throwing an {@link IllegalStateException} if not positive.
      *
      * @param value                the value to check for positivity
-     * @param errorMessageTemplate the error message template to use in the exception if not positive
+     * @param errorMessageTemplate a template for the exception message if value is not zero or positive, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @return the given value if positive or zero
      * @throws IllegalStateException if the value is not positive (e.g. greater than zero)
@@ -822,19 +838,26 @@ public class KiwiPreconditions {
      * @throws IllegalStateException if port is not valid
      */
     public static void checkValidPort(int port, String errorMessage) {
-        checkState(port >= 0 && port <= MAX_PORT_NUMBER, errorMessage);
+        checkState(isValidPort(port), errorMessage);
     }
 
     /**
      * Ensures given port is valid, between 0 and {@link #MAX_PORT_NUMBER}.
      *
      * @param port                 the port to check for validity
-     * @param errorMessageTemplate the error message template to use in the exception if port is not valid
+     * @param errorMessageTemplate a template for the exception message if port is not valid, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @throws IllegalStateException if port is not valid
      */
     public static void checkValidPort(int port, String errorMessageTemplate, Object... errorMessageArgs) {
-        checkState(port >= 0 && port <= MAX_PORT_NUMBER, errorMessageTemplate, errorMessageArgs);
+        if (!isValidPort(port)) {
+            throw newIllegalStateException(errorMessageTemplate, errorMessageArgs);
+        }
+    }
+
+    private static boolean isValidPort(int port) {
+        return port >= 0 && lessThanOrEqualToMaxPort(port);
     }
 
     /**
@@ -866,7 +889,8 @@ public class KiwiPreconditions {
      * Returns the given port if it is valid
      *
      * @param port                 the port to check for validity
-     * @param errorMessageTemplate the error message template to use in the exception if port is not valid
+     * @param errorMessageTemplate a template for the exception message if port is not valid, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @return the given port if valid
      * @throws IllegalStateException if port is not valid
@@ -894,19 +918,30 @@ public class KiwiPreconditions {
      * @throws IllegalStateException if port is not valid
      */
     public static void checkValidNonZeroPort(int port, String errorMessage) {
-        checkState(port > 0 && port <= MAX_PORT_NUMBER, errorMessage);
+        checkState(isValidPortAboveZero(port), errorMessage);
     }
 
     /**
      * Ensures given port is valid (excluding zero), between 1 and {@link #MAX_PORT_NUMBER}.
      *
      * @param port                 the port to check for validity
-     * @param errorMessageTemplate the error message template to use in the exception if port is not valid
+     * @param errorMessageTemplate a template for the exception message if port is not valid, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @throws IllegalStateException if port is not valid
      */
     public static void checkValidNonZeroPort(int port, String errorMessageTemplate, Object... errorMessageArgs) {
-        checkState(port > 0 && port <= MAX_PORT_NUMBER, errorMessageTemplate, errorMessageArgs);
+        if (!isValidPortAboveZero(port)) {
+            throw newIllegalStateException(errorMessageTemplate, errorMessageArgs);
+        }
+    }
+
+    private static boolean isValidPortAboveZero(int port) {
+        return port > 0 && lessThanOrEqualToMaxPort(port);
+    }
+
+    private static boolean lessThanOrEqualToMaxPort(int port) {
+        return port <= MAX_PORT_NUMBER;
     }
 
     /**
@@ -938,7 +973,8 @@ public class KiwiPreconditions {
      * Returns the given port if it is valid (excluding zero)
      *
      * @param port                 the port to check for validity
-     * @param errorMessageTemplate the error message template to use in the exception if port is not valid
+     * @param errorMessageTemplate a template for the exception message if port is not valid, according to how
+     *                             {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param errorMessageArgs     the arguments to populate into the error message template
      * @return the given port if valid
      * @throws IllegalStateException if port is not valid
@@ -1049,4 +1085,9 @@ public class KiwiPreconditions {
         return new IllegalArgumentException(errorMessage);
     }
 
+    private static IllegalStateException newIllegalStateException(String errorMessageTemplate,
+                                                                        Object... errorMessageArgs) {
+        var errorMessage = format(errorMessageTemplate, errorMessageArgs);
+        return new IllegalStateException(errorMessage);
+    }
 }

--- a/src/test/java/org/kiwiproject/base/KiwiPreconditionsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiPreconditionsTest.java
@@ -644,9 +644,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -680,9 +684,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1L, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositive(-1L, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -727,9 +735,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -768,9 +780,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1L, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.checkPositiveOrZero(-1L, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -813,9 +829,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -856,9 +876,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1L, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositive(-1L, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -903,9 +927,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenIntValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -944,9 +972,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom error message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1L, "custom error message template %s", "42"))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom error message template %s",
+                "custom error message template {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenLongValue_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.requirePositiveOrZero(-1L, template, "42"))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom error message template 42");
         }
@@ -989,9 +1021,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.checkValidPort(-1, "custom message %s", 42))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom message %s",
+                "custom message {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.checkValidPort(-1, template, 42))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom message 42");
         }
@@ -1038,9 +1074,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.requireValidPort(-1, "custom message %s", 42))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom message %s",
+                "custom message {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.requireValidPort(-1, template, 42))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom message 42");
         }
@@ -1087,9 +1127,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.checkValidNonZeroPort(-1, "custom message %s", 42))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom message %s",
+                "custom message {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.checkValidNonZeroPort(-1, template, 42))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom message 42");
         }
@@ -1143,9 +1187,13 @@ class KiwiPreconditionsTest {
                     .hasMessage("custom message");
         }
 
-        @Test
-        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative() {
-            assertThatThrownBy(() -> KiwiPreconditions.requireValidNonZeroPort(-1, "custom message %s", 42))
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "custom message %s",
+                "custom message {}"
+        })
+        void shouldThrowException_WithCustomMessageTemplate_WhenPort_IsNegative(String template) {
+            assertThatThrownBy(() -> KiwiPreconditions.requireValidNonZeroPort(-1, template, 42))
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("custom message 42");
         }


### PR DESCRIPTION
All KiwiPreconditions methods should accept the same message template placeholders as the other methods in the class, as specified by the KiwiStrings#format method.

Closes #984