### PR TITLE
Add lowercaseName to KiwiEnums

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiEnums.java
+++ b/src/main/java/org/kiwiproject/base/KiwiEnums.java
@@ -12,6 +12,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kiwiproject.collect.KiwiArrays;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -90,10 +91,6 @@ public class KiwiEnums {
         return enumValue.name().equalsIgnoreCase(stringOrNull(value));
     }
 
-    private static <E extends Enum<E>> void checkEnumNotNull(Enum<E> enumValue) {
-        checkArgumentNotNull(enumValue, "enumValue must not be null");
-    }
-
     /**
      * Compares the given enum's {@link Enum#name() name} with the given value for
      * inverse equality, i.e., they are not equal.
@@ -157,5 +154,35 @@ public class KiwiEnums {
     @SafeVarargs
     private static <E extends Enum<E>> void checkEnumsNotNullOrEmpty(Enum<E>... enumValues) {
         checkArgument(KiwiArrays.isNotNullOrEmpty(enumValues), "enumValues must not be null or empty");
+    }
+
+    /**
+     * Return the lowercase name of the enum value, using {@link Locale#ENGLISH} as the locale
+     * for the conversion.
+     *
+     * @param <E>       the enum type
+     * @param enumValue the enum value to lowercase
+     * @return the lowercase value of the enum value
+     * @see #lowercaseName(Enum, Locale)
+     */
+    public static <E extends Enum<E>> String lowercaseName(Enum<E> enumValue) {
+        return lowercaseName(enumValue, Locale.ENGLISH);
+    }
+
+    /**
+     * Return the lowercase name of the enum value.
+     *
+     * @param <E>       the enum type
+     * @param enumValue the enum value to lowercase
+     * @param locale    the Locale to use for the lowercase conversion
+     * @return the lowercase value of the enum value
+     */
+    public static <E extends Enum<E>> String lowercaseName(Enum<E> enumValue, Locale locale) {
+        checkEnumNotNull(enumValue);
+        return enumValue.name().toLowerCase(locale);
+    }
+
+    private static <E extends Enum<E>> void checkEnumNotNull(Enum<E> enumValue) {
+        checkArgumentNotNull(enumValue, "enumValue must not be null");
     }
 }

--- a/src/test/java/org/kiwiproject/base/KiwiEnumsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiEnumsTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.kiwiproject.util.BlankStringSource;
 
+import java.util.Locale;
+
 @DisplayName("KiwiEnums")
 class KiwiEnumsTest {
 
@@ -306,5 +308,37 @@ class KiwiEnumsTest {
 
     enum Color {
         RED, ORANGE, YELLOW, GREEN, BLUE, INDIGO, VIOLET
+    }
+
+    @Nested
+    class LowercaseName {
+
+        enum DrinkType {
+            BEER, JUICE, SODA, WATER, WINE
+        }
+
+        enum OrderStatus {
+            PENDING_PAYMENT,
+            PROCESSING_ORDER,
+            SHIPPED_OUT,
+            DELIVERED_SUCCESSFULLY,
+            CANCELLED_BY_CUSTOMER,
+            RETURN_REQUESTED
+        }
+
+        // IntelliJ warning about "No implicit conversion found to convert 'Xyz' to 'Enum<E>' is NOT correct
+        @SuppressWarnings("JUnitMalformedDeclaration")
+        @ParameterizedTest
+        @EnumSource(Season.class)
+        @EnumSource(Color.class)
+        @EnumSource(DrinkType.class)
+        @EnumSource(OrderStatus.class)
+        <E extends Enum<E>> void shouldConvertTheEnumNamesToLowercase(Enum<E> enumValue) {
+            var value = KiwiEnums.lowercaseName(enumValue);
+
+            com.google.common.base.Enums.getIfPresent(Season.class, "winter");
+
+            assertThat(value).isEqualTo(enumValue.name().toLowerCase(Locale.ENGLISH));
+        }
     }
 }


### PR DESCRIPTION
While perhaps a bit silly, having to do the same code to take an enum value, get its name, and convert it to lowercase a few times lately for various reasons is annoying. Hence, adding this trivial method.

There are two lowercaseName methods, one that accepts just the Enum value, and a second which accepts the Enum value and a Locale for the call to String#toLowerCase call, on the (very) off chance that it will matter to someone. The one-argument method uses Locale.ENGLISH.