### PR TITLE
Add int-to-boolean conversion methods to KiwiPrimitives

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiPrimitives.java
+++ b/src/main/java/org/kiwiproject/base/KiwiPrimitives.java
@@ -221,4 +221,33 @@ public class KiwiPrimitives {
             case NON_ZERO_AS_TRUE -> value != 0;
         };
     }
+
+    /**
+     * Converts the given int value to a boolean. The value must be zero or one.
+     *
+     * @param value the value to convert
+     * @return true if the value is one, or false if zero
+     * @throws IllegalArgumentException if the value in the column is not zero, one, or NULL
+     * @see #booleanFromInt(int, BooleanConversionOption)
+     */
+    public static boolean booleanFromInt(int value) {
+        return booleanFromInt(value, BooleanConversionOption.ZERO_OR_ONE);
+    }
+
+    /**
+     * Converts the given int value to a boolean using the specified {@link BooleanConversionOption}.
+     *
+     * @param value  the value to convert
+     * @param option how to convert the int value into a boolean
+     * @return true if the value is non-zero, otherwise false
+     */
+    public static boolean booleanFromInt(int value, BooleanConversionOption option) {
+        return switch (option) {
+            case ZERO_OR_ONE -> {
+                checkArgument(value == 0 || value == 1, "value must be 0 or 1, but found %s", value);
+                yield value == 1;
+            }
+            case NON_ZERO_AS_TRUE -> value != 0;
+        };
+    }
 }

--- a/src/test/java/org/kiwiproject/base/KiwiPrimitivesTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiPrimitivesTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.base.KiwiPrimitives.BooleanConversionOption;
 
 @DisplayName("KiwiPrimitives")
 @ExtendWith(SoftAssertionsExtension.class)
@@ -272,9 +273,46 @@ class KiwiPrimitivesTest {
                 0, NON_ZERO_AS_TRUE, false
                 """)
         void shouldConvertLong_UsingBooleanConversionOption(long value,
-                                                            KiwiPrimitives.BooleanConversionOption option,
+                                                            BooleanConversionOption option,
                                                             boolean expectedResult) {
             assertThat(KiwiPrimitives.booleanFromLong(value, option)).isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
+    class BooleanFromInt {
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                1, true,
+                0, false
+                """)
+        void shouldConvertInt_WithZeroOrOneConversionOption(int value, boolean expectedResult) {
+            assertThat(KiwiPrimitives.booleanFromInt(value)).isEqualTo(expectedResult);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { -10, -5, -1, 2, 10, 42 })
+        void shouldThrowIllegalArgument_WithZeroOrOneConversionOption_WhenValueIsNotZeroOrOne(int value) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiPrimitives.booleanFromInt(value))
+                    .withMessage("value must be 0 or 1, but found %d", value);
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                1, ZERO_OR_ONE, true,
+                1, NON_ZERO_AS_TRUE, true,
+                -1, NON_ZERO_AS_TRUE, true,
+                2, NON_ZERO_AS_TRUE, true,
+                1000, NON_ZERO_AS_TRUE, true,
+                0, ZERO_OR_ONE, false
+                0, NON_ZERO_AS_TRUE, false
+                """)
+        void shouldConvertInt_UsingBooleanConversionOption(int value,
+                                                            BooleanConversionOption option,
+                                                            boolean expectedResult) {
+            assertThat(KiwiPrimitives.booleanFromInt(value, option)).isEqualTo(expectedResult);
         }
     }
 }


### PR DESCRIPTION
* Add overloaded booleanFromInt methods: one accepts a int argument and uses the ZERO_OR_ONE conversion option, the second accepts int and BooleanConversionOption arguments.

Closes #1054