### PR TITLE
Replace usage of deprecated Session#save usage

### DIFF
--- a/src/test/java/org/kiwiproject/hibernate/usertype/ArrayUserTypesIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/ArrayUserTypesIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.kiwiproject.hibernate.usertype.UserTypeTestHelpers.preparedDbE
 import io.zonky.test.db.postgres.junit5.PreparedDbExtension;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,6 +27,7 @@ class ArrayUserTypesIntegrationTest {
     private static SessionFactory sessionFactory;
 
     private Session session;
+    private Transaction transaction;
 
     @BeforeAll
     static void beforeAll() {
@@ -36,10 +38,12 @@ class ArrayUserTypesIntegrationTest {
     @BeforeEach
     void setUp() {
         session = sessionFactory.openSession();
+        transaction = session.beginTransaction();
     }
 
     @AfterEach
     void tearDown() {
+        transaction.rollback();
         session.close();
     }
 

--- a/src/test/java/org/kiwiproject/hibernate/usertype/IdentifiableEntity.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/IdentifiableEntity.java
@@ -1,0 +1,6 @@
+package org.kiwiproject.hibernate.usertype;
+
+public interface IdentifiableEntity {
+    Long getId();
+    void setId(Long id);
+}

--- a/src/test/java/org/kiwiproject/hibernate/usertype/JSONBUserTypeIntegrationTest.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/JSONBUserTypeIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.kiwiproject.hibernate.usertype.UserTypeTestHelpers.preparedDbE
 import io.zonky.test.db.postgres.junit5.PreparedDbExtension;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,6 +28,7 @@ class JSONBUserTypeIntegrationTest {
     private static SessionFactory sessionFactory;
 
     private Session session;
+    private Transaction transaction;
 
     @BeforeAll
     static void beforeAll() {
@@ -37,10 +39,12 @@ class JSONBUserTypeIntegrationTest {
     @BeforeEach
     void setUp() {
         session = sessionFactory.openSession();
+        transaction = session.beginTransaction();
     }
 
     @AfterEach
     void tearDown() {
+        transaction.rollback();
         session.close();
     }
 

--- a/src/test/java/org/kiwiproject/hibernate/usertype/SampleEntity.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/SampleEntity.java
@@ -15,7 +15,7 @@ import org.hibernate.annotations.Type;
 @Getter
 @Setter
 @SuppressWarnings("JpaDataSourceORMInspection")
-class SampleEntity {
+class SampleEntity implements IdentifiableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/org/kiwiproject/hibernate/usertype/SampleJsonbEntity.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/SampleJsonbEntity.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.Type;
 @Getter
 @Setter
 @SuppressWarnings("JpaDataSourceORMInspection")
-class SampleJsonbEntity {
+class SampleJsonbEntity implements IdentifiableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/org/kiwiproject/hibernate/usertype/UserTypeTestHelpers.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/UserTypeTestHelpers.java
@@ -38,8 +38,11 @@ class UserTypeTestHelpers {
         return config;
     }
 
-    static Object saveAndClearSession(Session session, Object entity) {
-        var id = session.save(entity);
+    static Object saveAndClearSession(Session session, IdentifiableEntity entity) {
+        assertThat(entity.getId()).isNull();
+        session.persist(entity);
+
+        var id = entity.getId();
         assertThat(id)
                 .describedAs("Entity should have been flushed to database and now have an assigned ID")
                 .isNotNull();

--- a/src/test/java/org/kiwiproject/hibernate/usertype/UserTypeTestHelpers.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/UserTypeTestHelpers.java
@@ -39,6 +39,10 @@ class UserTypeTestHelpers {
     }
 
     static Object saveAndClearSession(Session session, IdentifiableEntity entity) {
+        assertThat(session.getTransaction())
+                .describedAs("A transaction must exist for this method to work properly")
+                .isNotNull();
+
         assertThat(entity.getId()).isNull();
         session.persist(entity);
 


### PR DESCRIPTION
Replace Session#save with #persist. To make this work, needed to first create an interface, IdentifiableEntity, which provides get and set methods for the ID. Then, in the test setup, begin a transaction, change #save to #persist in
UserTypeTestHelpers#saveAndClearSession and get the ID. Finally, rollback the transaction in the test tear down.

Closes #1010