### PR TITLE
Fix deserialization problems in TlsContextConfiguration

### DIFF
--- a/src/test/java/org/kiwiproject/util/YamlTestHelper.java
+++ b/src/test/java/org/kiwiproject/util/YamlTestHelper.java
@@ -1,5 +1,13 @@
 package org.kiwiproject.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.dropwizard.configuration.ResourceConfigurationSourceProvider;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+import jakarta.validation.Validator;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.internal.Fixtures;
 import org.yaml.snakeyaml.Yaml;
@@ -7,9 +15,43 @@ import org.yaml.snakeyaml.Yaml;
 @UtilityClass
 public class YamlTestHelper {
 
-    public static <T> T loadFromYaml(String filename, Class<T> clazz) {
+    private static final Validator VALIDATOR = Validators.newValidator();
+    private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
+
+    /**
+     * Deserialize YAML using <a href="https://bitbucket.org/snakeyaml/snakeyaml/">SnakeYAML</a>.
+     */
+    public static <T> T loadFromYamlWithSnakeYaml(String filename, Class<T> clazz) {
         var yaml = new Yaml();
         var yamlConfig = Fixtures.fixture(filename);
         return yaml.loadAs(yamlConfig, clazz);
+    }
+
+    /**
+     * Deserialize YAML using the same mechanism <a href="https://www.dropwizard.io/">Dropwizard</a>
+     * uses when starting an application. Under the covers, Dropwizard uses
+     * <a href="https://github.com/FasterXML/jackson-dataformats-text">Jackson</a>.
+     */
+    public static <T> T loadFromYamlWithDropwizard(String filename, Class<T> clazz) {
+        var factory = new YamlConfigurationFactory<T>(clazz, VALIDATOR, OBJECT_MAPPER, "dw");
+        try {
+            return factory.build(new ResourceConfigurationSourceProvider(), filename);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Deserialize YAML using <a href="https://github.com/FasterXML/jackson-dataformats-text">Jackson</a>.
+     */
+    public static <T> T loadFromYamlWithJackson(String filename, Class<T> clazz) {
+        var yamlFactory = new YAMLFactory();
+        var objectMapper = new ObjectMapper(yamlFactory);
+        var yamlConfig = Fixtures.fixture(filename);
+        try {
+            return objectMapper.readValue(yamlConfig, clazz);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/resources/SecureEndpointsConfigurationTest/secure-endpoints-config-minimal.yml
+++ b/src/test/resources/SecureEndpointsConfigurationTest/secure-endpoints-config-minimal.yml
@@ -1,0 +1,28 @@
+secureEndpoints:
+  keyStorePath: /path/to/keystore.jks
+  keyStorePassword: ksPassWd
+  trustStorePath: /path/to/truststore.jks
+  trustStorePassword: tsPass100
+  endpoints:
+    - tag: getUsers
+      scheme: https
+      domain: user.everythingstore.com
+      port: 5678
+      path: /users
+    - tag: getOrders
+      scheme: https
+      domain: order.everythingstore.com
+      port: 7890
+      path: /orders
+    - tag: paymentGatewayValidate
+      scheme: https
+      domain: pay.pal.com
+      path: /validate
+      urlRewriteConfiguration:
+        pathPrefix: /pay-proxy
+    - tag: paymentGatewayCharge
+      scheme: https
+      domain: pay.pal.com
+      path: /charge
+      urlRewriteConfiguration:
+        pathPrefix: /pay-proxy


### PR DESCRIPTION
* Replace Lombok constructor annotations with actual constructors such that the all-args constructor respects the default values.
* Remove the Builder.Default methods since the default values are now handled in the all-args constructor.
* The no-args constructor calls the all-args constructor with all null values so that defaults are in one place (instead of on field declarations and in the all-args constructor).
* The all-args constructor sets the appropriate default values when it does not receive a value for a given field. It also has the ConstructorProperties annotation to help deserializers know how the arguments map to fields.
* Update tests for TlsContextConfiguration and SecureEndpointsConfiguration so that deserialization from YAML is tested for both TlsContextConfiguration and SSLContextConfiguration (SecureEndpointsConfiguration extends it) using SnakeYAML, Jackson, and Dropwizard. Though Dropwizard uses Jackson and should be the same as using "plain Jackson," we want to make 100% sure Dropwizard isn't doing any kind of customization in Jackson that might change how it deserializes the YAML.
* Add new helper methods in YamlTestHelper and rename the existing method so that the method names clearly express how they perform the deserialization, i.e., using SnakeYAML or Jackson.

Closes #1209