### PR TITLE
Add methods to check 308 and 402 status codes

### DIFF
--- a/src/main/java/org/kiwiproject/net/KiwiHttpResponses.java
+++ b/src/main/java/org/kiwiproject/net/KiwiHttpResponses.java
@@ -206,6 +206,16 @@ public class KiwiHttpResponses {
     }
 
     /**
+     * Check if the given status code is 308 Permanent Redirect.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 308, otherwise false
+     */
+    public static boolean permanentRedirect(int statusCode) {
+        return statusCode == 308;
+    }
+
+    /**
      * Check if the given status code is 400 Bad Request.
      *
      * @param statusCode the status code to check
@@ -223,6 +233,16 @@ public class KiwiHttpResponses {
      */
     public static boolean unauthorized(int statusCode) {
         return statusCode == 401;
+    }
+
+    /**
+     * Check if the given status code is 402 Payment Required.
+     *
+     * @param statusCode the status code to check
+     * @return true if the status code is 402, otherwise false
+     */
+    public static boolean paymentRequired(int statusCode) {
+        return statusCode == 402;
     }
 
     /**

--- a/src/test/java/org/kiwiproject/net/KiwiHttpResponsesTest.java
+++ b/src/test/java/org/kiwiproject/net/KiwiHttpResponsesTest.java
@@ -69,11 +69,17 @@ class KiwiHttpResponsesTest {
             () -> assertThat(KiwiHttpResponses.temporaryRedirect(statusCode))
                     .isEqualTo(statusCode == 307),
 
+            () -> assertThat(KiwiHttpResponses.permanentRedirect(statusCode))
+                    .isEqualTo(statusCode == 308),
+
             () -> assertThat(KiwiHttpResponses.badRequest(statusCode))
                     .isEqualTo(statusCode == 400),
 
             () -> assertThat(KiwiHttpResponses.unauthorized(statusCode))
                     .isEqualTo(statusCode == 401),
+
+            () -> assertThat(KiwiHttpResponses.paymentRequired(statusCode))
+                    .isEqualTo(statusCode == 402),
 
             () -> assertThat(KiwiHttpResponses.forbidden(statusCode))
                     .isEqualTo(statusCode == 403),


### PR DESCRIPTION
Add methods in KiwiHttpResponses to check 308 Permanent Redirect and 402 Payment Required status codes. This class now has methods for all the ones in Jakarta REST's Response.Status enum except the deprecated 305 (Use Proxy). It also contains a method to check 422 (Unprocessable Entity) and the oh-so-important 418 (I'm a teapot). 🤣