### PR TITLE
Add method to KiwiJdbc to get trimmed string values or null when blank

### DIFF
--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -379,6 +379,21 @@ public class KiwiJdbc {
     }
 
     /**
+     * Returns a String from the specified column in the {@link ResultSet}, trimming leading and trailing
+     * whitespace. When the database value is {@code NULL} or contains only whitespace, returns {@code null}.
+     *
+     * @param rs         the ResultSet
+     * @param columnName the date column name
+     * @return the String with leading and trailing whitespace removed, or {@code null} if the
+     * column was blank or {@code NULL}
+     * @throws SQLException if there is any error getting the value from the database
+     */
+    @Nullable
+    public static String trimmedStringOrNullIfBlank(ResultSet rs, String columnName) throws SQLException {
+        return stringOrNullIfBlank(rs, columnName, StringTrimOption.REMOVE);
+    }
+
+    /**
      * Enum representing options for trimming strings.
      */
     public enum StringTrimOption {

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
@@ -687,6 +687,43 @@ class KiwiJdbcTest {
     }
 
     @Nested
+    class TrimmedStringOrNullIfBlank {
+
+        @ParameterizedTest
+        @BlankStringSource
+        void shouldReturnNull_WhenValue_IsBlank(String value) throws SQLException {
+            var resultSet = newMockResultSet();
+            when(resultSet.getString(anyString())).thenReturn(value);
+
+            assertThat(KiwiJdbc.trimmedStringOrNullIfBlank(resultSet, "comment")).isNull();
+
+            verify(resultSet).getString("comment");
+            verifyNoMoreInteractions(resultSet);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "alice",
+                "Sphinx of black quartz, judge my vow",
+                "  that was a pangram",
+                "and so is this...   ",
+                "  The five boxing\r\nwizards jump quickly  ",
+                "  and also this one \r\n ",
+                "Pack my box\r\nwith five dozen\r\nliquor jugs"
+        })
+        void shouldReturn_TrimmedStringValue_FromResultSet(String phrase) throws SQLException {
+            var resultSet = newMockResultSet();
+            when(resultSet.getString(anyString())).thenReturn(phrase);
+
+            var trimmed = phrase.strip();
+            assertThat(KiwiJdbc.trimmedStringOrNullIfBlank(resultSet, "phrase")).isEqualTo(trimmed);
+
+            verify(resultSet).getString("phrase");
+            verifyNoMoreInteractions(resultSet);
+        }
+    }
+
+    @Nested
     class StringOrNullIfBlankWithTrimOption {
 
         @ParameterizedTest


### PR DESCRIPTION
Add stringOrNullIfBlank method to KiwiJdbc. If the value returned from the database is null or blank (whitespace only), this method returns null. If the value from the database is not blank, the string is returned after trimming any leading or trailing whitespace.

Closes #1048