### PR TITLE
Use SuppressWarnings for unchecked conversion warnings

### DIFF
--- a/src/main/java/org/kiwiproject/json/JsonHelper.java
+++ b/src/main/java/org/kiwiproject/json/JsonHelper.java
@@ -339,6 +339,7 @@ public class JsonHelper {
      * @param <T>         the object type
      * @return a new instance of the given type, or {@code null} if the given input JSON is blank
      */
+    @SuppressWarnings("unchecked")
     public <T> T toObject(@Nullable String json, Class<T> targetClass) {
         if (isBlank(json)) {
             return null;
@@ -350,7 +351,6 @@ public class JsonHelper {
             if (nonNull(e.getTargetType())
                     && isNullOrEmpty(e.getPath())
                     && e.getTargetType().isAssignableFrom(String.class)) {
-                //noinspection unchecked
                 return (T) json;
             } else {
                 throw new RuntimeJsonException(e);
@@ -581,13 +581,13 @@ public class JsonHelper {
      * @return a new instance of the target type
      * @see ObjectMapper#convertValue(Object, Class)
      */
+    @SuppressWarnings("unchecked")
     public <T> T convert(Object fromObject, Class<T> targetType) {
         if (isNull(fromObject)) {
             return null;
         }
 
         if (targetType.isAssignableFrom(String.class)) {
-            //noinspection unchecked
             return (T) toJson(fromObject);
         }
 
@@ -947,6 +947,7 @@ public class JsonHelper {
      * @return a new instance of type T
      * @see MergeOption
      */
+    @SuppressWarnings("unchecked")
     public <T> T mergeObjects(T originalObject, Object updateObject, MergeOption... mergeOptions) {
         var originalObjJson = toJson(originalObject);
         var updateObjJson = toJson(updateObject);
@@ -956,7 +957,6 @@ public class JsonHelper {
 
         JsonNode updatedNode = mergeNodes(originalNode, updateNode, mergeOptions);
 
-        //noinspection unchecked
         return (T) toObject(updatedNode.toString(), originalObject.getClass());
     }
 

--- a/src/main/java/org/kiwiproject/validation/InternalKiwiValidators.java
+++ b/src/main/java/org/kiwiproject/validation/InternalKiwiValidators.java
@@ -54,6 +54,7 @@ class InternalKiwiValidators {
      * it becomes unreadable. Interestingly, neither IntelliJ not Sonar is complaining...maybe we don't have the
      * appropriate rules enabled. Suggestions for improvement welcome!
      */
+    @SuppressWarnings("unchecked")
     static <T> Comparable<T> toComparableOrNull(String compareValue, Comparable<T> value) {
         if (isBlank(compareValue) || isNull(value)) {
             return null;
@@ -88,7 +89,6 @@ class InternalKiwiValidators {
             throw new IllegalArgumentException(message);
         }
 
-        //noinspection unchecked
         return (Comparable<T>) typedValue;
     }
 

--- a/src/main/java/org/kiwiproject/validation/RangeValidator.java
+++ b/src/main/java/org/kiwiproject/validation/RangeValidator.java
@@ -56,6 +56,7 @@ public class RangeValidator implements ConstraintValidator<Range, Object> {
         return isNotBlank(constraintAnnotation.min()) || isNotBlank(constraintAnnotation.max());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public boolean isValid(Object value, ConstraintValidatorContext context) {
         Validity validity;
@@ -63,7 +64,6 @@ public class RangeValidator implements ConstraintValidator<Range, Object> {
             validity = checkNull(value, context);
 
             if (validity == Validity.CONTINUE) {
-                // noinspection unchecked
                 validity = checkMinMax((Comparable<Object>) value, context);
             }
         } catch (Exception e) {

--- a/src/test/java/org/kiwiproject/jaxrs/JaxrsTestHelper.java
+++ b/src/test/java/org/kiwiproject/jaxrs/JaxrsTestHelper.java
@@ -105,11 +105,11 @@ public class JaxrsTestHelper {
         );
     }
 
+    @SuppressWarnings("unchecked")
     public static Map<String, Object> assertHasMapEntity(Response response) {
         var entityObj = response.getEntity();
         assertThat(entityObj).isInstanceOf(Map.class);
 
-        //noinspection unchecked
         return (Map<String, Object>) entityObj;
     }
 }

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
@@ -448,6 +448,7 @@ class KiwiResourcesTest {
             assertThat(mapEntity).isEqualTo(FromResponseTestResource.ENTITY);
         }
 
+        @SuppressWarnings("resource")
         @Test
         void shouldThrowIllegalStateException_WhenEntityAlreadyConsumed() {
             var originalResponse = RESOURCES.client().target("/from-response/with-entity").request().get();

--- a/src/test/java/org/kiwiproject/jaxrs/exception/ConstraintViolationExceptionMapperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/exception/ConstraintViolationExceptionMapperTest.java
@@ -67,7 +67,7 @@ class ConstraintViolationExceptionMapperTest {
             var entity = assertHasMapEntity(response);
             assertThat(entity).containsOnlyKeys("errors");
 
-            //noinspection unchecked
+            @SuppressWarnings("unchecked")
             var errors = (List<ErrorMessage>) entity.get("errors");
 
             assertThat(errors).containsExactlyInAnyOrder(
@@ -98,7 +98,7 @@ class ConstraintViolationExceptionMapperTest {
             var entity = assertHasMapEntity(response);
             assertThat(entity).containsOnlyKeys("errors");
 
-            //noinspection unchecked
+            @SuppressWarnings("unchecked")
             var errors = (List<ErrorMessage>) entity.get("errors");
             assertThat(errors).hasSameSizeAs(violations);
         }


### PR DESCRIPTION
Switch to generic SuppressWarnings instead of IntelliJ-specific comment for unchecked warnings. This will minimize errors shown in both IntellIJ and VSCode