### PR TITLE
Add long-to-boolean conversion methods to KiwiPrimitives

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiPrimitives.java
+++ b/src/main/java/org/kiwiproject/base/KiwiPrimitives.java
@@ -174,4 +174,51 @@ public class KiwiPrimitives {
             throw new IllegalStateException(e);
         }
     }
+
+    /**
+     * Enum representing options for converting a numeric value into a boolean.
+     */
+    public enum BooleanConversionOption {
+
+        /**
+         * Convert numeric values into boolean where one represents true and zero
+         * represents false. No other values are allowed.
+         */
+        ZERO_OR_ONE,
+
+        /**
+         * Convert numeric values into boolean where any non-zero value
+         * represents true, and zero represents false.
+         */
+        NON_ZERO_AS_TRUE
+    }
+
+    /**
+     * Converts the given long value to a boolean. The value must be zero or one.
+     *
+     * @param value the value to convert
+     * @return true if the value is one, or false if zero
+     * @throws IllegalArgumentException if the value in the column is not zero, one, or NULL
+     * @see #booleanFromLong(long, BooleanConversionOption)
+     */
+    public static boolean booleanFromLong(long value) {
+        return booleanFromLong(value, BooleanConversionOption.ZERO_OR_ONE);
+    }
+
+    /**
+     * Converts the given long value to a boolean using the specified {@link BooleanConversionOption}.
+     *
+     * @param value the value to convert
+     * @param option how to convert the long value into a boolean
+     * @return true if the value is non-zero, otherwise false
+     */
+    public static boolean booleanFromLong(long value, BooleanConversionOption option) {
+        return switch (option) {
+            case ZERO_OR_ONE -> {
+                checkArgument(value == 0 || value == 1, "value must be 0 or 1, but found %s", value);
+                yield value == 1;
+            }
+            case NON_ZERO_AS_TRUE -> value != 0;
+        };
+    }
 }


### PR DESCRIPTION
* Add BooleanConversionOption enum, which specifies how numeric values (not just long) should be converted to boolean values
* Add overloaded booleanFromLong methods: one accepts a long argument and uses the ZERO_OR_ONE conversion option, the second accepts long and BooleanConversionOption arguments.
* Also fixed misspelled word "return" in several existing tests

Closes #1053