### PR TITLE
Add disableSniHostCheck property to TLS and SSL configuration classes

### DIFF
--- a/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
@@ -25,6 +25,7 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
     private String keyStoreType = KeyStoreType.JKS.value;
     private String trustStoreType = KeyStoreType.JKS.value;
     private boolean verifyHostname = true;
+    private boolean disableSniHostCheck;
 
     /**
      * A builder class for {@link SSLContextConfiguration}.
@@ -110,6 +111,20 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
             return this;
         }
 
+        /**
+         * Whether the SNI (Server Name Indication) host check is disabled. Default is {@code false}
+         *
+         * @see <a href="https://www.cloudflare.com/learning/ssl/what-is-sni/">What is SNI? How TLS server name indication works</a>
+         */
+        public Builder disableSniHostCheck(boolean disableSniHostCheck) {
+            return setDisableSniHostCheck(disableSniHostCheck);
+        }
+
+        public Builder setDisableSniHostCheck(boolean disableSniHostCheck) {
+            configuration.setDisableSniHostCheck(disableSniHostCheck);
+            return this;
+        }
+
         public SSLContextConfiguration build() {
             return configuration;
         }
@@ -145,8 +160,15 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
      * @return a new instance
      */
     public SimpleSSLContextFactory toSimpleSSLContextFactory() {
-        return new SimpleSSLContextFactory(
-                keyStorePath, keyStorePassword, keyStoreType, trustStorePath, trustStorePassword, trustStoreType, protocol, verifyHostname);
+        return new SimpleSSLContextFactory(keyStorePath,
+                keyStorePassword,
+                keyStoreType,
+                trustStorePath,
+                trustStorePassword,
+                trustStoreType,
+                protocol,
+                verifyHostname,
+                disableSniHostCheck);
     }
 
     /**
@@ -164,6 +186,7 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
                 .trustStoreType(trustStoreType)
                 .protocol(protocol)
                 .verifyHostname(verifyHostname)
+                .disableSniHostCheck(disableSniHostCheck)
                 .build();
     }
 

--- a/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)  // for Builder (b/c also need no-args constructor)
-@ToString(exclude = {"keyStorePassword", "trustStorePassword"})
+@ToString(exclude = { "keyStorePassword", "trustStorePassword" })
 public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
 
     /**
@@ -47,7 +47,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
     private String protocol = SSLContextProtocol.TLS_1_2.value;
 
     /**
-     * The name of the JCE (Java Cryptography Extension) provider to use on client side for cryptographic
+     * The name of the JCE (Java Cryptography Extension) provider to use on the client side for cryptographic
      * support (for example, SunJCE, Conscrypt, BC, etc.).
      * <p>
      * For more details, see the "Java Cryptography Architecture (JCA) Reference Guide" section of the Java
@@ -75,7 +75,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
     private String keyStoreType = KeyStoreType.JKS.value;
 
     /**
-     * The name of the provider for the key store, i.e. the value of {@code provider} to use when getting the
+     * The name of the provider for the key store, i.e., the value of {@code provider} to use when getting the
      * {@link java.security.KeyStore} instance for the key store.
      * <p>
      * For more details, see the "Java Cryptography Architecture (JCA) Reference Guide" section of the Java
@@ -107,7 +107,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
     private String trustStoreType = KeyStoreType.JKS.value;
 
     /**
-     * The name of the provider for the trust store, i.e. the value of {@code provider} to use when getting the
+     * The name of the provider for the trust store, i.e., the value of {@code provider} to use when getting the
      * {@link java.security.KeyStore} instance for the trust store.
      * <p>
      * For more details, see the "Java Cryptography Architecture (JCA) Reference Guide" section of the Java
@@ -129,6 +129,13 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
     private boolean verifyHostname = true;
 
     /**
+     * Whether the SNI (Server Name Indication) host check is disabled. Default is {@code false}
+     *
+     * @see <a href="https://www.cloudflare.com/learning/ssl/what-is-sni/">What is SNI? How TLS server name indication works</a>
+     */
+    private boolean disableSniHostCheck;
+
+    /**
      * List of supported protocols. It can be {@code null}. See the implementation note for why.
      *
      * @implNote Yes, this is null by default. This is due to the Dropwizard {@link TlsConfiguration} which has this
@@ -139,7 +146,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
      * {@link org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory#createLayeredSocket(Socket, String, int, org.apache.hc.core5.http.protocol.HttpContext)}.
      * You will need to look at the source code, as the JavaDoc doesn't mention this tidbit, nor do the constructors
      * since they don't have any documentation regarding their arguments. If you don't like reading source code of the
-     * open source tools you rely on, then please close this file, log out, and change careers.
+     * open-source tools you rely on, then please close this file, log out, and change careers.
      */
     private List<String> supportedProtocols;
 
@@ -162,8 +169,12 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
      * Given a Dropwizard {@link TlsConfiguration}, create a new {@link TlsContextConfiguration}.
      * <p>
      * Even though {@link TlsContextConfiguration} does not permit null trust store properties (per the validation
-     * annotations), the {@link TlsConfiguration} does. If we encounter this sitation, we will be lenient; even though
+     * annotations), the {@link TlsConfiguration} does. If we encounter this situation, we will be lenient; even though
      * this could possibly cause downstream problems, we will just assume the caller knows what it is doing.
+     * <p>
+     * The Dropwizard {@link TlsConfiguration} class does not contain a {@code disableSniHostCheck} property, so
+     * it cannot transfer and is therefore ignored during conversions. Also note that it is set to {@code false}
+     * in the returned {@link TlsContextConfiguration} since that is the more secure option.
      *
      * @param tlsConfig the Dropwizard TlsConfiguration from which to pull information
      * @return a new TlsContextConfiguration instance
@@ -185,6 +196,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
                 .trustStoreProvider(tlsConfig.getTrustStoreProvider())
                 .trustSelfSignedCertificates(tlsConfig.isTrustSelfSignedCertificates())
                 .verifyHostname(tlsConfig.isVerifyHostname())
+                .disableSniHostCheck(false)
                 .supportedProtocols(tlsConfig.getSupportedProtocols())
                 .supportedCiphers(tlsConfig.getSupportedCiphers())
                 .certAlias(tlsConfig.getCertAlias())
@@ -198,6 +210,9 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
     /**
      * Convert this {@link TlsContextConfiguration} into a Dropwizard {@link TlsConfiguration} object. Assumes that
      * this object is valid.
+     * <p>
+     * The Dropwizard {@link TlsConfiguration} class does not contain a {@code disableSniHostCheck} property, so
+     * it cannot transfer and is therefore ignored during conversions.
      *
      * @return a new Dropwizard TlsConfiguration instance
      * @implNote Requires dropwizard-client as a dependency
@@ -248,6 +263,7 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
                 .trustStoreType(trustStoreType)
                 .protocol(protocol)
                 .verifyHostname(verifyHostname)
+                .disableSniHostCheck(disableSniHostCheck)
                 .build();
     }
 }

--- a/src/test/java/org/kiwiproject/config/SSLContextConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/config/SSLContextConfigurationTest.java
@@ -1,13 +1,17 @@
 package org.kiwiproject.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.kiwiproject.beans.BeanConverter;
 import org.kiwiproject.security.KeyStoreType;
 import org.kiwiproject.security.SecureTestConstants;
+
+import java.util.Map;
 
 @DisplayName("SSLContextConfiguration")
 class SSLContextConfigurationTest {
@@ -66,15 +70,34 @@ class SSLContextConfigurationTest {
 
         var tlsConfig = sslConfig.toTlsContextConfiguration();
 
-        assertThat(tlsConfig.getKeyStorePath()).isEqualTo(sslConfig.getKeyStorePath());
-        assertThat(tlsConfig.getKeyStorePassword()).isEqualTo(sslConfig.getKeyStorePassword());
-        assertThat(tlsConfig.getKeyStoreType()).isEqualTo(sslConfig.getKeyStoreType());
-        assertThat(tlsConfig.getTrustStorePath()).isEqualTo(sslConfig.getTrustStorePath());
-        assertThat(tlsConfig.getTrustStorePassword()).isEqualTo(sslConfig.getTrustStorePassword());
-        assertThat(tlsConfig.getTrustStoreType()).isEqualTo(sslConfig.getTrustStoreType());
-        assertThat(tlsConfig.isVerifyHostname()).isEqualTo(sslConfig.isVerifyHostname());
-        assertThat(tlsConfig.getProtocol()).isEqualTo(sslConfig.getProtocol());
-        assertThat(tlsConfig.getSupportedProtocols()).isNull();
+        assertAll(
+                () -> assertThat(tlsConfig.getKeyStorePath()).isEqualTo(sslConfig.getKeyStorePath()),
+                () -> assertThat(tlsConfig.getKeyStorePassword()).isEqualTo(sslConfig.getKeyStorePassword()),
+                () -> assertThat(tlsConfig.getKeyStoreType()).isEqualTo(sslConfig.getKeyStoreType()),
+                () -> assertThat(tlsConfig.getTrustStorePath()).isEqualTo(sslConfig.getTrustStorePath()),
+                () -> assertThat(tlsConfig.getTrustStorePassword()).isEqualTo(sslConfig.getTrustStorePassword()),
+                () -> assertThat(tlsConfig.getTrustStoreType()).isEqualTo(sslConfig.getTrustStoreType()),
+                () -> assertThat(tlsConfig.isVerifyHostname()).isEqualTo(sslConfig.isVerifyHostname()),
+                () -> assertThat(tlsConfig.isDisableSniHostCheck()).isEqualTo(sslConfig.isDisableSniHostCheck()),
+                () -> assertThat(tlsConfig.getProtocol()).isEqualTo(sslConfig.getProtocol()),
+                () -> assertThat(tlsConfig.getSupportedProtocols()).isNull()
+        );
+    }
+
+    @Test
+    void shouldConvertToSimpleSSLContextFactory() {
+        var sslConfig = newSampleSslContextConfiguration();
+        var sslContextFactory = sslConfig.toSimpleSSLContextFactory();
+
+        // Since SimpleSSLContextFactory does not have getters for most properties, get its
+        // configuration as a Map, convert it to an SSLContextConfiguration, and verify that
+        // it is equal to the original sslConfig
+        var converter = new BeanConverter<Map<String, Object>>();
+        var expectedConfig = converter.convert(sslContextFactory.configuration(), new SSLContextConfiguration());
+        assertThat(expectedConfig)
+                .describedAs("round-trip conversion should result in equal SSLContextConfiguration")
+                .usingRecursiveComparison()
+                .isEqualTo(sslConfig);
     }
 
     private SSLContextConfiguration newSampleSslContextConfiguration() {
@@ -87,6 +110,7 @@ class SSLContextConfigurationTest {
                 .trustStoreType(type)
                 .protocol(protocol)
                 .verifyHostname(false)
+                .disableSniHostCheck(true)
                 .build();
     }
 }

--- a/src/test/java/org/kiwiproject/config/TlsContextConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/config/TlsContextConfigurationTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.kiwiproject.util.YamlTestHelper.loadFromYaml;
 import static org.kiwiproject.validation.ValidationTestHelper.assertNoViolations;
 import static org.kiwiproject.validation.ValidationTestHelper.assertOnePropertyViolation;
@@ -46,21 +47,24 @@ class TlsContextConfigurationTest {
     }
 
     private static void assertAllDefaultValues(TlsContextConfiguration config) {
-        assertThat(config.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value);
-        assertThat(config.getProvider()).isNull();
-        assertThat(config.getKeyStorePath()).isNull();
-        assertThat(config.getKeyStorePassword()).isNull();
-        assertThat(config.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value);
-        assertThat(config.getKeyStoreProvider()).isNull();
-        assertThat(config.getTrustStorePath()).isNull();
-        assertThat(config.getTrustStorePassword()).isNull();
-        assertThat(config.getTrustStoreType()).isEqualTo(KeyStoreType.JKS.value);
-        assertThat(config.getTrustStoreProvider()).isNull();
-        assertThat(config.isTrustSelfSignedCertificates()).isFalse();
-        assertThat(config.isVerifyHostname()).isTrue();
-        assertThat(config.getSupportedProtocols()).isNull();
-        assertThat(config.getSupportedCiphers()).isNull();
-        assertThat(config.getCertAlias()).isNull();
+        assertAll(
+                () -> assertThat(config.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value),
+                () -> assertThat(config.getProvider()).isNull(),
+                () -> assertThat(config.getKeyStorePath()).isNull(),
+                () -> assertThat(config.getKeyStorePassword()).isNull(),
+                () -> assertThat(config.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value),
+                () -> assertThat(config.getKeyStoreProvider()).isNull(),
+                () -> assertThat(config.getTrustStorePath()).isNull(),
+                () -> assertThat(config.getTrustStorePassword()).isNull(),
+                () -> assertThat(config.getTrustStoreType()).isEqualTo(KeyStoreType.JKS.value),
+                () -> assertThat(config.getTrustStoreProvider()).isNull(),
+                () -> assertThat(config.isTrustSelfSignedCertificates()).isFalse(),
+                () -> assertThat(config.isVerifyHostname()).isTrue(),
+                () -> assertThat(config.isDisableSniHostCheck()).isFalse(),
+                () -> assertThat(config.getSupportedProtocols()).isNull(),
+                () -> assertThat(config.getSupportedCiphers()).isNull(),
+                () -> assertThat(config.getCertAlias()).isNull()
+        );
     }
 
     @Nested
@@ -106,10 +110,12 @@ class TlsContextConfigurationTest {
 
             assertDefaultValues(tlsConfig);
 
-            assertThat(tlsConfig.getKeyStorePath()).isEqualTo("/path/to/keystore.jks");
-            assertThat(tlsConfig.getKeyStorePassword()).isEqualTo("ksPassWd");
-            assertThat(tlsConfig.getTrustStorePath()).isEqualTo("/path/to/truststore.jks");
-            assertThat(tlsConfig.getTrustStorePassword()).isEqualTo("tsPass100");
+            assertAll(
+                    () -> assertThat(tlsConfig.getKeyStorePath()).isEqualTo("/path/to/keystore.jks"),
+                    () -> assertThat(tlsConfig.getKeyStorePassword()).isEqualTo("ksPassWd"),
+                    () -> assertThat(tlsConfig.getTrustStorePath()).isEqualTo("/path/to/truststore.jks"),
+                    () -> assertThat(tlsConfig.getTrustStorePassword()).isEqualTo("tsPass100")
+            );
         }
 
         @Test
@@ -118,35 +124,43 @@ class TlsContextConfigurationTest {
 
             assertDefaultValues(tlsConfig);
 
-            assertThat(tlsConfig.getKeyStorePath()).isNull();
-            assertThat(tlsConfig.getKeyStorePassword()).isNull();
+            assertAll(
+                    () -> assertThat(tlsConfig.getKeyStorePath()).isNull(),
+                    () -> assertThat(tlsConfig.getKeyStorePassword()).isNull()
+            );
         }
 
         @Test
         void shouldDeserializeFullConfig() {
             var tlsConfig = loadTlsContextConfiguration("TlsContextConfigurationTest/full-tls-config.yml");
 
-            assertThat(tlsConfig.getProtocol()).isEqualTo("TLSv1.3");
-            assertThat(tlsConfig.getKeyStorePath()).isEqualTo("/path/to/keystore.pkcs12");
-            assertThat(tlsConfig.getKeyStorePassword()).isEqualTo("ksPassWd");
-            assertThat(tlsConfig.getKeyStoreType()).isEqualTo("PKCS12");
-            assertThat(tlsConfig.getTrustStorePath()).isEqualTo("/path/to/truststore.pkcs12");
-            assertThat(tlsConfig.getTrustStorePassword()).isEqualTo("tsPass100");
-            assertThat(tlsConfig.getTrustStoreType()).isEqualTo("PKCS12");
-            assertThat(tlsConfig.isVerifyHostname()).isFalse();
-            assertThat(tlsConfig.getSupportedProtocols()).containsOnly(
-                    SSLContextProtocol.TLS_1_2.value,
-                    SSLContextProtocol.TLS_1_3.value
+            assertAll(
+                    () -> assertThat(tlsConfig.getProtocol()).isEqualTo("TLSv1.3"),
+                    () -> assertThat(tlsConfig.getKeyStorePath()).isEqualTo("/path/to/keystore.pkcs12"),
+                    () -> assertThat(tlsConfig.getKeyStorePassword()).isEqualTo("ksPassWd"),
+                    () -> assertThat(tlsConfig.getKeyStoreType()).isEqualTo("PKCS12"),
+                    () -> assertThat(tlsConfig.getTrustStorePath()).isEqualTo("/path/to/truststore.pkcs12"),
+                    () -> assertThat(tlsConfig.getTrustStorePassword()).isEqualTo("tsPass100"),
+                    () -> assertThat(tlsConfig.getTrustStoreType()).isEqualTo("PKCS12"),
+                    () -> assertThat(tlsConfig.isVerifyHostname()).isFalse(),
+                    () -> assertThat(tlsConfig.isDisableSniHostCheck()).isTrue(),
+                    () -> assertThat(tlsConfig.getSupportedProtocols()).containsOnly(
+                            SSLContextProtocol.TLS_1_2.value,
+                            SSLContextProtocol.TLS_1_3.value
+                    )
             );
         }
     }
 
     private static void assertDefaultValues(TlsContextConfiguration config) {
-        assertThat(config.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value);
-        assertThat(config.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value);
-        assertThat(config.getTrustStoreType()).isEqualTo(KeyStoreType.JKS.value);
-        assertThat(config.isVerifyHostname()).isTrue();
-        assertThat(config.getSupportedProtocols()).isNull();
+        assertAll(
+                () -> assertThat(config.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value),
+                () -> assertThat(config.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value),
+                () -> assertThat(config.getTrustStoreType()).isEqualTo(KeyStoreType.JKS.value),
+                () -> assertThat(config.isVerifyHostname()).isTrue(),
+                () -> assertThat(config.isDisableSniHostCheck()).isFalse(),
+                () -> assertThat(config.getSupportedProtocols()).isNull()
+        );
     }
 
     @Nested
@@ -235,6 +249,7 @@ class TlsContextConfigurationTest {
                     .trustStoreProvider("BC")
                     .trustSelfSignedCertificates(true)
                     .verifyHostname(false)
+                    .disableSniHostCheck(true)
                     .supportedProtocols(List.of("TLSv1.3"))
                     .supportedCiphers(List.of("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"))
                     .certAlias("cert84")
@@ -279,44 +294,50 @@ class TlsContextConfigurationTest {
 
                 var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
 
-                // The following also test assumptions about defaults of Dropwizard's TlsConfiguration, for example
-                // which are null. This isn't wonderful but at the same time we'll find out quickly what Dropwizard
+                // The following also tests assumptions about defaults of Dropwizard's TlsConfiguration, for example,
+                // which ones are null. This isn't wonderful, but at the same time we'll find out quickly what Dropwizard
                 // has changed.
-                assertThat(tlsContextConfig.getProtocol()).isNotNull().isEqualTo(dwTlsConfig.getProtocol());
-                assertThat(tlsContextConfig.getKeyStorePath()).isNull();
-                assertThat(tlsContextConfig.getKeyStorePassword()).isNull();
-                assertThat(tlsContextConfig.getKeyStoreType()).isNotNull().isEqualTo(dwTlsConfig.getKeyStoreType());
-                assertThat(tlsContextConfig.getKeyStoreProvider()).isNull();
-                assertThat(tlsContextConfig.getTrustStorePath()).isNull();
-                assertThat(tlsContextConfig.getTrustStorePassword()).isNull();
-                assertThat(tlsContextConfig.getTrustStoreType()).isNotNull().isEqualTo(dwTlsConfig.getTrustStoreType());
-                assertThat(tlsContextConfig.getTrustStoreProvider()).isNull();
-                assertThat(tlsContextConfig.isTrustSelfSignedCertificates()).isFalse();
-                assertThat(tlsContextConfig.isVerifyHostname()).isTrue();
-                assertThat(tlsContextConfig.getSupportedProtocols()).isNull();
-                assertThat(tlsContextConfig.getSupportedCiphers()).isNull();
-                assertThat(tlsContextConfig.getCertAlias()).isNull();
+                assertAll(
+                        () -> assertThat(tlsContextConfig.getProtocol()).isNotNull().isEqualTo(dwTlsConfig.getProtocol()),
+                        () -> assertThat(tlsContextConfig.getKeyStorePath()).isNull(),
+                        () -> assertThat(tlsContextConfig.getKeyStorePassword()).isNull(),
+                        () -> assertThat(tlsContextConfig.getKeyStoreType()).isNotNull().isEqualTo(dwTlsConfig.getKeyStoreType()),
+                        () -> assertThat(tlsContextConfig.getKeyStoreProvider()).isNull(),
+                        () -> assertThat(tlsContextConfig.getTrustStorePath()).isNull(),
+                        () -> assertThat(tlsContextConfig.getTrustStorePassword()).isNull(),
+                        () -> assertThat(tlsContextConfig.getTrustStoreType()).isNotNull().isEqualTo(dwTlsConfig.getTrustStoreType()),
+                        () -> assertThat(tlsContextConfig.getTrustStoreProvider()).isNull(),
+                        () -> assertThat(tlsContextConfig.isTrustSelfSignedCertificates()).isFalse(),
+                        () -> assertThat(tlsContextConfig.isVerifyHostname()).isTrue(),
+                        () -> assertThat(tlsContextConfig.isDisableSniHostCheck()).isFalse(),
+                        () -> assertThat(tlsContextConfig.getSupportedProtocols()).isNull(),
+                        () -> assertThat(tlsContextConfig.getSupportedCiphers()).isNull(),
+                        () -> assertThat(tlsContextConfig.getCertAlias()).isNull()
+                );
             }
 
             @Test
             void shouldReturnTlsContextConfiguration() {
                 var tlsContextConfig = TlsContextConfiguration.fromDropwizardTlsConfiguration(dwTlsConfig);
 
-                assertThat(tlsContextConfig.getProtocol()).isEqualTo("TLSv1.3");
-                assertThat(tlsContextConfig.getProvider()).isEqualTo("BC");
-                assertThat(tlsContextConfig.getKeyStorePath()).isEqualTo("/pki/test.ks");
-                assertThat(tlsContextConfig.getKeyStorePassword()).isEqualTo("ks-pass");
-                assertThat(tlsContextConfig.getKeyStoreType()).isEqualTo("PKCS12");
-                assertThat(tlsContextConfig.getKeyStoreProvider()).isEqualTo("BC");
-                assertThat(tlsContextConfig.getTrustStorePath()).isEqualTo("/pki/test.ts");
-                assertThat(tlsContextConfig.getTrustStorePassword()).isEqualTo("ts-pass");
-                assertThat(tlsContextConfig.getTrustStoreType()).isEqualTo("PKCS12");
-                assertThat(tlsContextConfig.getTrustStoreProvider()).isEqualTo("BC");
-                assertThat(tlsContextConfig.isTrustSelfSignedCertificates()).isTrue();
-                assertThat(tlsContextConfig.isVerifyHostname()).isFalse();
-                assertThat(tlsContextConfig.getSupportedProtocols()).containsOnly("TLSv1.3");
-                assertThat(tlsContextConfig.getSupportedCiphers()).containsOnly("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256");
-                assertThat(tlsContextConfig.getCertAlias()).isEqualTo("cert42");
+                assertAll(
+                        () -> assertThat(tlsContextConfig.getProtocol()).isEqualTo("TLSv1.3"),
+                        () -> assertThat(tlsContextConfig.getProvider()).isEqualTo("BC"),
+                        () -> assertThat(tlsContextConfig.getKeyStorePath()).isEqualTo("/pki/test.ks"),
+                        () -> assertThat(tlsContextConfig.getKeyStorePassword()).isEqualTo("ks-pass"),
+                        () -> assertThat(tlsContextConfig.getKeyStoreType()).isEqualTo("PKCS12"),
+                        () -> assertThat(tlsContextConfig.getKeyStoreProvider()).isEqualTo("BC"),
+                        () -> assertThat(tlsContextConfig.getTrustStorePath()).isEqualTo("/pki/test.ts"),
+                        () -> assertThat(tlsContextConfig.getTrustStorePassword()).isEqualTo("ts-pass"),
+                        () -> assertThat(tlsContextConfig.getTrustStoreType()).isEqualTo("PKCS12"),
+                        () -> assertThat(tlsContextConfig.getTrustStoreProvider()).isEqualTo("BC"),
+                        () -> assertThat(tlsContextConfig.isTrustSelfSignedCertificates()).isTrue(),
+                        () -> assertThat(tlsContextConfig.isVerifyHostname()).isFalse(),
+                        () -> assertThat(tlsContextConfig.isDisableSniHostCheck()).isFalse(),
+                        () -> assertThat(tlsContextConfig.getSupportedProtocols()).containsOnly("TLSv1.3"),
+                        () -> assertThat(tlsContextConfig.getSupportedCiphers()).containsOnly("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"),
+                        () -> assertThat(tlsContextConfig.getCertAlias()).isEqualTo("cert42")
+                );
             }
 
             @Test
@@ -381,21 +402,25 @@ class TlsContextConfigurationTest {
             void shouldReturnTlsConfiguration() {
                 var dwTlsConfig = tlsConfig.toDropwizardTlsConfiguration();
 
-                assertThat(dwTlsConfig.getProtocol()).isEqualTo(protocol);
-                assertThat(dwTlsConfig.getProvider()).isEqualTo("BC");
-                assertThat(dwTlsConfig.getKeyStorePath().getAbsolutePath()).isEqualTo(path);
-                assertThat(dwTlsConfig.getKeyStorePassword()).isEqualTo(password);
-                assertThat(dwTlsConfig.getKeyStoreType()).isEqualTo(type);
-                assertThat(dwTlsConfig.getKeyStoreProvider()).isEqualTo("BC");
-                assertThat(dwTlsConfig.getTrustStorePath().getAbsolutePath()).isEqualTo(path);
-                assertThat(dwTlsConfig.getTrustStorePassword()).isEqualTo(password);
-                assertThat(dwTlsConfig.getTrustStoreType()).isEqualTo(type);
-                assertThat(dwTlsConfig.getTrustStoreProvider()).isEqualTo("BC");
-                assertThat(dwTlsConfig.isTrustSelfSignedCertificates()).isTrue();
-                assertThat(dwTlsConfig.isVerifyHostname()).isFalse();
-                assertThat(dwTlsConfig.getSupportedProtocols()).containsOnly("TLSv1.3");
-                assertThat(dwTlsConfig.getSupportedCiphers()).containsOnly("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256");
-                assertThat(dwTlsConfig.getCertAlias()).isEqualTo("cert84");
+                // Note: Dropwizard TlsConfiguration does not contain disableSniHostCheck, so we cannot check it
+                
+                assertAll(
+                        () -> assertThat(dwTlsConfig.getProtocol()).isEqualTo(protocol),
+                        () -> assertThat(dwTlsConfig.getProvider()).isEqualTo("BC"),
+                        () -> assertThat(dwTlsConfig.getKeyStorePath().getAbsolutePath()).isEqualTo(path),
+                        () -> assertThat(dwTlsConfig.getKeyStorePassword()).isEqualTo(password),
+                        () -> assertThat(dwTlsConfig.getKeyStoreType()).isEqualTo(type),
+                        () -> assertThat(dwTlsConfig.getKeyStoreProvider()).isEqualTo("BC"),
+                        () -> assertThat(dwTlsConfig.getTrustStorePath().getAbsolutePath()).isEqualTo(path),
+                        () -> assertThat(dwTlsConfig.getTrustStorePassword()).isEqualTo(password),
+                        () -> assertThat(dwTlsConfig.getTrustStoreType()).isEqualTo(type),
+                        () -> assertThat(dwTlsConfig.getTrustStoreProvider()).isEqualTo("BC"),
+                        () -> assertThat(dwTlsConfig.isTrustSelfSignedCertificates()).isTrue(),
+                        () -> assertThat(dwTlsConfig.isVerifyHostname()).isFalse(),
+                        () -> assertThat(dwTlsConfig.getSupportedProtocols()).containsOnly("TLSv1.3"),
+                        () -> assertThat(dwTlsConfig.getSupportedCiphers()).containsOnly("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"),
+                        () -> assertThat(dwTlsConfig.getCertAlias()).isEqualTo("cert84")
+                );
             }
 
             @SuppressWarnings("DataFlowIssue")  // b/c IntelliJ sees Dropwizard [key|trust]StorePath are @Nullable
@@ -409,14 +434,16 @@ class TlsContextConfigurationTest {
 
                 var dwTlsConfig = tlsConfig.toDropwizardTlsConfiguration();
 
-                assertThat(dwTlsConfig.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value);
-                assertThat(dwTlsConfig.getKeyStorePath()).isNull();
-                assertThat(dwTlsConfig.getKeyStorePassword()).isNull();
-                assertThat(dwTlsConfig.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value);
-                assertThat(dwTlsConfig.getTrustStorePath().getAbsolutePath()).isEqualTo("/data/pki/trust-store.pkcs12");
-                assertThat(dwTlsConfig.getTrustStorePassword()).isEqualTo("mySuperSecretTsPassword");
-                assertThat(dwTlsConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value);
-                assertThat(dwTlsConfig.isVerifyHostname()).isTrue();
+                assertAll(
+                        () -> assertThat(dwTlsConfig.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_2.value),
+                        () -> assertThat(dwTlsConfig.getKeyStorePath()).isNull(),
+                        () -> assertThat(dwTlsConfig.getKeyStorePassword()).isNull(),
+                        () -> assertThat(dwTlsConfig.getKeyStoreType()).isEqualTo(KeyStoreType.JKS.value),
+                        () -> assertThat(dwTlsConfig.getTrustStorePath().getAbsolutePath()).isEqualTo("/data/pki/trust-store.pkcs12"),
+                        () -> assertThat(dwTlsConfig.getTrustStorePassword()).isEqualTo("mySuperSecretTsPassword"),
+                        () -> assertThat(dwTlsConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value),
+                        () -> assertThat(dwTlsConfig.isVerifyHostname()).isTrue()
+                );
             }
         }
 
@@ -428,6 +455,7 @@ class TlsContextConfigurationTest {
                 var tlsContextConfig = TlsContextConfiguration.builder()
                         .protocol(SSLContextProtocol.TLS_1_3.value)
                         .verifyHostname(false)
+                        .disableSniHostCheck(true)
                         .keyStorePath("/data/pki/key-store.pkcs12")
                         .keyStorePassword("myKsPassword")
                         .keyStoreType(KeyStoreType.PKCS12.value)
@@ -439,16 +467,17 @@ class TlsContextConfigurationTest {
 
                 var sslConfig = tlsContextConfig.toSslContextConfiguration();
 
-                assertThat(sslConfig.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_3.value);
-                assertThat(sslConfig.isVerifyHostname()).isFalse();
-
-                assertThat(sslConfig.getKeyStorePath()).isEqualTo("/data/pki/key-store.pkcs12");
-                assertThat(sslConfig.getKeyStorePassword()).isEqualTo("myKsPassword");
-                assertThat(sslConfig.getKeyStoreType()).isEqualTo(KeyStoreType.PKCS12.value);
-
-                assertThat(sslConfig.getTrustStorePath()).isEqualTo("/data/pki/trust-store.pkcs12");
-                assertThat(sslConfig.getTrustStorePassword()).isEqualTo("myTsPassword");
-                assertThat(sslConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value);
+                assertAll(
+                        () -> assertThat(sslConfig.getProtocol()).isEqualTo(SSLContextProtocol.TLS_1_3.value),
+                        () -> assertThat(sslConfig.isVerifyHostname()).isFalse(),
+                        () -> assertThat(sslConfig.isDisableSniHostCheck()).isTrue(),
+                        () -> assertThat(sslConfig.getKeyStorePath()).isEqualTo("/data/pki/key-store.pkcs12"),
+                        () -> assertThat(sslConfig.getKeyStorePassword()).isEqualTo("myKsPassword"),
+                        () -> assertThat(sslConfig.getKeyStoreType()).isEqualTo(KeyStoreType.PKCS12.value),
+                        () -> assertThat(sslConfig.getTrustStorePath()).isEqualTo("/data/pki/trust-store.pkcs12"),
+                        () -> assertThat(sslConfig.getTrustStorePassword()).isEqualTo("myTsPassword"),
+                        () -> assertThat(sslConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value)
+                );
             }
 
             @Test

--- a/src/test/resources/TlsContextConfigurationTest/full-tls-config.yml
+++ b/src/test/resources/TlsContextConfigurationTest/full-tls-config.yml
@@ -7,6 +7,7 @@ tlsConfig:
   trustStorePassword: tsPass100
   trustStoreType: PKCS12
   verifyHostname: false
+  disableSniHostCheck: true
   supportedProtocols:
     - TLSv1.2
     - TLSv1.3


### PR DESCRIPTION
* Add disableSniHostCheck to TlsContextConfiguration, SSLContextConfiguration, and SimpleSSLContextFactory
* Update SSLContextConfiguration#toSimpleSSLContextFactory factory method to provide disableSniHostCheck to SimpleSSLContextFactory
* Update SSLContextConfiguration#toTlsContextConfiguration factory method to provide disableSniHostCheck to TlsContextConfiguration
* Update javadoc of the conversion functions in TlsContextConfiguration to explain how disableSniHostCheck is handled (since it does not exist in Dropwizard TlsConfiguration)
* Update TlsContextConfiguration#toSslContextConfiguration to provide disableSniHostCheck to SSLContextConfiguration
* Add new all-args constructor to SimpleSSLContextFactory
* Clean up duplicative code in SimpleSSLContextFactory by extracting several private helper methods
* Change SimpleSSLContextFactory#configuration method to be public, and to return unmodifiable map.
* Change tests with lots of assertions to use assertAll
* Minor grammatical fixes in javadocs and comments

Closes #1080
Closes #1085