### PR TITLE
Enhance javadocs for JsonHelper#toJsonIgnoringPaths

### DIFF
--- a/src/main/java/org/kiwiproject/json/JsonHelper.java
+++ b/src/main/java/org/kiwiproject/json/JsonHelper.java
@@ -319,6 +319,11 @@ public class JsonHelper {
 
     /**
      * Convert the given object to JSON, but ignoring (excluding) the given paths.
+     * <p>
+     * Note that if the input object is {@code null}, then the returned value is
+     * the string literal {@code "null"}. The reason is that a {@code null} object
+     * is represented as a {@link NullNode}, and its {@code toString} method returns
+     * the literal {@code "null"}.
      *
      * @param object       the object to convert
      * @param ignoredPaths the paths to ignore/exclude

--- a/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
+++ b/src/test/java/org/kiwiproject/json/JsonHelperBasicsTest.java
@@ -343,6 +343,15 @@ class JsonHelperBasicsTest {
             var workAddress = (Map<String, Object>) sanitizedBob.get("workAddress");
             assertThat(workAddress).doesNotContainKeys("street1", "street2");
         }
+
+        @Test
+        void shouldHandleNullInput_WhenIgnoringPaths() {
+            var json = jsonHelper.toJsonIgnoringPaths(null, "username", "password");
+
+            assertThat(json)
+                    .describedAs("Null input should result in a literal \"null\" String value")
+                    .isEqualTo("null");
+        }
     }
 
     @Nested
@@ -514,6 +523,17 @@ class JsonHelperBasicsTest {
         @ValueSource(strings = {" ", "  ", "\t", " \n "})
         void shouldReturnEmptyOptional_WhenGivenBlankInput(String value) {
             assertThat(jsonHelper.toObjectOptional(value, Person.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnDefaultObject_WhenGivenEmptyJson() {
+            assertThat(jsonHelper.toObjectOptional("{}", Person.class))
+                .describedAs("Return value should be the 'default' object")
+                .contains(new Person(null, null, 0));
+
+            assertThat(jsonHelper.toObjectOptional("{}", User.class))
+                .describedAs("Return value should be the 'default' object")
+                .contains(User.builder().luckyNumbers(null).build());
         }
     }
 


### PR DESCRIPTION
* Add explanation in JsonHelper#toJsonIgnoringPaths javadocs why the literal "null" is returned for a nul input object.
* Add test for the above behavior
* Add additonal test for JsonHelper#toObjectOptional