### PR TITLE
Fix javadoc in IllegalStateExceptionMapper

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/exception/IllegalStateExceptionMapper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/exception/IllegalStateExceptionMapper.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.ext.Provider;
 /**
  * Map {@link IllegalStateException} to {@link Response}.
  * <p>
- * The mapped response has status code 500 (Bad Request) and media type JSON.
+ * The mapped response has status code 500 (Internal Server Error) and media type JSON.
  */
 @Provider
 public class IllegalStateExceptionMapper implements ExceptionMapper<IllegalStateException> {


### PR DESCRIPTION
The javadoc has the wrong reason for a 500 status code.