### PR TITLE
Use strip instead of trim in KiwiUrls#stripTrailingSlash

### DIFF
--- a/src/main/java/org/kiwiproject/net/KiwiUrls.java
+++ b/src/main/java/org/kiwiproject/net/KiwiUrls.java
@@ -389,7 +389,7 @@ public class KiwiUrls {
      * @return the URL minus any trailing slash
      */
     public static String stripTrailingSlash(String url) {
-        var trimmedUrl = url.trim();
+        var trimmedUrl = url.strip();
 
         if (trimmedUrl.endsWith("/")) {
             return trimmedUrl.substring(0, trimmedUrl.length() - 1);


### PR DESCRIPTION
Strip was introduced in JDK 11 and is more generic and handles white space better than trim, i.e., more generically.