### PR TITLE
Make FileDeleteResult public

### DIFF
--- a/src/main/java/org/kiwiproject/io/TimeBasedDirectoryCleaner.java
+++ b/src/main/java/org/kiwiproject/io/TimeBasedDirectoryCleaner.java
@@ -290,7 +290,6 @@ public class TimeBasedDirectoryCleaner implements Runnable {
         return FileDeleteResult.skipped(absolutePath);
     }
 
-    @VisibleForTesting
     @AllArgsConstructor
     @Getter
     public static class FileDeleteResult {

--- a/src/main/java/org/kiwiproject/io/TimeBasedDirectoryCleaner.java
+++ b/src/main/java/org/kiwiproject/io/TimeBasedDirectoryCleaner.java
@@ -293,7 +293,7 @@ public class TimeBasedDirectoryCleaner implements Runnable {
     @VisibleForTesting
     @AllArgsConstructor
     @Getter
-    static class FileDeleteResult {
+    public static class FileDeleteResult {
 
         private final String absolutePath;
         private final boolean deleteWasAttempted;


### PR DESCRIPTION
IntelliJ code analysis issued the following warning:

Class 'FileDeleteResult' is exposed outside its defined visibility scope

The problem is that DeleteError is already public, and it contains a public factory "of" method that accepts a FileDeleteResult. Therefore, FileDeleteResult should be public.