### PR TITLE
Make fields final in a few classes; suppress warning in another class

### DIFF
--- a/src/main/java/org/kiwiproject/json/PropertyMaskingOptions.java
+++ b/src/main/java/org/kiwiproject/json/PropertyMaskingOptions.java
@@ -23,17 +23,17 @@ public class PropertyMaskingOptions {
      */
     @NonNull
     @Builder.Default
-    List<String> maskedFieldRegexps = new ArrayList<>();
+    final List<String> maskedFieldRegexps = new ArrayList<>();
 
     /**
      * The replacement text for masked field values. Can be {@code null}.
      */
     @Builder.Default
-    String maskedFieldReplacementText = DEFAULT_MASK_TEXT_REPLACEMENT;
+    final String maskedFieldReplacementText = DEFAULT_MASK_TEXT_REPLACEMENT;
 
     /**
      * The replacement text for serialization errors. Can be {@code null}.
      */
     @Builder.Default
-    String serializationErrorReplacementText = DEFAULT_FAILED_TEXT_REPLACEMENT;
+    final String serializationErrorReplacementText = DEFAULT_FAILED_TEXT_REPLACEMENT;
 }

--- a/src/main/java/org/kiwiproject/retry/SimpleRetryer.java
+++ b/src/main/java/org/kiwiproject/retry/SimpleRetryer.java
@@ -92,42 +92,42 @@ public class SimpleRetryer {
      */
     @VisibleForTesting
     @Builder.Default
-    KiwiEnvironment environment = new DefaultEnvironment();
+    final KiwiEnvironment environment = new DefaultEnvironment();
 
     /**
      * The maximum number of attempts before giving up.
      */
     @VisibleForTesting
     @Builder.Default
-    int maxAttempts = DEFAULT_MAX_ATTEMPTS;
+    final int maxAttempts = DEFAULT_MAX_ATTEMPTS;
 
     /**
      * The time to sleep between retry attempts.
      */
     @VisibleForTesting
     @Builder.Default
-    long retryDelayTime = DEFAULT_RETRY_DELAY_TIME;
+    final long retryDelayTime = DEFAULT_RETRY_DELAY_TIME;
 
     /**
      * The time unit for the time to sleep between retry attempts.
      */
     @VisibleForTesting
     @Builder.Default
-    TimeUnit retryDelayUnit = DEFAULT_RETRY_DELAY_UNIT;
+    final TimeUnit retryDelayUnit = DEFAULT_RETRY_DELAY_UNIT;
 
     /**
      * The common type/description to include in log messages for each attempt.
      */
     @VisibleForTesting
     @Builder.Default
-    String commonType = DEFAULT_TYPE;
+    final String commonType = DEFAULT_TYPE;
 
     /**
      * The SLF4J log level to use when logging retry attempts. The first attempt is always logged at TRACE level.
      */
     @VisibleForTesting
     @Builder.Default
-    Level logLevelForSubsequentAttempts = DEFAULT_RETRY_LOG_LEVEL;
+    final Level logLevelForSubsequentAttempts = DEFAULT_RETRY_LOG_LEVEL;
 
     /**
      * Try to get an object.

--- a/src/test/java/org/kiwiproject/validation/RequiredValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/RequiredValidatorTest.java
@@ -145,6 +145,12 @@ class RequiredValidatorTest {
                 var user = User.builder().requiredOrEmptyPrefs(new Preferences()).build();
                 assertNoPropertyViolations(validator, user, "requiredOrEmptyPrefs");
             }
+
+            @Test
+            void shouldNotFlagNonEmptyAsViolation() {
+                var user = User.builder().requiredPrefs(new Preferences(Map.of("theme", "dark"))).build();
+                assertNoPropertyViolations(validator, user, "requiredPrefs");
+            }
         }
 
         @Nested
@@ -257,6 +263,7 @@ class RequiredValidatorTest {
     @AllArgsConstructor
     static class Preferences {
 
+        @SuppressWarnings("CanBeFinal")
         Map<String, String> values = new HashMap<>();
 
         public boolean isEmpty() {


### PR DESCRIPTION
* Make fields final in PropertyMaskingOptions and SimpleRetryer
* Suppress the "field can be final" warning in RequiredValidatorTest. If you make the field final, then the Lombok AllArgsConstructor annotation no longer generates a constructor at all.
* Add test to RequiredValidatorTest to verify that a property with an #isEmpty method and which is not empty, has no violations