### PR TITLE
Deprecate custom Hibernate array UserTypes

### DIFF
--- a/src/main/java/org/kiwiproject/hibernate/usertype/AbstractArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/AbstractArrayUserType.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 /**
  * Abstract base class for custom Hibernate user-defined array types.
  *
+ * @deprecated Replaced by native arrary support in Hibernate
  * @implNote Suppress Sonar "'throws' declarations should not be superfluous" warning since the signatures
  * come directly from UserType, and we are just preserving them.
  */

--- a/src/main/java/org/kiwiproject/hibernate/usertype/AbstractArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/AbstractArrayUserType.java
@@ -6,6 +6,8 @@ import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.usertype.UserType;
+import org.kiwiproject.base.KiwiDeprecated;
+import org.kiwiproject.base.KiwiDeprecated.Severity;
 
 import java.io.Serializable;
 import java.sql.PreparedStatement;
@@ -21,6 +23,11 @@ import java.util.Arrays;
  * come directly from UserType, and we are just preserving them.
  */
 @SuppressWarnings("java:S1130")
+@Deprecated(since = "3.4.0", forRemoval = true)
+@KiwiDeprecated(removeAt = "4.0.0",
+                replacedBy = "Native array support in Hibernate",
+                usageSeverity = Severity.SEVERE,
+                reference = "https://github.com/kiwiproject/kiwi/issues/1117")
 public abstract class AbstractArrayUserType<T> implements UserType<T> {
 
     private static final int[] SQL_TYPES = {Types.ARRAY};

--- a/src/main/java/org/kiwiproject/hibernate/usertype/BigintArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/BigintArrayUserType.java
@@ -1,9 +1,17 @@
 package org.kiwiproject.hibernate.usertype;
 
+import org.kiwiproject.base.KiwiDeprecated;
+import org.kiwiproject.base.KiwiDeprecated.Severity;
+
 /**
  * A Hibernate user-defined type that maps to/from (Postgres) array column of type {@code BIGINT} mapping to the
  * Java type {@code Long[]}.
  */
+@Deprecated(since = "3.4.0", forRemoval = true)
+@KiwiDeprecated(removeAt = "4.0.0",
+                replacedBy = "Native array support in Hibernate",
+                usageSeverity = Severity.SEVERE,
+                reference = "https://github.com/kiwiproject/kiwi/issues/1117")
 public class BigintArrayUserType extends AbstractArrayUserType<Long[]> {
 
     /**

--- a/src/main/java/org/kiwiproject/hibernate/usertype/BigintArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/BigintArrayUserType.java
@@ -6,6 +6,8 @@ import org.kiwiproject.base.KiwiDeprecated.Severity;
 /**
  * A Hibernate user-defined type that maps to/from (Postgres) array column of type {@code BIGINT} mapping to the
  * Java type {@code Long[]}.
+ *
+ * @deprecated Replaced by native arrary support in Hibernate
  */
 @Deprecated(since = "3.4.0", forRemoval = true)
 @KiwiDeprecated(removeAt = "4.0.0",

--- a/src/main/java/org/kiwiproject/hibernate/usertype/TextArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/TextArrayUserType.java
@@ -6,6 +6,8 @@ import org.kiwiproject.base.KiwiDeprecated.Severity;
 /**
  * A Hibernate user-defined type that maps to/from (Postgres) array column of a text type, e.g. {@code TEXT[]}
  * or {@code VARCHAR[]}, mapping to the Java type {@code String[]}.
+ *
+ * @deprecated Replaced by native arrary support in Hibernate
  */
 @Deprecated(since = "3.4.0", forRemoval = true)
 @KiwiDeprecated(removeAt = "4.0.0",

--- a/src/main/java/org/kiwiproject/hibernate/usertype/TextArrayUserType.java
+++ b/src/main/java/org/kiwiproject/hibernate/usertype/TextArrayUserType.java
@@ -1,9 +1,17 @@
 package org.kiwiproject.hibernate.usertype;
 
+import org.kiwiproject.base.KiwiDeprecated;
+import org.kiwiproject.base.KiwiDeprecated.Severity;
+
 /**
  * A Hibernate user-defined type that maps to/from (Postgres) array column of a text type, e.g. {@code TEXT[]}
  * or {@code VARCHAR[]}, mapping to the Java type {@code String[]}.
  */
+@Deprecated(since = "3.4.0", forRemoval = true)
+@KiwiDeprecated(removeAt = "4.0.0",
+                replacedBy = "Native array support in Hibernate",
+                usageSeverity = Severity.SEVERE,
+                reference = "https://github.com/kiwiproject/kiwi/issues/1117")
 public class TextArrayUserType extends AbstractArrayUserType<String[]> {
 
     /**

--- a/src/test/java/org/kiwiproject/hibernate/usertype/ArrayUserTypesUnitTest.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/ArrayUserTypesUnitTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.Serializable;
 
 @DisplayName("ArrayUserTypes (Unit)")
+@SuppressWarnings({"deprecation", "removal"})
 class ArrayUserTypesUnitTest {
 
     private AbstractArrayUserType<String[]> arrayUserType;

--- a/src/test/java/org/kiwiproject/hibernate/usertype/SampleEntity.java
+++ b/src/test/java/org/kiwiproject/hibernate/usertype/SampleEntity.java
@@ -14,7 +14,7 @@ import org.hibernate.annotations.Type;
 @Table(name = "sample_entity")
 @Getter
 @Setter
-@SuppressWarnings("JpaDataSourceORMInspection")
+@SuppressWarnings({"JpaDataSourceORMInspection", "removal"})
 class SampleEntity implements IdentifiableEntity {
 
     @Id


### PR DESCRIPTION
* Deprecate AbstractArrayUserType, BigintArrayUserType, and TextArrayUserType for removal
* Suppress the removal warnings in test code

Closes #1117