### PR TITLE
Cleanup: replace usages of deprecated catchThrowableOfType

### DIFF
--- a/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiResourcesTest.java
@@ -1023,8 +1023,8 @@ class KiwiResourcesTest {
         @NullAndEmptySource
         void shouldThrowBadRequest_WhenListIsNullOrEmpty(List<Object> values) {
             var thrown = catchThrowableOfType(
-                    () -> KiwiResources.assertOneElementOrThrowBadRequest(values, "testParam"),
-                    JaxrsBadRequestException.class);
+                    JaxrsBadRequestException.class,
+                    () -> KiwiResources.assertOneElementOrThrowBadRequest(values, "testParam"));
 
             assertThat(thrown.getMessage()).isEqualTo("testParam has no values, but exactly one was expected");
             assertThat(thrown.getErrors()).hasSize(1);
@@ -1035,8 +1035,8 @@ class KiwiResourcesTest {
             var values = List.of("42", "84");
 
             var thrown = catchThrowableOfType(
-                    () -> KiwiResources.assertOneElementOrThrowBadRequest(values, "testParam"),
-                    JaxrsBadRequestException.class);
+                    JaxrsBadRequestException.class,
+                    () -> KiwiResources.assertOneElementOrThrowBadRequest(values, "testParam"));
 
             assertThat(thrown.getMessage()).isEqualTo("testParam has 2 values, but only one was expected");
             assertThat(thrown.getErrors()).hasSize(1);

--- a/src/test/java/org/kiwiproject/retry/KiwiRetryerTest.java
+++ b/src/test/java/org/kiwiproject/retry/KiwiRetryerTest.java
@@ -226,7 +226,8 @@ class KiwiRetryerTest {
 
             var retryer = KiwiRetryer.<Response>newRetryerWithDefaultExceptions("thisFails");
 
-            var kiwiRetryerException = catchThrowableOfType(() -> retryer.call(callable), KiwiRetryerException.class);
+            var kiwiRetryerException = catchThrowableOfType(KiwiRetryerException.class,
+                    () -> retryer.call(callable));
 
             assertThat(kiwiRetryerException)
                     .hasMessage("KiwiRetryer thisFails failed all 1 attempts. Error: Retrying failed to complete successfully after 1 attempts.");
@@ -374,7 +375,8 @@ class KiwiRetryerTest {
                         .exceptionPredicate(KiwiRetryerPredicates.UNKNOWN_HOST)
                         .build();
 
-                var kiwiRetryerException = catchThrowableOfType(() -> retryer.call(callable), KiwiRetryerException.class);
+                var kiwiRetryerException = catchThrowableOfType(KiwiRetryerException.class,
+                        () -> retryer.call(callable));
 
                 assertThat(kiwiRetryerException)
                         .hasMessage("KiwiRetryer retryOnAllRuntimeExceptionsShouldTakePrecedence failed all 1 attempts." +

--- a/src/test/java/org/kiwiproject/validation/KiwiValidationsTest.java
+++ b/src/test/java/org/kiwiproject/validation/KiwiValidationsTest.java
@@ -159,7 +159,8 @@ class KiwiValidationsTest {
             var contactDetails = new SampleContactDetails("bob@example.org", "");
             var bob = new SamplePerson("Bob", null, null, contactDetails);
 
-            var exception = catchThrowableOfType(() -> KiwiValidations.validateThrowing(bob), ConstraintViolationException.class);
+            var exception = catchThrowableOfType(ConstraintViolationException.class,
+                    () -> KiwiValidations.validateThrowing(bob));
             var violations = exception.getConstraintViolations();
             assertThat(violations)
                     .extracting(v -> v.getPropertyPath().toString())
@@ -186,7 +187,8 @@ class KiwiValidationsTest {
             var contactDetails = new SampleContactDetails("bob@example.org", "");
             var bob = new SamplePerson(null, "S", null, contactDetails);
 
-            var exception = catchThrowableOfType(() -> KiwiValidations.validateThrowing(bob, Default.class, Secret.class), ConstraintViolationException.class);
+            var exception = catchThrowableOfType(ConstraintViolationException.class,
+                    () -> KiwiValidations.validateThrowing(bob, Default.class, Secret.class));
             var violations = exception.getConstraintViolations();
             assertThat(violations)
                     .extracting(v -> v.getPropertyPath().toString())


### PR DESCRIPTION
* Use the catchThrowableOfType that has the Class argument first