### PR TITLE
Sonar: fix modifier order in tests

### DIFF
--- a/src/test/java/org/kiwiproject/reflect/KiwiReflectionTest.java
+++ b/src/test/java/org/kiwiproject/reflect/KiwiReflectionTest.java
@@ -1680,7 +1680,7 @@ class KiwiReflectionTest {
 
     @NoArgsConstructor
     @AllArgsConstructor
-    static abstract class NotQuiteReal {
+    abstract static class NotQuiteReal {
         String value;
     }
 

--- a/src/test/java/org/kiwiproject/retry/KiwiRetryerPredicatesTest.java
+++ b/src/test/java/org/kiwiproject/retry/KiwiRetryerPredicatesTest.java
@@ -83,7 +83,7 @@ class KiwiRetryerPredicatesTest {
      * Base class providing test generation for the Throwable predicates in KiwiRetryerPredicates.
      */
     @DisplayNameGeneration(PredicateDisplayNameGenerator.class)
-    static abstract class AbstractExceptionPredicateTest {
+    abstract static class AbstractExceptionPredicateTest {
 
         /**
          * The predicate to test.


### PR DESCRIPTION
* Fix "Modifiers should be declared in the correct order" in several tests (java:S1124)