### PR TITLE
Add ability to configure the key exchange type for SFTP connections

### DIFF
--- a/src/main/java/org/kiwiproject/jsch/SftpConfig.java
+++ b/src/main/java/org/kiwiproject/jsch/SftpConfig.java
@@ -76,6 +76,13 @@ public class SftpConfig {
     private String preferredAuthentications = DEFAULT_PREFERRED_AUTHENTICATIONS;
 
     /**
+     * The key exchange type, for example, {@code "ssh-rsa"} or {@code "ecdsa-sha2-nistp256}.
+     * <p>
+     * There is no default value.
+     */
+    private String keyExchangeType;
+
+    /**
      * The root directory of the remote SFTP location, provided as a convenience to store the remote path in the same
      * place as the other SFTP properties.
      * <p>
@@ -122,6 +129,7 @@ public class SftpConfig {
      * @param password                  the SFTP password
      * @param privateKeyFilePath        path to the private key file
      * @param preferredAuthentications  comma-separated list of authentications to attempt
+     * @param keyExchangeType           the key exchange type to use
      * @param remoteBasePath            root directory of the remote SFTP location
      * @param errorPath                 local directory to write out any errors if SFTP fails
      * @param knownHostsFile            path to the known hosts file
@@ -138,7 +146,7 @@ public class SftpConfig {
     @SuppressWarnings({"java:S107"})
     @ConstructorProperties({
             "port", "host", "user", "password",
-            "privateKeyFilePath", "preferredAuthentications",
+            "privateKeyFilePath", "preferredAuthentications", "keyExchangeType",
             "remoteBasePath", "errorPath", "knownHostsFile",
             "disableStrictHostChecking", "timeout"
     })
@@ -148,6 +156,7 @@ public class SftpConfig {
                       String password,
                       String privateKeyFilePath,
                       String preferredAuthentications,
+                      String keyExchangeType,
                       String remoteBasePath,
                       String errorPath,
                       String knownHostsFile,
@@ -161,6 +170,7 @@ public class SftpConfig {
         this.privateKeyFilePath = privateKeyFilePath;
         this.preferredAuthentications =
                 isBlank(preferredAuthentications) ? DEFAULT_PREFERRED_AUTHENTICATIONS : preferredAuthentications;
+        this.keyExchangeType = isBlank(keyExchangeType) ? null : keyExchangeType;
         this.remoteBasePath = remoteBasePath;
         this.errorPath = errorPath;
         this.knownHostsFile = knownHostsFile;

--- a/src/test/java/org/kiwiproject/jsch/SftpConfigTest.java
+++ b/src/test/java/org/kiwiproject/jsch/SftpConfigTest.java
@@ -60,6 +60,7 @@ class SftpConfigTest {
             assertThat(config.getUser()).isNull();
             assertThat(config.getPassword()).isNull();
             assertThat(config.getPrivateKeyFilePath()).isNull();
+            assertThat(config.getKeyExchangeType()).isNull();
             assertThat(config.getRemoteBasePath()).isNull();
             assertThat(config.getErrorPath()).isNull();
             assertThat(config.getKnownHostsFile()).isNull();
@@ -79,7 +80,7 @@ class SftpConfigTest {
     }
 
     private static SftpConfig newConfigUsingAllArgsConstructor() {
-        return new SftpConfig(0, null, null, null, null, null, null, null, null, false, null);
+        return new SftpConfig(0, null, null, null, null, null, null, null, null, null, false, null);
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/jsch/SftpConnectorTest.java
+++ b/src/test/java/org/kiwiproject/jsch/SftpConnectorTest.java
@@ -1,13 +1,20 @@
 package org.kiwiproject.jsch;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import com.jcraft.jsch.HostKey;
+import com.jcraft.jsch.HostKeyRepository;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
@@ -15,6 +22,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
 
 @DisplayName("SftpConnector")
 class SftpConnectorTest {
@@ -47,6 +58,101 @@ class SftpConnectorTest {
                     .isExactlyInstanceOf(SftpTransfersException.class)
                     .hasMessage("Error occurred connecting to server-1.test")
                     .hasCause(jSchException);
+        }
+    }
+
+    @Nested
+    class SetKeyExchangeTypeIfConfiguredOrDetected {
+
+        @Test
+        void shouldSetKeyExchangeTypeOnSession_WhenKeyExchangeTypeIsPresent() {
+            config.setHost("server-1.test");
+
+            var keyExchangeType = "ecdsa-sha2-nistp256";
+            config.setKeyExchangeType(keyExchangeType);
+
+            var connector = new SftpConnector(jsch, config);
+
+            connector.setKeyExchangeTypeIfConfiguredOrDetected(session);
+
+            verify(session).setConfig(anyString(), eq(keyExchangeType));
+        }
+
+        @Test
+        void shouldNotSetKeyExchangeTypeOnSession_WhenKeyExchangeTypeNotConfiguredOrDetected() {
+            config.setHost("server-1.test");
+
+            var hostKeyRepository = mock(HostKeyRepository.class);
+            when(hostKeyRepository.getHostKey()).thenReturn(new HostKey[0]);
+            when(jsch.getHostKeyRepository()).thenReturn(hostKeyRepository);
+
+            var connector = new SftpConnector(jsch, config);
+            
+            connector.setKeyExchangeTypeIfConfiguredOrDetected(session);
+
+            verifyNoInteractions(session);
+        }
+    }
+
+    @Nested
+    class GetOrDetectKeyExchangeType {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "ssh-rsa",
+                "ecdsa-sha2-nistp256",
+                "ecdsa-sha2-nistp521"
+        })
+        void shouldReturnOptionalContainingValueFromSftpConfig(String keyExchangeType) {
+            config.setKeyExchangeType(keyExchangeType);
+
+            var connector = new SftpConnector(jsch, config);
+
+            assertThat(connector.getOrDetectKeyExchangeType()).hasValue(keyExchangeType);
+
+            verifyNoInteractions(jsch);
+        }
+
+        @Test
+        void shouldReturnEmptyOptional_WhenNotConfigured_OrDetected() {
+            config.setHost("server-1.test");
+            config.setKnownHostsFile("/home/users/bob/.ssh/known_hosts");
+
+            var hostKeyRepository = mock(HostKeyRepository.class);
+            when(hostKeyRepository.getHostKey()).thenReturn(new HostKey[0]);
+            when(jsch.getHostKeyRepository()).thenReturn(hostKeyRepository);
+
+            var connector = new SftpConnector(jsch, config);
+
+            assertThat(connector.getOrDetectKeyExchangeType()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "ssh-rsa",
+                "ecdsa-sha2-nistp256",
+                "ecdsa-sha2-nistp521"
+        })
+        void shouldReturnOptional_ContainingDetectedValue(String keyExchangeType) {
+            config.setHost("server-1.test");
+            config.setKnownHostsFile("/home/users/bob/.ssh/known_hosts");
+
+            var hostKeyRepository = mock(HostKeyRepository.class);
+
+            when(jsch.getHostKeyRepository()).thenReturn(hostKeyRepository);
+
+            // Mocks the static KiwiJSchHelpers#detectKeyExchangeTypeForHost method called
+            // by getOrDetectKeyExchangeType()
+            try (var mockedStatic = mockStatic(KiwiJSchHelpers.class)) {
+                mockedStatic.when(() -> KiwiJSchHelpers.detectKeyExchangeTypeForHost(anyString(), any(HostKeyRepository.class)))
+                        .thenReturn(Optional.of(keyExchangeType));
+
+                var connector = new SftpConnector(jsch, config);
+
+                assertThat(connector.getOrDetectKeyExchangeType()).hasValue(keyExchangeType);
+
+                mockedStatic.verify(() -> KiwiJSchHelpers.detectKeyExchangeTypeForHost(config.getHost(), hostKeyRepository));
+            }
         }
     }
 

--- a/src/test/resources/SftpConfigTest/config-all-properties.json
+++ b/src/test/resources/SftpConfigTest/config-all-properties.json
@@ -3,6 +3,7 @@
   "host": "localhost",
   "user": "bob",
   "preferredAuthentications": "publickey",
+  "keyExchangeType": "ssh-rsa",
   "privateKeyFilePath": "/home/bob/.ssh/id_rsa",
   "knownHostsFile": "/home/bob/.ssh/known_hosts",
   "remoteBasePath": "/data_shared/development/my-service/remote-base-path",

--- a/src/test/resources/SftpConfigTest/config-all-properties.yml
+++ b/src/test/resources/SftpConfigTest/config-all-properties.yml
@@ -4,6 +4,7 @@ sftpConfig:
   host: localhost
   user: bob
   preferredAuthentications: publickey
+  keyExchangeType: ssh-rsa
   privateKeyFilePath: /home/bob/.ssh/id_rsa
   knownHostsFile: /home/bob/.ssh/known_hosts
   remoteBasePath: /data_shared/development/my-service/remote-base-path


### PR DESCRIPTION
* Add keyExchangeType to SftpConfig with no default value (null)
* Update SftpConnector to use the keyExchangeType in SftpConfig if not null. Otherwise, it falls back to detecting the type from the known hosts file.

Closes #1249