### PR TITLE
Add KiwiDurations utility class for working with java.time.Duration

### DIFF
--- a/src/main/java/org/kiwiproject/time/KiwiDurations.java
+++ b/src/main/java/org/kiwiproject/time/KiwiDurations.java
@@ -1,0 +1,42 @@
+package org.kiwiproject.time;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.Duration;
+
+/**
+ * Utilities related to Java's {@link Duration} class.
+ */
+@UtilityClass
+public class KiwiDurations {
+
+    /**
+     * Check if a {@link Duration} is positive.
+     *
+     * @param duration the duration to check
+     * @return true if the duration is strictly positive, otherwise false
+     */
+    public static boolean isPositive(Duration duration) {
+        return !duration.isNegative() && !duration.isZero();
+    }
+
+    /**
+     * Check if a {@link Duration} is positive or zero.
+     *
+     * @param duration the duration to check
+     * @return true if the duration is positive or zero, otherwise false
+     */
+    public static boolean isPositiveOrZero(Duration duration) {
+        return !duration.isNegative();
+    }
+
+    /**
+     * Check if a {@link Duration} is negative or zero.
+     *
+     * @param duration the duration to check
+     * @return true if the duration is negative or zero, otherwise false
+     */
+    public static boolean isNegativeOrZero(Duration duration) {
+        return duration.isNegative() || duration.isZero();
+    }
+}

--- a/src/test/java/org/kiwiproject/time/KiwiDurationsTest.java
+++ b/src/test/java/org/kiwiproject/time/KiwiDurationsTest.java
@@ -1,0 +1,60 @@
+package org.kiwiproject.time;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.random.RandomGenerator;
+import java.util.stream.Stream;
+
+@DisplayName("KiwiDurations")
+class KiwiDurationsTest {
+
+    @ParameterizedTest
+    @MethodSource("durations")
+    void shouldCheckIsPositive(Duration duration) {
+        var expectPositive = duration.toNanos() > 0;
+        assertThat(KiwiDurations.isPositive(duration)).isEqualTo(expectPositive);
+    }
+
+    @ParameterizedTest
+    @MethodSource("durations")
+    void shouldCheckIsPositiveOrZero(Duration duration) {
+        var expectPositiveOrZero = duration.toNanos() >= 0;
+        assertThat(KiwiDurations.isPositiveOrZero(duration)).isEqualTo(expectPositiveOrZero);
+    }
+
+    @ParameterizedTest
+    @MethodSource("durations")
+    void shouldCheckIsNegativeOrZero(Duration duration) {
+        var expectNegativeOrZero = duration.toNanos() <= 0;
+        assertThat(KiwiDurations.isNegativeOrZero(duration)).isEqualTo(expectNegativeOrZero);
+    }
+
+    static Stream<Duration> durations() {
+        return Stream.of(
+                Duration.ofNanos(randomPositiveInt()),
+                Duration.ofNanos(0),
+                Duration.ofNanos(randomPositiveInt()),
+
+                Duration.ofMillis(randomPositiveInt()),
+                Duration.ofMillis(0),
+                Duration.ofMillis(randomNegativeInt()),
+
+                Duration.ofSeconds(randomPositiveInt()),
+                Duration.ofSeconds(0),
+                Duration.ofSeconds(randomNegativeInt())
+        );
+    }
+
+    private static int randomNegativeInt() {
+        return -randomPositiveInt();
+    }
+
+    private static int randomPositiveInt() {
+        return Math.abs(RandomGenerator.getDefault().nextInt());
+    }
+}


### PR DESCRIPTION
Java's Duration contains (instance) methods isNegative() and isZero(), but nothing else. Add convenience methods that allow for one-liner checks of Duration instances whether they are positive, positive or zero, or negative or zero.

The initial KiwiDurations contains the following methods:

* isPositive
* isPositiveOrZero
* isNegativeOrZero

Closes #1221