### PR TITLE
Clean up: use BlankStringSource in tests

### DIFF
--- a/src/test/java/org/kiwiproject/base/KiwiEnumsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiEnumsTest.java
@@ -8,12 +8,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 @DisplayName("KiwiEnums")
 class KiwiEnumsTest {
@@ -28,7 +27,7 @@ class KiwiEnumsTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldReturnEmptyOptionalWhenGivenBlankInput(String input) {
             assertThat(KiwiEnums.getIfPresent(Season.class, input)).isEmpty();
         }
@@ -65,7 +64,7 @@ class KiwiEnumsTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldReturnEmptyOptionalWhenGivenBlankInput(String input) {
             assertThat(KiwiEnums.getIfPresent(Season.class, input)).isEmpty();
         }

--- a/src/test/java/org/kiwiproject/base/KiwiPreconditionsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiPreconditionsTest.java
@@ -23,11 +23,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.math.BigInteger;
 import java.time.Instant;
@@ -278,7 +277,7 @@ class KiwiPreconditionsTest {
         class WithNoMessage {
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldNotThrow_WhenArgumentIsBlank(String string) {
                 assertThatCode(() -> KiwiPreconditions.checkArgumentIsBlank(string))
                         .doesNotThrowAnyException();
@@ -295,7 +294,7 @@ class KiwiPreconditionsTest {
         class WithMessage {
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldNotThrow_WhenArgumentIsBlank(String string) {
                 assertThatCode(() -> KiwiPreconditions.checkArgumentIsBlank(string, "the argument cannot be blank"))
                         .doesNotThrowAnyException();
@@ -315,7 +314,7 @@ class KiwiPreconditionsTest {
         class WithTemplateMessage {
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldNotThrow_WhenArgumentIsBlank(String string) {
                 assertThatCode(() ->
                         KiwiPreconditions.checkArgumentIsBlank(string, "{} cannot be blank", "foo"))
@@ -574,14 +573,14 @@ class KiwiPreconditionsTest {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void testRequireNotBlank_NoMessage(String value, SoftAssertions softly) {
         softly.assertThatThrownBy(() -> requireNotBlank(value))
                 .isExactlyInstanceOf(IllegalArgumentException.class);
     }
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void testRequireNotBlank_StaticMessage(String value, SoftAssertions softly) {
         var errorMessage = "foo cannot be null";
 
@@ -592,7 +591,7 @@ class KiwiPreconditionsTest {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void testRequireNotBlank_MessageWithTemplate(String value, SoftAssertions softly) {
         var errorMessageTemplate = "{} cannot be null (code: {})";
         Object[] args = { "foo", 42 };

--- a/src/test/java/org/kiwiproject/base/KiwiStringsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiStringsTest.java
@@ -24,9 +24,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -117,21 +116,21 @@ class KiwiStringsTest {
         class NullSafeWithTrimAndOmitEmpty {
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyIterable_WithBlankArgument(String string) {
                 var iterable = nullSafeSplitWithTrimAndOmitEmpty(string);
                 assertThat(iterable).isEmpty();
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyIterable_WithBlankArgument_AndCharSeparator(String string) {
                 var iterable = nullSafeSplitWithTrimAndOmitEmpty(string, COMMA);
                 assertThat(iterable).isEmpty();
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyIterable_WithBlankArgument_AndStringSeparator(String string) {
                 var iterable = nullSafeSplitWithTrimAndOmitEmpty(string, String.valueOf(COMMA));
                 assertThat(iterable).isEmpty();
@@ -231,32 +230,32 @@ class KiwiStringsTest {
         class NullSafeToList {
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyList_WithBlankArgument(String string) {
                 assertThat(nullSafeSplitToList(string)).isEmpty();
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyList_WithBlankArgument_AndCharSeparator(String string) {
                 assertThat(nullSafeSplitToList(string, COMMA)).isEmpty();
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyList_WithBlankArgument_AndStringSeparator(String string) {
                 assertThat(nullSafeSplitToList(string, String.valueOf(COMMA))).isEmpty();
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyList_WithBlankArgument_AndCharSeparator_AndMaxGroups(String string) {
                 assertThat(nullSafeSplitToList(string, NEWLINE, 5)).isEmpty();
             }
 
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void shouldReturnEmptyList_WithBlankArgument_AndStringSeparator_AndMaxGroups(String string) {
                 assertThat(nullSafeSplitToList(string, String.valueOf(COMMA), 10)).isEmpty();
             }
@@ -434,7 +433,7 @@ class KiwiStringsTest {
     class BlankToNull {
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldBeNull_WithBlankStrings(String argument) {
             var result = blankToNull(argument);
             assertThat(result).isNull();

--- a/src/test/java/org/kiwiproject/collect/KiwiMapsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiMapsTest.java
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -250,7 +249,7 @@ class KiwiMapsTest {
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void whenKeyIsBlank(String value) {
                 assertThat(KiwiMaps.keyExistsWithNullValue(Map.of(), value)).isFalse();
             }

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiJaxrsValidationsTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiJaxrsValidationsTest.java
@@ -14,11 +14,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.kiwiproject.jaxrs.exception.ErrorMessage;
 import org.kiwiproject.jaxrs.exception.JaxrsBadRequestException;
 import org.kiwiproject.jaxrs.exception.JaxrsValidationException;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 import org.kiwiproject.validation.group.ExistingObject;
 import org.kiwiproject.validation.group.KiwiValidationGroups;
 import org.kiwiproject.validation.group.NewObject;
@@ -152,7 +151,7 @@ class KiwiJaxrsValidationsTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldThrow_WhenStringIsBlank(String input) {
             var thrown = catchThrowable(() ->
                     KiwiJaxrsValidations.assertNotBlank("mobileNumber", input));

--- a/src/test/java/org/kiwiproject/jaxrs/exception/ErrorMessageTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/ErrorMessageTest.java
@@ -12,11 +12,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.kiwiproject.collect.KiwiMaps;
 import org.kiwiproject.internal.Fixtures;
 import org.kiwiproject.json.JsonHelper;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -42,7 +41,7 @@ class ErrorMessageTest {
     class ShouldConstruct {
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void withBlankString(String blankString) {
             var errorMessage = new ErrorMessage(blankString);
 
@@ -211,7 +210,7 @@ class ErrorMessageTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void whenMapContainsBlankMessage(String blankMessage) {
             // Map.of does not permit null values; use KiwiMaps instead
             Map<String, Object> props = KiwiMaps.newHashMap(

--- a/src/test/java/org/kiwiproject/net/SimpleHostAndPortTest.java
+++ b/src/test/java/org/kiwiproject/net/SimpleHostAndPortTest.java
@@ -6,14 +6,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 @DisplayName("SimpleHostAndPort")
 class SimpleHostAndPortTest {
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void testFromWithDefaults_WithBlankStrings(String input) {
         var hostAndPort = SimpleHostAndPort.from(input, "192.168.1.101", 8900);
 
@@ -44,7 +43,7 @@ class SimpleHostAndPortTest {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void testFromWithNoDefaults_WithBlankStrings(String input) {
         assertThatThrownBy(() -> SimpleHostAndPort.from(input))
                 .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/org/kiwiproject/security/KiwiSecurityTest.java
+++ b/src/test/java/org/kiwiproject/security/KiwiSecurityTest.java
@@ -9,10 +9,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
@@ -150,7 +149,7 @@ class KiwiSecurityTest {
                 }
 
                 @ParameterizedTest
-                @ArgumentsSource(BlankStringArgumentsProvider.class)
+                @BlankStringSource
                 void andKeyStoreTypeIsBlank(String blankKeyStoreType) {
                     assertThatIllegalArgumentException()
                             .isThrownBy(() ->
@@ -162,7 +161,7 @@ class KiwiSecurityTest {
                 }
 
                 @ParameterizedTest
-                @ArgumentsSource(BlankStringArgumentsProvider.class)
+                @BlankStringSource
                 void andKeyManagerAlgorithmIsBlank(String blankKeyManagerAlgorithm) {
                     assertThatIllegalArgumentException()
                             .isThrownBy(() ->
@@ -176,7 +175,7 @@ class KiwiSecurityTest {
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void whenBlankTrustStorePath(String blankTrustStorePath) {
                 assertThatIllegalArgumentException()
                         .isThrownBy(() ->
@@ -201,7 +200,7 @@ class KiwiSecurityTest {
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void whenBlankTrustStoreType(String blankTrustStoreType) {
                 assertThatIllegalArgumentException()
                         .isThrownBy(() ->
@@ -213,7 +212,7 @@ class KiwiSecurityTest {
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void whenBlankTrustManagerAlgorithm(String blankTrustManagerAlgorithm) {
                 assertThatIllegalArgumentException()
                         .isThrownBy(() ->
@@ -225,7 +224,7 @@ class KiwiSecurityTest {
             }
 
             @ParameterizedTest
-            @ArgumentsSource(BlankStringArgumentsProvider.class)
+            @BlankStringSource
             void whenBlankProtocol(String blankProtocol) {
                 assertThatIllegalArgumentException()
                         .isThrownBy(() ->

--- a/src/test/java/org/kiwiproject/spring/data/KiwiSortTest.java
+++ b/src/test/java/org/kiwiproject/spring/data/KiwiSortTest.java
@@ -12,14 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.json.JsonHelper.OutputFormat;
 import org.kiwiproject.spring.data.KiwiSort.Direction;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.util.stream.Stream;
 
@@ -89,7 +88,7 @@ class KiwiSortTest {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void shouldNotPermitBlankPropertyForAscendingSort(String value) {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> KiwiSort.ofAscending(value));
@@ -108,7 +107,7 @@ class KiwiSortTest {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(BlankStringArgumentsProvider.class)
+    @BlankStringSource
     void shouldNotPermitBlankPropertyForDescendingSort(String value) {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> KiwiSort.ofDescending(value));
@@ -138,7 +137,7 @@ class KiwiSortTest {
     class DirectionFromString {
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldRequireNonBlankValue(String value) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> Direction.fromString(value))

--- a/src/test/java/org/kiwiproject/validation/KiwiValidationsTest.java
+++ b/src/test/java/org/kiwiproject/validation/KiwiValidationsTest.java
@@ -34,9 +34,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -695,7 +694,7 @@ class KiwiValidationsTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldReturnNull_WhenFieldNameIsBlank(String input) {
             var contactDetails = new SampleContactDetails("bob@gmail.com", "703-555-1212");
 

--- a/src/test/java/org/kiwiproject/yaml/YamlHelperTest.java
+++ b/src/test/java/org/kiwiproject/yaml/YamlHelperTest.java
@@ -21,9 +21,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.kiwiproject.internal.Fixtures;
-import org.kiwiproject.util.BlankStringArgumentsProvider;
+import org.kiwiproject.util.BlankStringSource;
 
 import java.util.List;
 import java.util.Map;
@@ -158,7 +157,7 @@ class YamlHelperTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldThrow_GivenBlankArgument(String value) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> yamlHelper.toObject(value, Person.class));
@@ -187,7 +186,7 @@ class YamlHelperTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldThrow_GivenBlankArgument(String value) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> yamlHelper.toObject(value, PERSON_TYPE_REFERENCE));
@@ -219,7 +218,7 @@ class YamlHelperTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldThrow_GivenBlankArgument(String value) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> yamlHelper.toObjectList(value, PERSON_LIST_TYPE_REFERENCE));
@@ -246,7 +245,7 @@ class YamlHelperTest {
         }
 
         @ParameterizedTest
-        @ArgumentsSource(BlankStringArgumentsProvider.class)
+        @BlankStringSource
         void shouldThrow_GivenBlankArgument(String value) {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> yamlHelper.toMap(value));


### PR DESCRIPTION
In tests, change all instances of:

@ArgumentsSource(BlankStringArgumentsProvider.class)

to:

@BlankStringSource