### PR TITLE
Add nextCircularListIndex to KiwiLists

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiLists.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiLists.java
@@ -281,6 +281,21 @@ public class KiwiLists {
     }
 
     /**
+     * Returns the next index in a circular list. When the current index is at the end of the list, it
+     * wraps around to the beginning of the list.
+     *
+     * @param currentIndex the current index of a circular list
+     * @param listSize the size of the list
+     * @return the index following the current index, which may wrap around to zero
+     */
+    public static int nextCircularListIndex(int currentIndex, int listSize) {
+        checkArgument(listSize > 0, "listSize must be positive");
+        checkArgument(currentIndex > -1 && currentIndex < listSize,
+                "currentIndex must be in the range [0, %s]", (listSize - 1));
+        return (currentIndex + 1) % listSize;
+    }
+
+    /**
      * Returns a view of the portion of the given list excluding the first element.
      * <p>
      * This method has the same semantics as {@link List#subList(int, int)} since it calls that method.


### PR DESCRIPTION
This method handles the simple calculation of getting the next index of a circular list (or array), wrapping around to the beginning when at the end. It also provides input validation on the list size and index.

I am adding this because, rather unbelievably, I was not able to find something like it in any "standard" utility libraries (Google Guava, Apache Commons Lang or Collections), etc. Maybe one exists, but I could not find it. The closest I found was the CircularFifoQueue in Apache Commons Collections.