### PR TITLE
Add methods to KiwiJdbc to convert java.sql.Date to LocalDate

### DIFF
--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -129,8 +129,8 @@ public class KiwiJdbc {
      * @throws SQLException if there is problem getting the date
      */
     @Nullable
-    public static LocalDate localDateOrNullFromDate(ResultSet rs, String columnName) throws SQLException {
-        return localDateOrNullFromDate(rs.getDate(columnName));
+    public static LocalDate localDateFromDateOrNull(ResultSet rs, String columnName) throws SQLException {
+        return localDateFromDateOrNull(rs.getDate(columnName));
     }
 
     /**
@@ -140,7 +140,7 @@ public class KiwiJdbc {
      * @return the converted LocalDate or {@code null} if the date is {@code null}
      */
     @Nullable
-    public static LocalDate localDateOrNullFromDate(java.sql.@Nullable Date date) {
+    public static LocalDate localDateFromDateOrNull(java.sql.@Nullable Date date) {
         return isNull(date) ? null : date.toLocalDate();
     }
 

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.experimental.UtilityClass;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -11,6 +12,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -116,6 +118,30 @@ public class KiwiJdbc {
      */
     public static LocalDateTime localDateTimeFromTimestamp(Timestamp timestamp) {
         return isNull(timestamp) ? null : timestamp.toLocalDateTime();
+    }
+
+    /**
+     * Returns a {@link LocalDate} from the specified {@link java.sql.Date} column in the given {@link ResultSet}.
+     *
+     * @param rs         the ResultSet
+     * @param columnName the date column name
+     * @return the converted LocalDate or {@code null} if the column was {@code NULL}
+     * @throws SQLException if there is problem getting the date
+     */
+    @Nullable
+    public static LocalDate localDateOrNullFromDate(ResultSet rs, String columnName) throws SQLException {
+        return localDateOrNullFromDate(rs.getDate(columnName));
+    }
+
+    /**
+     * Returns a {@link LocalDateTime} from the given {@link java.sql.Date}.
+     *
+     * @param date the date to convert
+     * @return the converted LocalDate or {@code null} if the date is {@code null}
+     */
+    @Nullable
+    public static LocalDate localDateOrNullFromDate(java.sql.@Nullable Date date) {
+        return isNull(date) ? null : date.toLocalDate();
     }
 
     /**

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
@@ -198,19 +198,19 @@ class KiwiJdbcTest {
     }
 
     @Nested
-    class LocalDateFromJavaSqlDate {
+    class LocalDateFromDateOrNull {
 
         @Test
         void shouldConvertFromDate() {
             var originalDate = LocalDate.of(2023, Month.APRIL, 1);
             var date = java.sql.Date.valueOf(originalDate);
 
-            assertThat(KiwiJdbc.localDateOrNullFromDate(date)).isEqualTo(originalDate);
+            assertThat(KiwiJdbc.localDateFromDateOrNull(date)).isEqualTo(originalDate);
         }
 
         @Test
         void shouldReturnNull_WhenGivenNullDate() {
-            assertThat(KiwiJdbc.localDateOrNullFromDate(null)).isNull();
+            assertThat(KiwiJdbc.localDateFromDateOrNull(null)).isNull();
         }
 
         @Test
@@ -221,7 +221,7 @@ class KiwiJdbcTest {
             var resultSet = newMockResultSet();
             when(resultSet.getDate(anyString())).thenReturn(date);
 
-            assertThat(KiwiJdbc.localDateOrNullFromDate(resultSet, "date_of_birth"))
+            assertThat(KiwiJdbc.localDateFromDateOrNull(resultSet, "date_of_birth"))
                     .isEqualTo(originalDate);
 
             verify(resultSet).getDate("date_of_birth");
@@ -233,7 +233,7 @@ class KiwiJdbcTest {
             var resultSet = newMockResultSet();
             when(resultSet.getDate(anyString())).thenReturn(null);
 
-            assertThat(KiwiJdbc.localDateOrNullFromDate(resultSet, "expiration_date")).isNull();
+            assertThat(KiwiJdbc.localDateFromDateOrNull(resultSet, "expiration_date")).isNull();
 
             verify(resultSet).getDate("expiration_date");
             verifyNoMoreInteractions(resultSet);


### PR DESCRIPTION
Add two localDateOrNullFromDate methods, one that accepts a ResultSet and colum name, and one that accepts a java.sql.Date. They are both annotated with the Checker Nullable annotation to indicate null can be returned, and also that the java.sql.Date argument can be null as well.

Closes #1044