### PR TITLE
Deprecations and new methods in KiwiDurationFormatters

### DIFF
--- a/src/main/java/org/kiwiproject/time/KiwiDurationFormatters.java
+++ b/src/main/java/org/kiwiproject/time/KiwiDurationFormatters.java
@@ -2,15 +2,18 @@ package org.kiwiproject.time;
 
 import static java.util.Objects.isNull;
 
+import io.dropwizard.util.Duration;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.time.DurationFormatUtils;
-
-import java.time.Duration;
+import org.kiwiproject.base.KiwiDeprecated;
 
 /**
  * Utilities for formatting durations of various types.
  * <p>
  * See Apache Commons {@link DurationFormatUtils} for even more formatter methods.
+ *
+ * @implNote {@code dropwizard-util} must be a dependency or code using this class won't compile;
+ * this requirement will be necessary until the deprecated methods are removed.
  */
 @UtilityClass
 public class KiwiDurationFormatters {
@@ -20,13 +23,19 @@ public class KiwiDurationFormatters {
     private static final String LITERAL_NULL = "null";
 
     /**
-     * Formats a Java {@link Duration} using English words. Converts the duration to millis and then calls
-     * {@link #formatDurationWords(long)}.
+     * Formats a Java {@link java.time.Duration Duration} using English words.
+     * Converts the duration to millis and then calls {@link #formatDurationWords(long)}.
      *
      * @param duration the Java duration to format
      * @return the duration in words (e.g., 2 hours 5 minutes)
+     * @deprecated for removal; replaced by {@link #formatJavaDurationWords(java.time.Duration)}
      */
-    public static String formatDurationWords(Duration duration) {
+    @Deprecated(since = "4.6.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "formatJavaDurationWords(java.time.Duration duration)",
+            usageSeverity = KiwiDeprecated.Severity.SEVERE,
+            removeAt = "5.0.0")
+    public static String formatDurationWords(java.time.Duration duration) {
         if (isNull(duration)) {
             return LITERAL_NULL;
         }
@@ -35,19 +44,81 @@ public class KiwiDurationFormatters {
     }
 
     /**
-     * Formats a Dropwizard {@link io.dropwizard.util.Duration} using English words. Converts the duration to millis
-     * and then calls {@link #formatDurationWords(long)}.
+     * Formats a Java {@link java.time.Duration Duration} using English words.
+     * Converts the duration to millis and then calls {@link #formatMillisecondDurationWords(long)}.
+     *
+     * @param duration the Java duration to format
+     * @return the duration in words (e.g., 2 hours 5 minutes)
+     */
+    public static String formatJavaDurationWords(java.time.Duration duration) {
+        if (isNull(duration)) {
+            return LITERAL_NULL;
+        }
+
+        return formatMillisecondDurationWords(duration.toMillis());
+    }
+
+    /**
+     * Formats a Dropwizard {@code io.dropwizard.util.Duration} using English words.
+     * Converts the duration to millis and then calls {@link #formatDurationWords(long)}.
      *
      * @param duration the Dropwizard duration to format
      * @return the duration in words (e.g., 1 minute 45 seconds)
+     * @deprecated for removal; replaced by {@link #formatDropwizardDurationWords(Duration)}
      * @implNote You will need the Dropwizard Duration class available at runtime to call this method!
      */
-    public static String formatDurationWords(io.dropwizard.util.Duration duration) {
+    @Deprecated(since = "4.6.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "formatDropwizardDurationWords(io.dropwizard.util.Duration duration)",
+            usageSeverity = KiwiDeprecated.Severity.SEVERE,
+            removeAt = "5.0.0")
+    public static String formatDurationWords(Duration duration) {
         if (isNull(duration)) {
             return LITERAL_NULL;
         }
 
         return formatDurationWords(duration.toMilliseconds());
+    }
+
+    /**
+     * Formats a Dropwizard {@link io.dropwizard.util.Duration Duration} using English words.
+     * Converts the duration to millis and then calls {@link #formatMillisecondDurationWords(long)}.
+     *
+     * @param duration the Dropwizard duration to format
+     * @return the duration in words (e.g., 1 minute 45 seconds)
+     * @implNote You will need the Dropwizard Duration class available at runtime to call this method!
+     */
+    public static String formatDropwizardDurationWords(Duration duration) {
+        if (isNull(duration)) {
+            return LITERAL_NULL;
+        }
+
+        return formatMillisecondDurationWords(duration.toMilliseconds());
+    }
+
+    /**
+     * A thin wrapper around {@link DurationFormatUtils#formatDurationWords(long, boolean, boolean)} that always
+     * suppresses leading and trailing "zero elements" because why would you want to see
+     * "0 days 7 hours 25 minutes 0 seconds" instead of just "7 hours 25 minutes"? (We cannot think of a good reason...)
+     *
+     * @param durationMillis the duration in milliseconds to format
+     * @return the duration in words (e.g., 10 minutes)
+     * @deprecated for removal; replaced by {@link #formatMillisecondDurationWords(long)}
+     * @implNote The only real reason for this method to exist is, so we don't constantly have to pass the two
+     * boolean arguments. Plus, boolean arguments are evil because what exactly does "true, false" tell you without
+     * requiring you to look at the parameter documentation?
+     * @see DurationFormatUtils#formatDurationWords(long, boolean, boolean)
+     */
+    @Deprecated(since = "4.6.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "formatMillisecondDurationWords(long durationMillis)",
+            usageSeverity = KiwiDeprecated.Severity.SEVERE,
+            removeAt = "5.0.0")
+    public static String formatDurationWords(long durationMillis) {
+        return DurationFormatUtils.formatDurationWords(
+                durationMillis,
+                SUPPRESS_LEADING_ZERO_ELEMENTS,
+                SUPPRESS_TRAILING_ZERO_ELEMENTS);
     }
 
     /**
@@ -62,7 +133,7 @@ public class KiwiDurationFormatters {
      * requiring you to look at the parameter documentation?
      * @see DurationFormatUtils#formatDurationWords(long, boolean, boolean)
      */
-    public static String formatDurationWords(long durationMillis) {
+    public static String formatMillisecondDurationWords(long durationMillis) {
         return DurationFormatUtils.formatDurationWords(
                 durationMillis,
                 SUPPRESS_LEADING_ZERO_ELEMENTS,

--- a/src/test/java/org/kiwiproject/time/KiwiDurationFormattersTest.java
+++ b/src/test/java/org/kiwiproject/time/KiwiDurationFormattersTest.java
@@ -13,8 +13,9 @@ class KiwiDurationFormattersTest {
 
     private static final String SEVEN_HOURS_TWENTY_FIVE_MINUTES = "7 hours 25 minutes";
 
+    @SuppressWarnings("removal")
     @Nested
-    class FormatDurationWords {
+    class FormatDurationWordsDeprecated {
 
         @Test
         void shouldFormatMilliseconds() {
@@ -44,6 +45,48 @@ class KiwiDurationFormattersTest {
         void shouldFormatNullDropwizardDuration_AsLiteralNull() {
             var words = KiwiDurationFormatters.formatDurationWords((io.dropwizard.util.Duration) null);
             assertThat(words).isEqualTo("null");
+        }
+    }
+
+    @Nested
+    class FormatJavaDurationWords {
+
+        @Test
+        void shouldFormatJavaDuration() {
+            var words = KiwiDurationFormatters.formatJavaDurationWords(Duration.ofMinutes(445));
+            assertThat(words).isEqualTo(SEVEN_HOURS_TWENTY_FIVE_MINUTES);
+        }
+
+        @Test
+        void shouldFormatNullJavaDuration_AsLiteralNull() {
+            var words = KiwiDurationFormatters.formatJavaDurationWords(null);
+            assertThat(words).isEqualTo("null");
+        }
+    }
+
+    @Nested
+    class FormatDropwizardDurationWords {
+
+        @Test
+        void shouldFormatDropwizardDuration() {
+            var words = KiwiDurationFormatters.formatDropwizardDurationWords(io.dropwizard.util.Duration.minutes(445));
+            assertThat(words).isEqualTo(SEVEN_HOURS_TWENTY_FIVE_MINUTES);
+        }
+
+        @Test
+        void shouldFormatNullDropwizardDuration_AsLiteralNull() {
+            var words = KiwiDurationFormatters.formatDropwizardDurationWords(null);
+            assertThat(words).isEqualTo("null");
+        }
+    }
+
+    @Nested
+    class FormatMillisecondsDurationWords {
+
+        @Test
+        void shouldFormatMilliseconds() {
+            var words = KiwiDurationFormatters.formatMillisecondDurationWords(Duration.ofMinutes(445).toMillis());
+            assertThat(words).isEqualTo(SEVEN_HOURS_TWENTY_FIVE_MINUTES);
         }
     }
 }


### PR DESCRIPTION
* Deprecate all formatDurationWords methods
* Add replacement methods for deprecated ones

Closes #1219
Closes #1220
Related to #1218