### PR TITLE
Add methods to KiwiIO that can "close" any object

### DIFF
--- a/src/main/java/org/kiwiproject/io/KiwiIO.java
+++ b/src/main/java/org/kiwiproject/io/KiwiIO.java
@@ -235,7 +235,7 @@ public class KiwiIO {
             return;
         }
 
-       checkDoesNotContainAnyCloseableResources(objects);
+       checkDoesNotContainAnyCloseableResources(closeMethodName, objects);
 
         Arrays.stream(objects)
             .filter(Objects::nonNull)
@@ -243,15 +243,17 @@ public class KiwiIO {
             .forEach(KiwiIO::closeQuietly);
     }
 
-    private static void checkDoesNotContainAnyCloseableResources(Object... objects) {
+    private static void checkDoesNotContainAnyCloseableResources(String closeMethodName, Object... objects) {
         for (var object : objects) {
-            checkIsNotCloseableResource(object);
+            checkIsNotCloseableResource(closeMethodName, object);
         }
     }
 
-    private static void checkIsNotCloseableResource(Object object) {
-        checkArgument(isNotCloseableResource(object),
-                    "objects should not contain any instances of CloseableResource when a single closeMethodName is specified");
+    private static void checkIsNotCloseableResource(String closeMethodName, Object object) {
+        checkArgument(
+                isNotCloseableResource(object),
+                "objects should not contain any instances of CloseableResource when a single closeMethodName (%s) is specified",
+                closeMethodName);
     }
 
     private static boolean isNotCloseableResource(Object object) {

--- a/src/main/java/org/kiwiproject/io/KiwiIO.java
+++ b/src/main/java/org/kiwiproject/io/KiwiIO.java
@@ -273,7 +273,7 @@ public class KiwiIO {
         }
 
         var objectType = object.getClass();
-        var typeName = object.getClass().getName();
+        var typeName = objectType.getName();
 
         closeMethodNames.stream()
                 .map(methodName -> tryClose(object, objectType, typeName, methodName))

--- a/src/main/java/org/kiwiproject/io/KiwiIO.java
+++ b/src/main/java/org/kiwiproject/io/KiwiIO.java
@@ -226,8 +226,8 @@ public class KiwiIO {
     }
 
     private static CloseableResource asCloseableResource(Object object) {
-        return (object instanceof CloseableResource) ?
-                (CloseableResource) object : new CloseableResource(object, DEFAULT_CLOSE_METHOD_NAMES);
+        return (object instanceof CloseableResource closeableResource) ?
+                closeableResource : new CloseableResource(object, DEFAULT_CLOSE_METHOD_NAMES);
     }
 
     public static void closeObjectsQuietly(String closeMethodName, Object... objects) {


### PR DESCRIPTION
* Add: CloseableResource - a record that describes a resource/object that can be closed.
* Add: List<String> defaultCloseMethodNames - returns a list of default method names we'll try when closing an object.
* Add: void closeObjectQuietly(Object object) - closes any object, including CloseableResource, using default close method names
* Add: void closeObjectQuietly(String closeMethodName, Object object) - closes an object, excluding CloseableResource, using an explicit method name
* Add: void closeObjectsQuietly(Object... objects) - closes one or more objects, including CloseableResource, using default close method names
* Add: void closeObjectsQuietly(String closeMethodName, Object... objects) -  closes one or more objects, excluding CloseableResource, using an explicit method name
* Add: void closeResourceQuietly(CloseableResource closeableResource) - closes an object described by the CloseableResource
* Fix: test involving XMLStreamWriter that should have tested a "clean" close (no exception thrown)
* Enhance tests using mocks by adding verifications

Closes #1162 
Closes #1177