### PR TITLE
Remove the TODO from KiwiIterators.ThreadSafeCyclicIterator

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiIterators.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiIterators.java
@@ -45,8 +45,8 @@ public class KiwiIterators {
     }
 
     /**
-     * Returns a <em>thread-safe</em> iterator that cycles indefinitely over the elements of {@code iterable}, base
-     * on Guava's {@link com.google.common.collect.Iterables#cycle(Iterable)}. The differences from Guava is that the
+     * Returns a <em>thread-safe</em> iterator that cycles indefinitely over the elements of {@code iterable}, based
+     * on Guava's {@link com.google.common.collect.Iterables#cycle(Iterable)}. The differences from Guava are that the
      * returned iterator provides thread-safety; makes an immutable copy of the provided iterable; and does not
      * support element removal regardless of whether the original iterable does.
      * <p>
@@ -66,7 +66,6 @@ public class KiwiIterators {
         return new ThreadSafeCyclicIterator<>(newArrayList(elements));
     }
 
-    // TODO Should this be made public and/or a top-level class???
     private static class ThreadSafeCyclicIterator<E> implements Iterator<E> {
 
         private final Iterator<E> cycler;


### PR DESCRIPTION
We've never once needed to access ThreadSafeCyclicIterator directly, so I am removing the TODO. If there is ever a need, we can revisit at that time.

Also, fixed a minor grammatical error in the javadoc of KiwiIterators#cycleForever.