### PR TITLE
Create OsCommand interface in base.process package

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/OsCommand.java
+++ b/src/main/java/org/kiwiproject/base/process/OsCommand.java
@@ -1,0 +1,29 @@
+package org.kiwiproject.base.process;
+
+import java.util.List;
+
+/**
+ * Interface that describes a simple contract for an operating system command.
+ */
+public interface OsCommand {
+
+    /**
+     * Returns a list containing the command and all its arguments, which can then be used to construct
+     * a {@link ProcessBuilder}.
+     *
+     * @return a list of command arguments
+     * @see ProcessBuilder#ProcessBuilder(List)
+     */
+    List<String> parts();
+
+    /**
+     * Returns a string array containing the command and all its arguments, which can be used to construct
+     * a {@link ProcessBuilder}.
+     *
+     * @return a string array of command arguments
+     * @see ProcessBuilder#command(String...)
+     */
+    default String[] partsAsArray() {
+        return parts().toArray(new String[0]);
+    }
+}

--- a/src/test/java/org/kiwiproject/base/process/OsCommandTest.java
+++ b/src/test/java/org/kiwiproject/base/process/OsCommandTest.java
@@ -1,0 +1,18 @@
+package org.kiwiproject.base.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+@DisplayName("OsCommand")
+class OsCommandTest {
+
+    @Test
+    void shouldReturnPartsAsArray() {
+        OsCommand command = () -> List.of("sdk", "install", "java", "20.0.2-zulu");
+        assertThat(command.partsAsArray()).containsExactly("sdk", "install", "java", "20.0.2-zulu");
+    }
+}


### PR DESCRIPTION
This replaces the OsCommand in the ansible.vault package. It simplifies the name of the method to obtain the command parts as a List<String> from getCommandParts to just parts. It also adds a default method, partsAsArray, to obtain the command parts as a String array.

Closes #1025