### PR TITLE
Replace usages of deprecated org.kiwiproject.ansible.vault.OsCommand

### DIFF
--- a/src/main/java/org/kiwiproject/ansible/vault/VaultDecryptCommand.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/VaultDecryptCommand.java
@@ -6,6 +6,7 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.Builder;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.List;
  * Generates {@code ansible-vault decrypt} commands.
  */
 @Builder
-public class VaultDecryptCommand implements OsCommand {
+public class VaultDecryptCommand implements org.kiwiproject.base.process.OsCommand {
 
     public static final String OUTPUT_FILE_STDOUT = "-";
 
@@ -65,8 +66,22 @@ public class VaultDecryptCommand implements OsCommand {
                 .build();
     }
 
-    @Override
+    /**
+     * @return a list containing the command and its arguments
+     * @deprecated replaced by {@link #parts()}
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    @KiwiDeprecated(
+            removeAt = "4.0.0",
+            reference = "https://github.com/kiwiproject/kiwi/issues/1026",
+            replacedBy = "#parts"
+    )
     public List<String> getCommandParts() {
+        return parts();
+    }
+
+    @Override
+    public List<String> parts() {
         if (nonNull(outputFilePath)) {
             return getCommandPartsWithOutputFile();
         }

--- a/src/main/java/org/kiwiproject/ansible/vault/VaultEncryptCommand.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/VaultEncryptCommand.java
@@ -7,6 +7,7 @@ import static org.kiwiproject.base.KiwiStrings.f;
 
 import lombok.Builder;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ import java.util.List;
  * Generates {@code ansible-vault encrypt} commands.
  */
 @Builder
-public class VaultEncryptCommand implements OsCommand {
+public class VaultEncryptCommand implements org.kiwiproject.base.process.OsCommand {
 
     private final String ansibleVaultPath;
     private final String vaultIdLabel;
@@ -54,8 +55,22 @@ public class VaultEncryptCommand implements OsCommand {
                 .build();
     }
 
-    @Override
+    /**
+     * @return a list containing the command and its arguments
+     * @deprecated replaced by {@link #parts()}
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    @KiwiDeprecated(
+            removeAt = "4.0.0",
+            reference = "https://github.com/kiwiproject/kiwi/issues/1026",
+            replacedBy = "#parts"
+    )
     public List<String> getCommandParts() {
+        return parts();
+    }
+
+    @Override
+    public List<String> parts() {
         if (isNull(vaultIdLabel)) {
             return List.of(
                     ansibleVaultPath,

--- a/src/main/java/org/kiwiproject/ansible/vault/VaultEncryptStringCommand.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/VaultEncryptStringCommand.java
@@ -7,6 +7,7 @@ import static org.kiwiproject.base.KiwiStrings.f;
 
 import lombok.Builder;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.util.List;
 
@@ -14,7 +15,7 @@ import java.util.List;
  * Generates {@code ansible-vault encrypt_string} commands.
  */
 @Builder
-public class VaultEncryptStringCommand implements OsCommand {
+public class VaultEncryptStringCommand implements org.kiwiproject.base.process.OsCommand {
 
     private final String ansibleVaultPath;
     private final String vaultIdLabel;
@@ -62,8 +63,22 @@ public class VaultEncryptStringCommand implements OsCommand {
                 .build();
     }
 
-    @Override
+    /**
+     * @return a list containing the command and its arguments
+     * @deprecated replaced by {@link #parts()}
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    @KiwiDeprecated(
+            removeAt = "4.0.0",
+            reference = "https://github.com/kiwiproject/kiwi/issues/1026",
+            replacedBy = "#parts"
+    )
     public List<String> getCommandParts() {
+        return parts();
+    }
+
+    @Override
+    public List<String> parts() {
         if (isNull(vaultIdLabel)) {
             return List.of(
                     ansibleVaultPath,

--- a/src/main/java/org/kiwiproject/ansible/vault/VaultEncryptionHelper.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/VaultEncryptionHelper.java
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
  * The main class in this package for executing {@code ansible-vault} commands.
  * <p>
  * While it is possible to use the various command classes directly to build the operating system command,
- * create a {@link ProcessBuilder} and finally a {@link Process}, this class wraps all that and makes it realtively
+ * create a {@link ProcessBuilder} and finally a {@link Process}, this class wraps all that and makes it relatively
  * easy to make {@code ansible-vault} calls in the operating system.
  */
 @SuppressWarnings("WeakerAccess")
@@ -47,7 +47,7 @@ public class VaultEncryptionHelper {
      * Create an instance with the given vault configuration. Makes a copy of the given configuration, such that
      * changes to the supplied object are not seen by this instance.
      * <p>
-     * If the configuration needs to change, for example after a rekey operation, then simply construct a new
+     * If the configuration needs to change, for example after a re-key operation, then simply construct a new
      * instance passing in the new {@link VaultConfiguration} object.
      *
      * @param configuration the vault configuration
@@ -251,11 +251,11 @@ public class VaultEncryptionHelper {
     }
 
     /**
-     * Wraps ansible-vault rekey command. Returns the path of the rekeyed file.
+     * Wraps ansible-vault rekey command. Returns the path of the re-keyed file.
      *
      * @param encryptedFilePath        the path to the file to view
      * @param newVaultPasswordFilePath path to the file containing the new password
-     * @return the {@link Path} to the rekeyed file
+     * @return the {@link Path} to the re-keyed file
      */
     public Path rekeyFile(Path encryptedFilePath, Path newVaultPasswordFilePath) {
         checkArgumentNotNull(encryptedFilePath, ENCRYPTED_FILE_PATH_CANNOT_BE_NULL);
@@ -264,11 +264,11 @@ public class VaultEncryptionHelper {
     }
 
     /**
-     * Wraps ansible-vault rekey command. Returns the path of the rekeyed file.
+     * Wraps ansible-vault rekey command. Returns the path of the re-keyed file.
      *
      * @param encryptedFilePath        the path to the file to view
      * @param newVaultPasswordFilePath path to the file containing the new password
-     * @return the {@link Path} to the rekeyed file
+     * @return the {@link Path} to the re-keyed file
      */
     public Path rekeyFile(String encryptedFilePath, String newVaultPasswordFilePath) {
         checkArgumentNotBlank(encryptedFilePath, "encryptedFilePath cannot be blank");
@@ -280,7 +280,7 @@ public class VaultEncryptionHelper {
         return executeVaultCommandWithoutOutput(osCommand, encryptedFilePath);
     }
 
-    private Path executeVaultCommandWithoutOutput(OsCommand osCommand, String filePath) {
+    private Path executeVaultCommandWithoutOutput(org.kiwiproject.base.process.OsCommand osCommand, String filePath) {
         executeVaultCommand(osCommand);
         return Path.of(filePath);
     }
@@ -378,15 +378,15 @@ public class VaultEncryptionHelper {
         }
     }
 
-    private String executeVaultCommandReturningStdout(OsCommand osCommand) {
+    private String executeVaultCommandReturningStdout(org.kiwiproject.base.process.OsCommand osCommand) {
         var vaultProcess = executeVaultCommand(osCommand);
         return KiwiIO.readInputStreamOf(vaultProcess);
     }
 
-    private Process executeVaultCommand(OsCommand osCommand) {
-        LOG.debug("Ansible command: {}", lazy(osCommand::getCommandParts));
+    private Process executeVaultCommand(org.kiwiproject.base.process.OsCommand osCommand) {
+        LOG.debug("Ansible command: {}", lazy(osCommand::parts));
 
-        var vaultProcess = processHelper.launch(osCommand.getCommandParts());
+        var vaultProcess = processHelper.launch(osCommand.parts());
         var exitCode = processHelper.waitForExit(vaultProcess, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT_UNIT)
                 .orElseThrow(() -> new VaultEncryptionException("ansible-vault did not exit before timeout"));
         LOG.debug("ansible-vault exit code: {}", exitCode);

--- a/src/main/java/org/kiwiproject/ansible/vault/VaultRekeyCommand.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/VaultRekeyCommand.java
@@ -4,6 +4,7 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.Builder;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -12,7 +13,7 @@ import java.util.List;
  * Generates {@code ansible-vault rekey} commands.
  */
 @Builder
-public class VaultRekeyCommand implements OsCommand {
+public class VaultRekeyCommand implements org.kiwiproject.base.process.OsCommand {
 
     private final String ansibleVaultPath;
     private final String vaultPasswordFilePath;
@@ -23,7 +24,7 @@ public class VaultRekeyCommand implements OsCommand {
      * Create an instance.
      *
      * @param configuration            the {@link VaultConfiguration} to use
-     * @param encryptedFilePath        path to the encrypted file to rekey
+     * @param encryptedFilePath        path to the encrypted file to re-key
      * @param newVaultPasswordFilePath path to the vault password file containing the new password
      * @return the command
      */
@@ -42,8 +43,22 @@ public class VaultRekeyCommand implements OsCommand {
                 .build();
     }
 
-    @Override
+    /**
+     * @return a list containing the command and its arguments
+     * @deprecated replaced by {@link #parts()}
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    @KiwiDeprecated(
+            removeAt = "4.0.0",
+            reference = "https://github.com/kiwiproject/kiwi/issues/1026",
+            replacedBy = "#parts"
+    )
     public List<String> getCommandParts() {
+        return parts();
+    }
+
+    @Override
+    public List<String> parts() {
         return List.of(
                 ansibleVaultPath,
                 "rekey",

--- a/src/main/java/org/kiwiproject/ansible/vault/VaultViewCommand.java
+++ b/src/main/java/org/kiwiproject/ansible/vault/VaultViewCommand.java
@@ -4,6 +4,7 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.Builder;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -12,7 +13,7 @@ import java.util.List;
  * Generates {@code ansible-vault view} commands.
  */
 @Builder
-public class VaultViewCommand implements OsCommand {
+public class VaultViewCommand implements org.kiwiproject.base.process.OsCommand {
 
     private final String ansibleVaultPath;
     private final String vaultPasswordFilePath;
@@ -36,8 +37,22 @@ public class VaultViewCommand implements OsCommand {
                 .build();
     }
 
-    @Override
+    /**
+     * @return a list containing the command and its arguments
+     * @deprecated replaced by {@link #parts()}
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    @KiwiDeprecated(
+            removeAt = "4.0.0",
+            reference = "https://github.com/kiwiproject/kiwi/issues/1026",
+            replacedBy = "#parts"
+    )
     public List<String> getCommandParts() {
+        return parts();
+    }
+
+    @Override
+    public List<String> parts() {
         return List.of(
                 ansibleVaultPath,
                 "view",

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultDecryptCommandTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultDecryptCommandTest.java
@@ -29,13 +29,16 @@ class VaultDecryptCommandTest {
             var encryptedFilePath = "/data/secret/MySecret.txt";
             var command = VaultDecryptCommand.from(configuration, encryptedFilePath);
 
-            assertThat(command.getCommandParts()).containsExactly(
+            assertThat(command.parts()).containsExactly(
                     configuration.getAnsibleVaultPath(),
                     "decrypt",
                     "--vault-password-file",
                     configuration.getVaultPasswordFilePath(),
                     encryptedFilePath
             );
+
+            //noinspection removal
+            assertThat(command.getCommandParts()).isEqualTo(command.parts());
         }
 
         @Test
@@ -44,7 +47,7 @@ class VaultDecryptCommandTest {
             var outputFilePath = "/data/temp/Plain.txt";
             var command = VaultDecryptCommand.from(configuration, encryptedFilePath, outputFilePath);
 
-            assertThat(command.getCommandParts()).containsExactly(
+            assertThat(command.parts()).containsExactly(
                     configuration.getAnsibleVaultPath(),
                     "decrypt",
                     "--vault-password-file",
@@ -53,6 +56,9 @@ class VaultDecryptCommandTest {
                     outputFilePath,
                     encryptedFilePath
             );
+
+            //noinspection removal
+            assertThat(command.getCommandParts()).isEqualTo(command.parts());
         }
 
         @Test
@@ -60,7 +66,7 @@ class VaultDecryptCommandTest {
             var encryptedFilePath = "/data/secret/MySecret.txt";
             var command = VaultDecryptCommand.toStdoutFrom(configuration, encryptedFilePath);
 
-            assertThat(command.getCommandParts()).containsExactly(
+            assertThat(command.parts()).containsExactly(
                     configuration.getAnsibleVaultPath(),
                     "decrypt",
                     "--vault-password-file",
@@ -69,6 +75,9 @@ class VaultDecryptCommandTest {
                     "-",
                     encryptedFilePath
             );
+
+            //noinspection removal
+            assertThat(command.getCommandParts()).isEqualTo(command.parts());
         }
     }
 }

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptCommandTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptCommandTest.java
@@ -25,13 +25,16 @@ class VaultEncryptCommandTest {
 
         var command = VaultEncryptCommand.from(configuration, plainTextFileName);
 
-        assertThat(command.getCommandParts()).containsExactly(
+        assertThat(command.parts()).containsExactly(
                 configuration.getAnsibleVaultPath(),
                 "encrypt",
                 "--vault-password-file",
                 configuration.getVaultPasswordFilePath(),
                 plainTextFileName
         );
+
+        //noinspection removal
+        assertThat(command.getCommandParts()).isEqualTo(command.parts());
     }
 
     @Test
@@ -41,12 +44,15 @@ class VaultEncryptCommandTest {
 
         var command = VaultEncryptCommand.from(configuration, vaultIdLabel, plainTextFileName);
 
-        assertThat(command.getCommandParts()).containsExactly(
+        assertThat(command.parts()).containsExactly(
                 configuration.getAnsibleVaultPath(),
                 "encrypt",
                 "--vault-id",
                 vaultIdLabel + "@" + configuration.getVaultPasswordFilePath(),
                 plainTextFileName
         );
+
+        //noinspection removal
+        assertThat(command.getCommandParts()).isEqualTo(command.parts());
     }
 }

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptStringCommandTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptStringCommandTest.java
@@ -25,7 +25,7 @@ class VaultEncryptStringCommandTest {
         var variableName = "MySecret";
         var command = VaultEncryptStringCommand.from(configuration, plainText, variableName);
 
-        assertThat(command.getCommandParts()).containsExactly(
+        assertThat(command.parts()).containsExactly(
                 configuration.getAnsibleVaultPath(),
                 "encrypt_string",
                 "--vault-password-file",
@@ -34,6 +34,9 @@ class VaultEncryptStringCommandTest {
                 variableName,
                 plainText
         );
+
+        //noinspection removal
+        assertThat(command.getCommandParts()).isEqualTo(command.parts());
     }
 
     @Test
@@ -43,7 +46,7 @@ class VaultEncryptStringCommandTest {
         var variableName = "MySecret";
         var command = VaultEncryptStringCommand.from(configuration, vaultIdLabel, plainText, variableName);
 
-        assertThat(command.getCommandParts()).containsExactly(
+        assertThat(command.parts()).containsExactly(
                 configuration.getAnsibleVaultPath(),
                 "encrypt_string",
                 "--vault-id",
@@ -52,5 +55,8 @@ class VaultEncryptStringCommandTest {
                 variableName,
                 plainText
         );
+
+        //noinspection removal
+        assertThat(command.getCommandParts()).isEqualTo(command.parts());
     }
 }

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptionHelperTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultEncryptionHelperTest.java
@@ -168,7 +168,7 @@ class VaultEncryptionHelperTest {
             assertThat(encryptedFile).isEqualTo(Path.of(plainTextFile));
 
             var command = VaultEncryptCommand.from(configuration, plainTextFile);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
 
         @Test
@@ -183,7 +183,7 @@ class VaultEncryptionHelperTest {
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
             var command = VaultEncryptCommand.from(configuration, plainTextFile);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
     }
 
@@ -202,7 +202,7 @@ class VaultEncryptionHelperTest {
             assertThat(encryptedFile).isEqualTo(Path.of(plainTextFile));
 
             var command = VaultEncryptCommand.from(configuration, vaultIdLabel, plainTextFile);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
 
         @Test
@@ -218,7 +218,7 @@ class VaultEncryptionHelperTest {
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
             var command = VaultEncryptCommand.from(configuration, vaultIdLabel, plainTextFile);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
     }
 
@@ -239,7 +239,7 @@ class VaultEncryptionHelperTest {
                 assertThat(decryptedFile).isEqualTo(Path.of(encryptedFile));
 
                 var command = VaultDecryptCommand.from(configuration, encryptedFile);
-                verify(processHelper).launch(command.getCommandParts());
+                verify(processHelper).launch(command.parts());
             }
 
             @Test
@@ -254,7 +254,7 @@ class VaultEncryptionHelperTest {
                         .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
                 var command = VaultDecryptCommand.from(configuration, encryptedFilePath);
-                verify(processHelper).launch(command.getCommandParts());
+                verify(processHelper).launch(command.parts());
             }
         }
 
@@ -273,7 +273,7 @@ class VaultEncryptionHelperTest {
                 assertThat(decryptedFile).isEqualTo(Path.of(outputFile));
 
                 var command = VaultDecryptCommand.from(configuration, encryptedFile, outputFile);
-                verify(processHelper).launch(command.getCommandParts());
+                verify(processHelper).launch(command.parts());
             }
 
             @ParameterizedTest
@@ -303,7 +303,7 @@ class VaultEncryptionHelperTest {
                         .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
                 var command = VaultDecryptCommand.from(configuration, encryptedFile, outputFile);
-                verify(processHelper).launch(command.getCommandParts());
+                verify(processHelper).launch(command.parts());
             }
         }
     }
@@ -323,7 +323,7 @@ class VaultEncryptionHelperTest {
             assertThat(decryptedContents).isEqualTo(plainText);
 
             var command = VaultViewCommand.from(configuration, encryptedFile);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
 
         @Test
@@ -338,7 +338,7 @@ class VaultEncryptionHelperTest {
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
             var command = VaultViewCommand.from(configuration, encryptedFilePath);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
     }
 
@@ -357,7 +357,7 @@ class VaultEncryptionHelperTest {
             assertThat(rekeyedFile).isEqualTo(Path.of(encryptedFile));
 
             var command = VaultRekeyCommand.from(configuration, encryptedFile, newVaultPasswordFilePath);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
 
         @Test
@@ -385,7 +385,7 @@ class VaultEncryptionHelperTest {
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
             var command = VaultRekeyCommand.from(configuration, encryptedFilePath, newVaultPasswordFilePath);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
     }
 
@@ -405,7 +405,7 @@ class VaultEncryptionHelperTest {
             assertThat(result).isEqualTo(encryptedContent);
 
             var command = VaultEncryptStringCommand.from(configuration, plainText, variableName);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
 
         @Test
@@ -421,7 +421,7 @@ class VaultEncryptionHelperTest {
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
             var command = VaultEncryptStringCommand.from(configuration, plainText, variableName);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
     }
 
@@ -442,7 +442,7 @@ class VaultEncryptionHelperTest {
             assertThat(result).isEqualTo(encryptedContent);
 
             var command = VaultEncryptStringCommand.from(configuration, vaultIdLabel, plainText, variableName);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
 
         @Test
@@ -459,7 +459,7 @@ class VaultEncryptionHelperTest {
                     .hasMessage("ansible-vault returned non-zero exit code 1. Stderr: %s", errorOutput);
 
             var command = VaultEncryptStringCommand.from(configuration, vaultIdLabel, plainText, variableName);
-            verify(processHelper).launch(command.getCommandParts());
+            verify(processHelper).launch(command.parts());
         }
     }
 
@@ -490,7 +490,7 @@ class VaultEncryptionHelperTest {
             return commandParts -> {
                 // Check command up until last argument (file name, which has a random component)
                 var vaultDecryptCommand = VaultDecryptCommand.toStdoutFrom(configuration, encryptedFilePath.toString());
-                var vaultDecryptCommandParts = vaultDecryptCommand.getCommandParts();
+                var vaultDecryptCommandParts = vaultDecryptCommand.parts();
                 var expectedPartsExcludingLast = subListExcludingLast(vaultDecryptCommandParts);
 
                 var commandPartsExcludingLast = subListExcludingLast(commandParts);

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultRekeyCommandTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultRekeyCommandTest.java
@@ -26,7 +26,7 @@ class VaultRekeyCommandTest {
 
         var command = VaultRekeyCommand.from(configuration, encryptedFileName, newVaultPasswordFilePath);
 
-        assertThat(command.getCommandParts()).containsExactly(
+        assertThat(command.parts()).containsExactly(
                 configuration.getAnsibleVaultPath(),
                 "rekey",
                 "--vault-password-file",
@@ -35,5 +35,8 @@ class VaultRekeyCommandTest {
                 newVaultPasswordFilePath,
                 encryptedFileName
         );
+
+        //noinspection removal
+        assertThat(command.getCommandParts()).isEqualTo(command.parts());
     }
 }

--- a/src/test/java/org/kiwiproject/ansible/vault/VaultViewCommandTest.java
+++ b/src/test/java/org/kiwiproject/ansible/vault/VaultViewCommandTest.java
@@ -25,12 +25,15 @@ class VaultViewCommandTest {
 
         var command = VaultViewCommand.from(configuration, encryptedFileName);
 
-        assertThat(command.getCommandParts()).containsExactly(
+        assertThat(command.parts()).containsExactly(
                 configuration.getAnsibleVaultPath(),
                 "view",
                 "--vault-password-file",
                 configuration.getVaultPasswordFilePath(),
                 encryptedFileName
         );
+
+        //noinspection removal
+        assertThat(command.getCommandParts()).isEqualTo(command.parts());
     }
 }


### PR DESCRIPTION
* Replace all usages with org.kiwiproject.base.process.OsCommand
* Refactor existing AnsibleXxxCommand classes to implement org.kiwiproject.base.process.OsCommand
* Deprecate all the #getCommandParts methods in the AnsibleXxxCommand classes for removal; they are replaced by #parts. But since they are part of the public API, we need to first deprecate them and then remove them in the next major version, 4.0.0
* Update tests to use #parts method instead of #getCommandParts, but also add assertions that still test the old methods (and suppress the warnings about usages of code that is deprecated for removal)

Closes #1027
Closes #1031 