### PR TITLE
Fix flaky tests in AsyncTest

### DIFF
--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -275,11 +275,6 @@ class AsyncTest {
     @Nested
     class WaitFor {
 
-        /**
-         * @implNote This test has been failing intermittently running in GitHub actions, mainly on JDK 21 but
-         * sometimes on JDK 17. For now, making it a "retrying test". Also, see issue #1070.
-         */
-        // @RetryingTest(3)
         @Test
         void shouldSucceed_WhenTheFutureCompletes_BeforeTimeout() {
             var task = new ConcurrentTask(testName);
@@ -292,11 +287,6 @@ class AsyncTest {
             assertThat(future).isCompleted();
         }
 
-        /*
-         * @implNote This is a "retrying" test with a higher task duration because we have seen this test
-         * fail (see issue #1065) when run individually, i.e. in an IDE.
-         */
-        // @RetryingTest(3)
         @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeTheFutureCompletes() {
             var duration = Duration.ofMillis(100);
@@ -342,11 +332,6 @@ class AsyncTest {
             assertThat(future3).isCompleted();
         }
 
-        /*
-         * @implNote This is a "retrying" test with a higher task duration because we have seen this test
-         * fail (see issue #1065) when run individually, i.e. in an IDE.
-         */
-        // @RetryingTest(3)
         @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete() {
             var duration = Duration.ofMillis(200);
@@ -404,12 +389,7 @@ class AsyncTest {
             assertThat(future3).isCompleted();
         }
 
-        /*
-         * @implNote This is a "retrying" test with a higher task duration because we have seen this test
-         * fail (see issue #1065) when run individually, i.e. in an IDE.
-         */
         @SuppressWarnings({ "rawtypes", "unchecked" })
-        // @RetryingTest(3)
         @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete() {
             var duration = Duration.ofMillis(200);

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -47,13 +47,19 @@ class AsyncTest {
         // System.out.printf("BeforeAll: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
 
         var task = new ConcurrentTask();
+        System.out.printf("Task duration millis: %d%n", task.durationMillis);
         var future = Async.doAsync(task::supply);
 
-        var start = System.nanoTime();
-        Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
-        var elapsed = System.nanoTime() - start;
-        var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-        System.out.printf(":BeforeAll: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
+        try {
+            var start = System.nanoTime();
+            Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
+            var elapsed = System.nanoTime() - start;
+            var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+            System.out.printf(":BeforeAll: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
+        } catch (Exception e) {
+            System.out.println("EXCEPTION IN beforeAll");
+            e.printStackTrace(System.out);
+        }
     }
 
     @BeforeEach
@@ -65,13 +71,19 @@ class AsyncTest {
         // System.out.printf("BeforeEach: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
 
         var task = new ConcurrentTask();
+        System.out.printf("Task duration millis: %d%n", task.durationMillis);
         var future = Async.doAsync(task::supply);
 
-        var start = System.nanoTime();
-        Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
-        var elapsed = System.nanoTime() - start;
-        var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-        System.out.printf(":BeforeEach: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
+        try {
+            var start = System.nanoTime();
+            Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
+            var elapsed = System.nanoTime() - start;
+            var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+            System.out.printf(":BeforeEach: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
+        } catch (Exception e) {
+            System.out.println("EXCEPTION IN setUp");
+            e.printStackTrace(System.out);
+        }
     }
 
     @AfterEach

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -476,8 +476,8 @@ class AsyncTest {
     }
 
     private static <T> void cancel(CompletableFuture<T> future) {
-        var wasCancelled = future.cancel(true);
-        assertThat(wasCancelled).isTrue();
+//        var wasCancelled = future.cancel(true);
+//        assertThat(wasCancelled).isTrue();
     }
 
     private static void confirmCompletion(ConcurrentTask task) {

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -501,7 +501,22 @@ class AsyncTest {
                     .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
                     .hasCauseExactlyInstanceOf(TimeoutException.class);
 
-            cancel(futureWithTimeout);
+            LOG.info("futureWithTimeout.isDone: {}", futureWithTimeout.isDone());
+            LOG.info("futureWithTimeout.isCancelled: {}", futureWithTimeout.isCancelled());
+            LOG.info("futureWithTimeout.isCompletedExceptionally: {}", futureWithTimeout.isCompletedExceptionally());
+
+            LOG.info("future.isDone: {}", future.isDone());
+            LOG.info("future.isCancelled: {}", future.isCancelled());
+            LOG.info("future.isCompletedExceptionally: {}", future.isCompletedExceptionally());
+
+            LOG.info("Cancel the future!");
+
+            cancel(future);
+
+            LOG.info("future.isDone: {}", future.isDone());
+            LOG.info("future.isCancelled: {}", future.isCancelled());
+            LOG.info("future.isCompletedExceptionally: {}", future.isCompletedExceptionally());
+
         }
     }
 

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -509,6 +509,10 @@ class AsyncTest {
             LOG.info("future.isCancelled: {}", future.isCancelled());
             LOG.info("future.isCompletedExceptionally: {}", future.isCompletedExceptionally());
 
+            LOG.info("Wait a bit before cancelling the future...");
+
+            ENV.sleepQuietly(5_000);  // TODO - temporary b/c both sets of future.isXxx were the same, unexpectedly...
+
             LOG.info("Cancel the future!");
 
             cancel(future);

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -476,8 +476,8 @@ class AsyncTest {
     }
 
     private static <T> void cancel(CompletableFuture<T> future) {
-//        var wasCancelled = future.cancel(true);
-//        assertThat(wasCancelled).isTrue();
+        var wasCancelled = future.cancel(true);
+        assertThat(wasCancelled).isTrue();
     }
 
     private static void confirmCompletion(ConcurrentTask task) {

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -12,10 +12,11 @@ import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.RetryingTest;
+// import org.junitpioneer.jupiter.RetryingTest;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
 import org.kiwiproject.concurrent.Async.Mode;
@@ -26,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,6 +36,24 @@ import java.util.concurrent.atomic.AtomicReference;
 class AsyncTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
+
+    @BeforeAll
+    static void beforeAll() {
+        var start = System.nanoTime();
+        ForkJoinPool.commonPool();
+        var elapsed = System.nanoTime() - start;
+        var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+        System.out.printf("BeforeAll: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+    }
+
+    @BeforeEach
+    void setUp() {
+        var start = System.nanoTime();
+        ForkJoinPool.commonPool();
+        var elapsed = System.nanoTime() - start;
+        var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+        System.out.printf("BeforeEach: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+    }
 
     @AfterEach
     void tearDown() {
@@ -269,7 +289,8 @@ class AsyncTest {
          * @implNote This test has been failing intermittently running in GitHub actions, mainly on JDK 21 but
          * sometimes on JDK 17. For now, making it a "retrying test". Also, see issue #1070.
          */
-        @RetryingTest(3)
+        // @RetryingTest(3)
+        @Test
         void shouldSucceed_WhenTheFutureCompletes_BeforeTimeout() {
             var task = new ConcurrentTask();
             CompletableFuture<Integer> future = Async.doAsync(task::supply);
@@ -285,7 +306,8 @@ class AsyncTest {
          * @implNote This is a "retrying" test with a higher task duration because we have seen this test
          * fail (see issue #1065) when run individually, i.e. in an IDE.
          */
-        @RetryingTest(3)
+        // @RetryingTest(3)
+        @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeTheFutureCompletes() {
             var duration = Duration.ofMillis(100);
             var task = new ConcurrentTask(duration);
@@ -330,7 +352,8 @@ class AsyncTest {
          * @implNote This is a "retrying" test with a higher task duration because we have seen this test
          * fail (see issue #1065) when run individually, i.e. in an IDE.
          */
-        @RetryingTest(3)
+        // @RetryingTest(3)
+        @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete() {
             var duration = Duration.ofMillis(200);
             var task1 = new ConcurrentTask(duration);
@@ -386,7 +409,8 @@ class AsyncTest {
          * fail (see issue #1065) when run individually, i.e. in an IDE.
          */
         @SuppressWarnings("rawtypes")
-        @RetryingTest(3)
+        // @RetryingTest(3)
+        @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete() {
             var duration = Duration.ofMillis(200);
             var task1 = new ConcurrentTask(duration);

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -303,14 +303,16 @@ class AsyncTest {
             var task = new ConcurrentTask(testName, duration);
             CompletableFuture<Integer> future = Async.doAsync(task::supply);
 
-            assertThatThrownBy(() -> Async.waitFor(future, 1, TimeUnit.MILLISECONDS))
-                    .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
-                    .hasCauseInstanceOf(TimeoutException.class);
+            try {
+                assertThatThrownBy(() -> Async.waitFor(future, 1, TimeUnit.MILLISECONDS))
+                        .isExactlyInstanceOf(AsyncException.class)
+                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasCauseInstanceOf(TimeoutException.class);
 
-            assertThat(task.getCurrentCount()).isZero();
-
-            cancel(future);
+                assertThat(task.getCurrentCount()).isZero();
+            } finally {
+                cancel(future);
+            }
         }
     }
 
@@ -357,19 +359,21 @@ class AsyncTest {
             var task3 = new ConcurrentTask(testName + "#task3", duration);
             CompletableFuture<Integer> future3 = Async.doAsync(task3::supply);
 
-            var futures = List.of(future1, future2, future3);
-            assertThatThrownBy(() -> Async.waitForAll(futures, 1, TimeUnit.MILLISECONDS))
-                    .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
-                    .hasCauseInstanceOf(TimeoutException.class);
+            try {
+                var futures = List.of(future1, future2, future3);
+                assertThatThrownBy(() -> Async.waitForAll(futures, 1, TimeUnit.MILLISECONDS))
+                        .isExactlyInstanceOf(AsyncException.class)
+                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasCauseInstanceOf(TimeoutException.class);
 
-            assertThat(task1.getCurrentCount()).isZero();
-            assertThat(task2.getCurrentCount()).isZero();
-            assertThat(task3.getCurrentCount()).isZero();
-
-            cancel(future1);
-            cancel(future2);
-            cancel(future3);
+                assertThat(task1.getCurrentCount()).isZero();
+                assertThat(task2.getCurrentCount()).isZero();
+                assertThat(task3.getCurrentCount()).isZero();
+            } finally {
+                cancel(future1);
+                cancel(future2);
+                cancel(future3);
+            }
         }
     }
 
@@ -418,19 +422,21 @@ class AsyncTest {
             var task3 = new ConcurrentTask(testName + "#task3", duration);
             CompletableFuture future3 = Async.doAsync(task3::supply);
 
-            var futures = List.of(future1, future2, future3);
-            assertThatThrownBy(() -> Async.waitForAllIgnoringType(futures, 1, TimeUnit.MILLISECONDS))
-                    .isExactlyInstanceOf(AsyncException.class)
-                    .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
-                    .hasCauseInstanceOf(TimeoutException.class);
+            try {
+                var futures = List.of(future1, future2, future3);
+                assertThatThrownBy(() -> Async.waitForAllIgnoringType(futures, 1, TimeUnit.MILLISECONDS))
+                        .isExactlyInstanceOf(AsyncException.class)
+                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasCauseInstanceOf(TimeoutException.class);
 
-            assertThat(task1.getCurrentCount()).isZero();
-            assertThat(task2.getCurrentCount()).isZero();
-            assertThat(task3.getCurrentCount()).isZero();
-
-            cancel(future1);
-            cancel(future2);
-            cancel(future3);
+                assertThat(task1.getCurrentCount()).isZero();
+                assertThat(task2.getCurrentCount()).isZero();
+                assertThat(task3.getCurrentCount()).isZero();
+            } finally {
+                cancel(future1);
+                cancel(future2);
+                cancel(future3);
+            }
         }
     }
 

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -43,7 +43,7 @@ class AsyncTest {
     static void beforeAll() {
         LOG.info("-------------------- beforeAll --------------------");
 
-        var task = new ConcurrentTask();
+        var task = new ConcurrentTask("beforeAll");
         LOG.info("Task duration millis: {}", task.durationMillis);
         var future = Async.doAsync(task::supply);
 
@@ -63,7 +63,7 @@ class AsyncTest {
     void setUp() {
         System.out.println("-------------------- setUp --------------------");
 
-        var task = new ConcurrentTask();
+        var task = new ConcurrentTask("setUp");
         LOG.info("Task duration millis: {}", task.durationMillis);
         var future = Async.doAsync(task::supply);
 
@@ -102,7 +102,7 @@ class AsyncTest {
 
         @Test
         void shouldNotBlock_WhenAsyncModeIsEnabled() {
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithRunnable#shouldNotBlock_WhenAsyncModeIsEnabled");
             CompletableFuture<Void> future = Async.runAsync(task::run);
 
             // verify that immediately after triggering run, the count is still 0
@@ -118,7 +118,7 @@ class AsyncTest {
         @Test
         void shouldNotThrowExceptionWhenCompletesExceptionally() {
             var ex = new RuntimeException("oops");
-            var task = new ConcurrentTask().withException(ex);
+            var task = new ConcurrentTask("DoAsyncWithRunnable#shouldNotThrowExceptionWhenCompletesExceptionally").withException(ex);
             CompletableFuture<Void> future = Async.runAsync(task::run);
 
             // verify that immediately after triggering run, the count is still 0
@@ -134,7 +134,7 @@ class AsyncTest {
         @Test
         void shouldBlock_WhenAsyncModeIsDisabled() {
             Async.setUnitTestAsyncMode(Mode.DISABLED);
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithRunnable#shouldBlock_WhenAsyncModeIsDisabled");
             CompletableFuture<Void> future = Async.runAsync(task::run);
 
             // verify that immediately after triggering run with mode=DISABLED, the count is 1
@@ -167,7 +167,7 @@ class AsyncTest {
 
         @Test
         void shouldNotBlock_WhenAsyncModeIsEnabled() {
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithRunnableAndExecutor#shouldNotBlock_WhenAsyncModeIsEnabled");
             CompletableFuture<Void> future = Async.runAsync(task::run, executor);
 
             // verify that immediately after triggering run, the count is still 0
@@ -180,7 +180,7 @@ class AsyncTest {
         @Test
         void shouldBlock_WhenAsyncModeIsDisabled() {
             Async.setUnitTestAsyncMode(Mode.DISABLED);
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithRunnableAndExecutor#shouldBlock_WhenAsyncModeIsDisabled");
             CompletableFuture<Void> future = Async.runAsync(task::run, executor);
 
             // verify that immediately after triggering run with mode=DISABLED, the count is 1
@@ -236,7 +236,7 @@ class AsyncTest {
 
         @Test
         void shouldNotBlock_WhenAsyncModeIsEnabled() {
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithSupplier#shouldNotBlock_WhenAsyncModeIsEnabled");
             CompletableFuture<Integer> future = Async.supplyAsync(task::supply);
 
             // verify that immediately after triggering run, the count is still 0
@@ -250,7 +250,7 @@ class AsyncTest {
         @Test
         void shouldBlock_WhenAsyncModeIsDisabled() {
             Async.setUnitTestAsyncMode(Mode.DISABLED);
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithSupplier#shouldBlock_WhenAsyncModeIsDisabled");
             CompletableFuture<Integer> future = Async.supplyAsync(task::supply);
 
             // verify that immediately after triggering run with mode=DISABLED, the count is 1
@@ -281,7 +281,7 @@ class AsyncTest {
 
         @Test
         void shouldNotBlock_WhenAsyncModeIsEnabled() {
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithSupplierAndExecutor#shouldNotBlock_WhenAsyncModeIsEnabled");
             CompletableFuture<Integer> future = Async.supplyAsync(task::supply, executor);
 
             // verify that immediately after triggering run, the count is still 0
@@ -295,7 +295,7 @@ class AsyncTest {
         @Test
         void shouldBlock_WhenAsyncModeIsDisabled() {
             Async.setUnitTestAsyncMode(Mode.DISABLED);
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("DoAsyncWithSupplierAndExecutor#shouldBlock_WhenAsyncModeIsDisabled");
             CompletableFuture<Integer> future = Async.supplyAsync(task::supply, executor);
 
             // verify that immediately after triggering run with mode=DISABLED, the count is 1
@@ -316,7 +316,7 @@ class AsyncTest {
         // @RetryingTest(3)
         @Test
         void shouldSucceed_WhenTheFutureCompletes_BeforeTimeout() {
-            var task = new ConcurrentTask();
+            var task = new ConcurrentTask("WaitFor#shouldSucceed_WhenTheFutureCompletes_BeforeTimeout");
             CompletableFuture<Integer> future = Async.doAsync(task::supply);
 
             Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
@@ -334,7 +334,7 @@ class AsyncTest {
         @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeTheFutureCompletes() {
             var duration = Duration.ofMillis(100);
-            var task = new ConcurrentTask(duration);
+            var task = new ConcurrentTask("WaitFor#shouldThrowAsyncException_WhenTimesOut_BeforeTheFutureCompletes", duration);
             CompletableFuture<Integer> future = Async.doAsync(task::supply);
 
             assertThatThrownBy(() -> Async.waitFor(future, 1, TimeUnit.MILLISECONDS))
@@ -351,13 +351,13 @@ class AsyncTest {
 
         @Test
         void shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout() {
-            var task1 = new ConcurrentTask();
+            var task1 = new ConcurrentTask("WaitForAll#shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout#task1");
             CompletableFuture<Integer> future1 = Async.doAsync(task1::supply);
 
-            var task2 = new ConcurrentTask();
+            var task2 = new ConcurrentTask("WaitForAll#shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout#task2");
             CompletableFuture<Integer> future2 = Async.doAsync(task2::supply);
 
-            var task3 = new ConcurrentTask();
+            var task3 = new ConcurrentTask("WaitForAll#shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout#task3");
             CompletableFuture<Integer> future3 = Async.doAsync(task3::supply);
 
             var futures = List.of(future1, future2, future3);
@@ -380,13 +380,13 @@ class AsyncTest {
         @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete() {
             var duration = Duration.ofMillis(200);
-            var task1 = new ConcurrentTask(duration);
+            var task1 = new ConcurrentTask("WaitForAll#shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete#task1", duration);
             CompletableFuture<Integer> future1 = Async.doAsync(task1::supply);
 
-            var task2 = new ConcurrentTask(duration);
+            var task2 = new ConcurrentTask("WaitForAll#shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete#task2", duration);
             CompletableFuture<Integer> future2 = Async.doAsync(task2::supply);
 
-            var task3 = new ConcurrentTask(duration);
+            var task3 = new ConcurrentTask("WaitForAll#shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete#task3", duration);
             CompletableFuture<Integer> future3 = Async.doAsync(task3::supply);
 
             var futures = List.of(future1, future2, future3);
@@ -407,13 +407,13 @@ class AsyncTest {
         @SuppressWarnings({"rawtypes", "unchecked"})
         @Test
         void shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout() {
-            var task1 = new ConcurrentTask();
+            var task1 = new ConcurrentTask("WaitForAllIgnoringType#shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout#task1");
             CompletableFuture future1 = Async.doAsync(task1::supply);
 
-            var task2 = new ConcurrentTask();
+            var task2 = new ConcurrentTask("WaitForAllIgnoringType#shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout#task2");
             CompletableFuture future2 = Async.doAsync(task2::supply);
 
-            var task3 = new ConcurrentTask();
+            var task3 = new ConcurrentTask("WaitForAllIgnoringType#shouldSucceed_WhenAllTheFuturesComplete_BeforeTimeout#task3");
             CompletableFuture future3 = Async.doAsync(task3::supply);
 
             var futures = List.of(future1, future2, future3);
@@ -437,13 +437,13 @@ class AsyncTest {
         @Test
         void shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete() {
             var duration = Duration.ofMillis(200);
-            var task1 = new ConcurrentTask(duration);
+            var task1 = new ConcurrentTask("WaitForAllIgnoringType#shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete#task1", duration);
             CompletableFuture future1 = Async.doAsync(task1::supply);
 
-            var task2 = new ConcurrentTask(duration);
+            var task2 = new ConcurrentTask("WaitForAllIgnoringType#shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete#task2", duration);
             CompletableFuture future2 = Async.doAsync(task2::supply);
 
-            var task3 = new ConcurrentTask(duration);
+            var task3 = new ConcurrentTask("WaitForAllIgnoringType#shouldThrowAsyncException_WhenTimesOut_BeforeAllFuturesComplete#task3", duration);
             CompletableFuture future3 = Async.doAsync(task3::supply);
 
             var futures = List.of(future1, future2, future3);
@@ -463,7 +463,7 @@ class AsyncTest {
 
         @Test
         void shouldTimeout_WhenTaskTakesLongerThan_MaxTimeout() {
-            var task = new ConcurrentTask(Duration.ofSeconds(10));
+            var task = new ConcurrentTask("WithMaxTimeout#shouldTimeout_WhenTaskTakesLongerThan_MaxTimeout", Duration.ofSeconds(10));
             CompletableFuture<Integer> future = Async.doAsync(task::supply);
             CompletableFuture<Integer> futureWithTimeout = Async.withMaxTimeout(future, 5, TimeUnit.MILLISECONDS);
 
@@ -510,16 +510,18 @@ class AsyncTest {
     @Slf4j
     static class ConcurrentTask {
 
+        private final String name;
         private final AtomicInteger counter;
         private final long durationMillis;
 
         private RuntimeException exceptionToThrow;
 
-        ConcurrentTask() {
-            this(Duration.ofMillis(10));
+        ConcurrentTask(String name) {
+            this(name, Duration.ofMillis(10));
         }
 
-        ConcurrentTask(Duration duration) {
+        ConcurrentTask(String name, Duration duration) {
+            this.name = name;
             this.counter = new AtomicInteger();
             this.durationMillis = duration.toMillis();
         }
@@ -534,7 +536,7 @@ class AsyncTest {
         }
 
         Integer supply() {
-            LOG.debug("executing concurrent task with duration of: {}ms", durationMillis);
+            LOG.debug("executing concurrent task {} with duration of: {}ms", name, durationMillis);
             try {
                 var startTime = System.nanoTime();
                 performWait();
@@ -542,7 +544,7 @@ class AsyncTest {
                 long elapsed = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
 
                 var completionStatus = isNull(exceptionToThrow) ? "successfully" : "exceptionally";
-                LOG.debug("performed task {} in: {}ms", completionStatus, elapsed);
+                LOG.debug("performed task {} {} in: {}ms", name, completionStatus, elapsed);
 
                 var updatedCount = counter.incrementAndGet();
 
@@ -553,7 +555,7 @@ class AsyncTest {
                 return updatedCount;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                LOG.debug("Wait interrupted", e);
+                LOG.debug("Wait interrupted for task {}", name, e);
             }
 
             return counter.get();

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ForkJoinPool;
+// import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,20 +39,38 @@ class AsyncTest {
 
     @BeforeAll
     static void beforeAll() {
+        // var start = System.nanoTime();
+        // ForkJoinPool.commonPool();
+        // var elapsed = System.nanoTime() - start;
+        // var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+        // System.out.printf("BeforeAll: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+
+        var task = new ConcurrentTask();
+        var future = Async.doAsync(task::supply);
+
         var start = System.nanoTime();
-        ForkJoinPool.commonPool();
+        Async.waitFor(future, 1, TimeUnit.SECONDS);
         var elapsed = System.nanoTime() - start;
         var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-        System.out.printf("BeforeAll: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+        System.out.printf(":BeforeAll: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
     }
 
     @BeforeEach
     void setUp() {
+        // var start = System.nanoTime();
+        // ForkJoinPool.commonPool();
+        // var elapsed = System.nanoTime() - start;
+        // var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+        // System.out.printf("BeforeEach: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+
+        var task = new ConcurrentTask();
+        var future = Async.doAsync(task::supply);
+
         var start = System.nanoTime();
-        ForkJoinPool.commonPool();
+        Async.waitFor(future, 1, TimeUnit.SECONDS);
         var elapsed = System.nanoTime() - start;
         var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-        System.out.printf("BeforeEach: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+        System.out.printf(":BeforeEach: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
     }
 
     @AfterEach

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 // import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -49,7 +50,7 @@ class AsyncTest {
         var future = Async.doAsync(task::supply);
 
         var start = System.nanoTime();
-        Async.waitFor(future, 1, TimeUnit.SECONDS);
+        Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
         var elapsed = System.nanoTime() - start;
         var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
         System.out.printf(":BeforeAll: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
@@ -67,7 +68,7 @@ class AsyncTest {
         var future = Async.doAsync(task::supply);
 
         var start = System.nanoTime();
-        Async.waitFor(future, 1, TimeUnit.SECONDS);
+        Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
         var elapsed = System.nanoTime() - start;
         var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
         System.out.printf(":BeforeEach: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -40,6 +40,8 @@ class AsyncTest {
 
     @BeforeAll
     static void beforeAll() {
+        System.out.println("-------------------- beforeAll --------------------");
+
         // var start = System.nanoTime();
         // ForkJoinPool.commonPool();
         // var elapsed = System.nanoTime() - start;
@@ -51,6 +53,7 @@ class AsyncTest {
         var future = Async.doAsync(task::supply);
 
         try {
+            System.out.println("About to wait");
             var start = System.nanoTime();
             Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
             var elapsed = System.nanoTime() - start;
@@ -64,6 +67,8 @@ class AsyncTest {
 
     @BeforeEach
     void setUp() {
+        System.out.println("-------------------- setUp --------------------");
+
         // var start = System.nanoTime();
         // ForkJoinPool.commonPool();
         // var elapsed = System.nanoTime() - start;
@@ -75,6 +80,7 @@ class AsyncTest {
         var future = Async.doAsync(task::supply);
 
         try {
+            System.out.println("About to wait");
             var start = System.nanoTime();
             Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
             var elapsed = System.nanoTime() - start;

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -455,6 +455,13 @@ class AsyncTest {
         }
     }
 
+    /**
+     * Cancel the given CompletableFuture. This should be called by tests that are testing timeout situations
+     * such as when testing {@link Async#waitFor(CompletableFuture, long, TimeUnit)} and the other similar
+     * methods that wrap a CompletableFuture and apply a timeout. If the test is verifying that waitFor methods
+     * work as expected when a CompletableFuture has not completed when the timeout period expires, then that
+     * test should call this method to ensure the outstanding tasks are canceled.
+     */
     private static <T> void cancel(CompletableFuture<T> future) {
         var wasCancelled = future.cancel(true);
         assertThat(wasCancelled).isTrue();

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -34,34 +34,28 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+@Slf4j
 class AsyncTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
 
     @BeforeAll
     static void beforeAll() {
-        System.out.println("-------------------- beforeAll --------------------");
-
-        // var start = System.nanoTime();
-        // ForkJoinPool.commonPool();
-        // var elapsed = System.nanoTime() - start;
-        // var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-        // System.out.printf("BeforeAll: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
+        LOG.info("-------------------- beforeAll --------------------");
 
         var task = new ConcurrentTask();
-        System.out.printf("Task duration millis: %d%n", task.durationMillis);
+        LOG.info("Task duration millis: {}", task.durationMillis);
         var future = Async.doAsync(task::supply);
 
         try {
-            System.out.println("About to wait");
+            LOG.info("About to wait");
             var start = System.nanoTime();
             Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
             var elapsed = System.nanoTime() - start;
             var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-            System.out.printf(":BeforeAll: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
+            LOG.info(":BeforeAll: Took {} nanos ( {} millis ) for waitFor to return with 250ms timeout%n", elapsed, millis);
         } catch (Exception e) {
-            System.out.println("EXCEPTION IN beforeAll");
-            e.printStackTrace(System.out);
+            LOG.error("EXCEPTION IN beforeAll", e);
         }
     }
 
@@ -69,26 +63,19 @@ class AsyncTest {
     void setUp() {
         System.out.println("-------------------- setUp --------------------");
 
-        // var start = System.nanoTime();
-        // ForkJoinPool.commonPool();
-        // var elapsed = System.nanoTime() - start;
-        // var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-        // System.out.printf("BeforeEach: Took %d nanos ( %d millis ) to init the common pool%n", elapsed, millis);
-
         var task = new ConcurrentTask();
-        System.out.printf("Task duration millis: %d%n", task.durationMillis);
+        LOG.info("Task duration millis: {}", task.durationMillis);
         var future = Async.doAsync(task::supply);
 
         try {
-            System.out.println("About to wait");
+            LOG.info("About to wait");
             var start = System.nanoTime();
             Async.waitFor(future, 250, TimeUnit.MILLISECONDS);
             var elapsed = System.nanoTime() - start;
             var millis = TimeUnit.NANOSECONDS.toMillis(elapsed);
-            System.out.printf(":BeforeEach: Took %d nanos ( %d millis ) for waitFor to return with 1 second timeout%n", elapsed, millis);
+            LOG.info(":BeforeEach: Took {} nanos ( {} millis ) for waitFor to return with 250ms timeout%n", elapsed, millis);
         } catch (Exception e) {
-            System.out.println("EXCEPTION IN setUp");
-            e.printStackTrace(System.out);
+            LOG.error("EXCEPTION IN setUp", e);
         }
     }
 


### PR DESCRIPTION
Ensure that the tests all pass consistently by canceling the futures in the tests
where we expect to timeout before the tasks complete. Without canceling them,
tests which call methods in Async that use the common ForkJoinPool can be
blocked by tasks that are still executing from previous tests! So, in the three tests
where waitFor/waitForAll/waitForAllIgnoringTypes time out before the tasks complete,
wrap the assertions in a try/finally and cancel the futures in the finally block. This
commit also removes the RetryingTest annotations on the four tests which had them
and replaces them with the standard JUnit Test annotation. Hopefully this will be
the last time we ever need to deal with flaky tests in Async.

Closes #1070