### PR TITLE
Add more methods to check HTTP status codes in KiwiHttpResponses

### DIFF
--- a/src/main/java/org/kiwiproject/net/KiwiHttpResponses.java
+++ b/src/main/java/org/kiwiproject/net/KiwiHttpResponses.java
@@ -136,6 +136,26 @@ public class KiwiHttpResponses {
     }
 
     /**
+     * Check if the given status code is 205 Reset Content.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 205, otherwise false
+     */
+    public static boolean resetContent(int statusCode) {
+        return statusCode == 205;
+    }
+
+    /**
+     * Check if the given status code is 206 Partial Content.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 206, otherwise false
+     */
+    public static boolean partialContent(int statusCode) {
+        return statusCode == 206;
+    }
+
+    /**
      * Check if the given status code is 301 Moved Permanently.
      *
      * @param statusCode the status code to check
@@ -156,6 +176,16 @@ public class KiwiHttpResponses {
     }
 
     /**
+     * Check if the given status code is 303 See Other.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 303, otherwise false
+     */
+    public static boolean seeOther(int statusCode) {
+        return statusCode == 303;
+    }
+
+    /**
      * Check if the given status code is 304 Not Modified.
      *
      * @param statusCode the status code to check
@@ -163,6 +193,16 @@ public class KiwiHttpResponses {
      */
     public static boolean notModified(int statusCode) {
         return statusCode == 304;
+    }
+
+    /**
+     * Check if the given status code is 307 Temporary Redirect.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 307, otherwise false
+     */
+    public static boolean temporaryRedirect(int statusCode) {
+        return statusCode == 307;
     }
 
     /**
@@ -226,6 +266,26 @@ public class KiwiHttpResponses {
     }
 
     /**
+     * Check if the given status code is 407 Proxy Authentication Required.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 407, otherwise false
+     */
+    public static boolean proxyAuthenticationRequired(int statusCode) {
+        return statusCode == 407;
+    }
+
+    /**
+     * Check if the given status code is 408 Request Timeout.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 408, otherwise false
+     */
+    public static boolean requestTimeout(int statusCode) {
+        return statusCode == 408;
+    }
+
+    /**
      * Check if the given status code is 409 Conflict.
      *
      * @param statusCode the status code to check
@@ -236,6 +296,149 @@ public class KiwiHttpResponses {
     }
 
     /**
+     * Check if the given status code is 410 Gone.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 410, otherwise false
+     */
+    public static boolean gone(int statusCode) {
+        return statusCode == 410;
+    }
+
+    /**
+     * Check if the given status code is 411 Length Required.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 411, otherwise false
+     */
+    public static boolean lengthRequired(int statusCode) {
+        return statusCode == 411;
+    }
+
+    /**
+     * Check if the given status code is 412 Precondition Failed.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 412, otherwise false
+     */
+    public static boolean preconditionFailed(int statusCode) {
+        return statusCode == 412;
+    }
+
+    /**
+     * Check if the given status code is 413 Request Entity Too Large.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 413, otherwise false
+     */
+    public static boolean requestEntityTooLarge(int statusCode) {
+        return statusCode == 413;
+    }
+
+    /**
+     * Check if the given status code is 414 Request-URI Too Long.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 414, otherwise false
+     */
+    public static boolean requestUriTooLong(int statusCode) {
+        return statusCode == 414;
+    }
+
+    /**
+     * Check if the given status code is 415 Unsupported Media Type.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 415, otherwise false
+     */
+    public static boolean unsupportedMediaType(int statusCode) {
+        return statusCode == 415;
+    }
+
+    /**
+     * Check if the given status code is 416 Requested Range Not Satisfiable.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 416, otherwise false
+     */
+    public static boolean requestedRangeNotSatisfiable(int statusCode) {
+        return statusCode == 416;
+    }
+
+    /**
+     * Check if the given status code is 417 Expectation Failed.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 417, otherwise false
+     */
+    public static boolean expectationFailed(int statusCode) {
+        return statusCode == 417;
+    }
+
+    /**
+     * Check if the given status code is 418 I'm a teapot.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 418, otherwise false
+     */
+    public static boolean iAmATeapot(int statusCode) {
+        return statusCode == 418;
+    }
+
+    /**
+     * Check if the given status code is 422 Unprocessable Content.
+     * <p>
+     * This is technically a WebDAV code, but is used by many web
+     * frameworks to indicate an input validation failure.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 422, otherwise false
+     */
+    public static boolean unprocessableContent(int statusCode) {
+        return statusCode == 422;
+    }
+
+    /**
+     * Check if the given status code is 426 Upgrade Required.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 426, otherwise false
+     */
+    public static boolean upgradeRequired(int statusCode) {
+        return statusCode == 426;
+    }
+
+    /**
+     * Check if the given status code is 428 Precondition Required.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 428, otherwise false
+     */
+    public static boolean preconditionRequired(int statusCode) {
+        return statusCode == 428;
+    }
+
+    /**
+     * Check if the given status code is 429 Too Many Requests.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 429, otherwise false
+     */
+    public static boolean tooManyRequests(int statusCode) {
+        return statusCode == 429;
+    }
+
+    /**
+     * Check if the given status code is 431 Request Header Fields Too Large.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 431, otherwise false
+     */
+    public static boolean requestHeaderFieldsTooLarge(int statusCode) {
+        return statusCode == 431;
+    }
+
+    /**
      * Check if the given status code is 500 Internal Server Error.
      *
      * @param statusCode the status code to check
@@ -243,6 +446,16 @@ public class KiwiHttpResponses {
      */
     public static boolean internalServerError(int statusCode) {
         return statusCode == 500;
+    }
+
+     /**
+     * Check if the given status code is 501 Not Implemented.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 501, otherwise false
+     */
+    public static boolean notImplemented(int statusCode) {
+        return statusCode == 501;
     }
 
     /**
@@ -263,5 +476,35 @@ public class KiwiHttpResponses {
      */
     public static boolean serviceUnavailable(int statusCode) {
         return statusCode == 503;
+    }
+
+    /**
+     * Check if the given status code is 504 Gateway Timeout.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 504, otherwise false
+     */
+    public static boolean gatewayTimeout(int statusCode) {
+        return statusCode == 504;
+    }
+
+    /**
+     * Check if the given status code is 505 HTTP Version Not Supported.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 505, otherwise false
+     */
+    public static boolean httpVersionNotSupported(int statusCode) {
+        return statusCode == 505;
+    }
+
+    /**
+     * Check if the given status code is 511 Network Authentication Required.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 511, otherwise false
+     */
+    public static boolean networkAuthenticationRequired(int statusCode) {
+        return statusCode == 511;
     }
 }

--- a/src/test/java/org/kiwiproject/net/KiwiHttpResponsesTest.java
+++ b/src/test/java/org/kiwiproject/net/KiwiHttpResponsesTest.java
@@ -48,14 +48,26 @@ class KiwiHttpResponsesTest {
             () -> assertThat(KiwiHttpResponses.noContent(statusCode))
                     .isEqualTo(statusCode == 204),
 
+            () -> assertThat(KiwiHttpResponses.resetContent(statusCode))
+                    .isEqualTo(statusCode == 205),
+
+            () -> assertThat(KiwiHttpResponses.partialContent(statusCode))
+                    .isEqualTo(statusCode == 206),
+
             () -> assertThat(KiwiHttpResponses.movedPermanently(statusCode))
                     .isEqualTo(statusCode == 301),
 
             () -> assertThat(KiwiHttpResponses.found(statusCode))
                     .isEqualTo(statusCode == 302),
 
+            () -> assertThat(KiwiHttpResponses.seeOther(statusCode))
+                    .isEqualTo(statusCode == 303),
+
             () -> assertThat(KiwiHttpResponses.notModified(statusCode))
                     .isEqualTo(statusCode == 304),
+
+            () -> assertThat(KiwiHttpResponses.temporaryRedirect(statusCode))
+                    .isEqualTo(statusCode == 307),
 
             () -> assertThat(KiwiHttpResponses.badRequest(statusCode))
                     .isEqualTo(statusCode == 400),
@@ -75,17 +87,77 @@ class KiwiHttpResponsesTest {
             () -> assertThat(KiwiHttpResponses.notAcceptable(statusCode))
                     .isEqualTo(statusCode == 406),
 
+            () -> assertThat(KiwiHttpResponses.proxyAuthenticationRequired(statusCode))
+                    .isEqualTo(statusCode == 407),
+
+            () -> assertThat(KiwiHttpResponses.requestTimeout(statusCode))
+                    .isEqualTo(statusCode == 408),
+
             () -> assertThat(KiwiHttpResponses.conflict(statusCode))
                     .isEqualTo(statusCode == 409),
 
+            () -> assertThat(KiwiHttpResponses.gone(statusCode))
+                    .isEqualTo(statusCode == 410),
+
+            () -> assertThat(KiwiHttpResponses.lengthRequired(statusCode))
+                    .isEqualTo(statusCode == 411),
+
+            () -> assertThat(KiwiHttpResponses.preconditionFailed(statusCode))
+                    .isEqualTo(statusCode == 412),
+
+            () -> assertThat(KiwiHttpResponses.requestEntityTooLarge(statusCode))
+                    .isEqualTo(statusCode == 413),
+
+            () -> assertThat(KiwiHttpResponses.requestUriTooLong(statusCode))
+                    .isEqualTo(statusCode == 414),
+
+            () -> assertThat(KiwiHttpResponses.unsupportedMediaType(statusCode))
+                    .isEqualTo(statusCode == 415),
+
+            () -> assertThat(KiwiHttpResponses.requestedRangeNotSatisfiable(statusCode))
+                    .isEqualTo(statusCode == 416),
+
+            () -> assertThat(KiwiHttpResponses.expectationFailed(statusCode))
+                    .isEqualTo(statusCode == 417),
+
+            () -> assertThat(KiwiHttpResponses.iAmATeapot(statusCode))
+                    .isEqualTo(statusCode == 418),
+
+            () -> assertThat(KiwiHttpResponses.unprocessableContent(statusCode))
+                    .isEqualTo(statusCode == 422),
+
+            () -> assertThat(KiwiHttpResponses.upgradeRequired(statusCode))
+                    .isEqualTo(statusCode == 426),
+
+            () -> assertThat(KiwiHttpResponses.preconditionRequired(statusCode))
+                    .isEqualTo(statusCode == 428),
+
+            () -> assertThat(KiwiHttpResponses.tooManyRequests(statusCode))
+                    .isEqualTo(statusCode == 429),
+
+            () -> assertThat(KiwiHttpResponses.requestHeaderFieldsTooLarge(statusCode))
+                    .isEqualTo(statusCode == 431),
+
             () -> assertThat(KiwiHttpResponses.internalServerError(statusCode))
                     .isEqualTo(statusCode == 500),
+
+            () -> assertThat(KiwiHttpResponses.notImplemented(statusCode))
+                    .isEqualTo(statusCode == 501),
 
             () -> assertThat(KiwiHttpResponses.badGateway(statusCode))
                     .isEqualTo(statusCode == 502),
 
             () -> assertThat(KiwiHttpResponses.serviceUnavailable(statusCode))
-                    .isEqualTo(statusCode == 503)
+                    .isEqualTo(statusCode == 503),
+
+            () -> assertThat(KiwiHttpResponses.gatewayTimeout(statusCode))
+                    .isEqualTo(statusCode == 504),
+
+            () -> assertThat(KiwiHttpResponses.httpVersionNotSupported(statusCode))
+                    .isEqualTo(statusCode == 505),
+
+            () -> assertThat(KiwiHttpResponses.networkAuthenticationRequired(statusCode))
+                    .isEqualTo(statusCode == 511)
         );
     }
 


### PR DESCRIPTION
Adds a bunch more methods to KiwiHttpResponses to check whether a status code is a specific type, for example gatewayTimeout checks if the status code is 504.