### PR TITLE
Add method to KiwiJdbc to get string values with option to trim

### DIFF
--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.jdbc;
 
 import static java.util.Objects.isNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 
 import lombok.experimental.UtilityClass;
@@ -128,7 +129,7 @@ public class KiwiJdbc {
      * @param rs         the ResultSet
      * @param columnName the date column name
      * @return the converted LocalDate or {@code null} if the column was {@code NULL}
-     * @throws SQLException if there is problem getting the date
+     * @throws SQLException if there is any error getting the date value from the database
      */
     @Nullable
     public static LocalDate localDateFromDateOrNull(ResultSet rs, String columnName) throws SQLException {
@@ -361,6 +362,44 @@ public class KiwiJdbc {
             throws SQLException {
 
         return KiwiPrimitives.booleanFromInt(rs.getInt(columnName), option);
+    }
+
+    /**
+     * Enum representing options for trimming strings.
+     */
+    public enum StringTrimOption {
+
+        /**
+         * Preserves leading and trailing whitespace.
+         */
+        PRESERVE,
+
+        /**
+         * Removes any leading and trailing whitespace.
+         */
+        REMOVE
+    }
+
+    /**
+     * Returns a String from the specified column in the {@link ResultSet} using the given {@link StringTrimOption}.
+     * When the database value is {@code NULL} or contains only whitespace, returns {@code null}.
+     *
+     * @param rs         the ResultSet
+     * @param columnName the date column name
+     * @param option     how to handle leading and trailing whitespace
+     * @return the String with the specified trim option applied, or {@code null} if the column was blank or {@code NULL}
+     * @throws SQLException if there is any error getting the value from the database
+     */
+    @Nullable
+    public static String stringOrNullIfBlank(ResultSet rs,
+                                             String columnName,
+                                             StringTrimOption option) throws SQLException {
+
+        var s = rs.getString(columnName);
+        return isBlank(s) ? null : switch (option) {
+            case PRESERVE -> s;
+            case REMOVE -> s.strip();
+        };
     }
 
     /**

--- a/src/test/java/org/kiwiproject/util/BlankStringSource.java
+++ b/src/test/java/org/kiwiproject/util/BlankStringSource.java
@@ -1,0 +1,32 @@
+package org.kiwiproject.util;
+
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @BlankStringSource} is an {@link ArgumentsSource} which provides blank strings.
+ * <p>
+ * Usage:
+ * <pre>
+ * {@literal @}ParameterizedTest
+ * {@literal @}BlankStringSource
+ *  void testThatEachProvidedArgumentIsBlank(String blankString) 1
+ *      assertThat(blankString).isBlank();
+ *      // or whatever else you need to test where you need a blank String...
+ *  }
+ * </pre>
+ *
+ * <p>
+ *  <strong>NOTE:</strong> This is a duplicate of the kiwi-test version. It is included here to prevent a circular dependency.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ArgumentsSource(BlankStringArgumentsProvider.class)
+public @interface BlankStringSource {
+}


### PR DESCRIPTION
Add stringOrNullIfBlank method to KiwiJdbc. If the value returned from the database is null or blank (whitespace only), this method returns null. If the value from the database is not blank, the string is returned after applying a StringTrimOption to it. This option can either preserve leading and trailing whitespace, or remove it. All intermediate whitespace (i.e. between words) is preserved.

Also added BlankStringSource, which is copied from kiwi-test in order to avoid a circular dependency between kiwi and kiwi-test.

Closes #1049