### PR TITLE
Improve Javadocs in Processes and ProcessHelper

### DIFF
--- a/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
+++ b/src/main/java/org/kiwiproject/base/process/ProcessHelper.java
@@ -18,9 +18,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 /**
- * Wrapper class around the static utility functions in {@link Processes} that requires an instance, adn thus by using
- * an instance of this class instead of {@link Processes} directly, it will make it much easier to test code that deals
- * with processes.
+ * This is a wrapper class around the static utility functions in {@link Processes}. You need to create an instance
+ * of this class to use it.
+ * <p>
+ * Using an instance of this class instead of {@link Processes} directly will make
+ * it much easier to test code that deals with operating system processes.
  * <p>
  * <em>Note that most of the methods are intended only for use on Unix/Linux operating systems.</em>
  */

--- a/src/main/java/org/kiwiproject/base/process/Processes.java
+++ b/src/main/java/org/kiwiproject/base/process/Processes.java
@@ -35,6 +35,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Utility class for working with operating system processes.
  * <p>
+ * If you need to be able to mock any of the operations in this class in test code, consider using
+ * {@link ProcessHelper} instead.
+ * <p>
  * <em>Note that most of the methods are intended only for use on Unix/Linux operating systems.</em>
  *
  * @see ProcessHelper


### PR DESCRIPTION
* Rewrite the class-level Javadoc in ProcessHelper so that, well, it makes sense.
* Improve the Javadocs in Processes to mention using ProcessHelper to make testing easier.