### PR TITLE
Make flaky test in AsyncTest a "retrying test"

### DIFF
--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -265,7 +265,11 @@ class AsyncTest {
     @Nested
     class WaitFor {
 
-        @Test
+        /**
+         * @implNote This test has been failing intermittently running in GitHub actions, mainly on JDK 21 but
+         * sometimes on JDK 17. For now, making it a "retrying test". Also, see issue #1070.
+         */
+        @RetryingTest(3)
         void shouldSucceed_WhenTheFutureCompletes_BeforeTimeout() {
             var task = new ConcurrentTask();
             CompletableFuture<Integer> future = Async.doAsync(task::supply);


### PR DESCRIPTION
Hopefully temporary, but change
shouldSucceed_WhenTheFutureCompletes_BeforeTimeout to a RetryingTest so that it (hopefully) will consistently pass when running in GitHub actions.

Relates to #1070