### PR TITLE
Investigate new StripedLockTest failures in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java_version }}
-          distribution: 'temurin'
+          distribution: 'zulu'
           check-latest: true
 
       # Cache all the things

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,7 @@ on:
 jobs:
   build:
     name: Build
-#    runs-on: ubuntu-latest
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+#    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java_version }}
-          distribution: 'zulu'
+          distribution: 'temurin'
           check-latest: true
 
       # Cache all the things

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -238,10 +238,21 @@ class StripedLockTest {
     }
 
     private void logAndCheckExecutionTimes(TaskRecorder recorder1, TaskRecorder recorder2, boolean expectedOverlap) {
-        LOG.debug("task 1 execution time range: {}", recorder1.timeRange());
-        LOG.debug("task 2 execution time range: {}", recorder2.timeRange());
+        var range1 = recorder1.timeRange();
+        LOG.debug("task 1 execution time range: {}", range1);
 
-        assertThat(recorder1.overlaps(recorder2)).isEqualTo(expectedOverlap);
+        var range2 = recorder2.timeRange();
+        LOG.debug("task 2 execution time range: {}", range2);
+
+        var overlap = recorder1.overlaps(recorder2);
+        LOG.debug("task 1 and 2 overlap? {} (expecting: {})", overlap, expectedOverlap);
+
+        var description = expectedOverlap ?
+                "expected execution time ranges to overlap but they do not (range 1: %s ; range 2: %s)" :
+                "did not expect execution time ranges to overlap but they do (range 1: %s ; range 2: %s)";
+        assertThat(overlap)
+                .describedAs(description, range1, range2)
+                .isEqualTo(expectedOverlap);
     }
 
     static class TaskRecorder {

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -289,7 +289,7 @@ class StripedLockTest {
     }
 
     private <T> void waitForAll(List<CompletableFuture<T>> futures) {
-        Async.waitForAll(futures, 300, TimeUnit.MILLISECONDS);
+        Async.waitForAll(futures, 1, TimeUnit.SECONDS);
     }
 
     private void logAndCheckExecutionTimes(TaskRecorder recorder1, TaskRecorder recorder2, boolean expectedOverlap) {

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -8,6 +8,7 @@ import static org.kiwiproject.collect.KiwiLists.second;
 import com.google.common.collect.Range;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,6 +17,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.base.process.Processes;
+import org.kiwiproject.io.KiwiIO;
 
 import java.time.Instant;
 import java.util.List;
@@ -31,6 +34,16 @@ import java.util.function.Supplier;
 class StripedLockTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
+
+    @BeforeAll
+    static void beforeAll() {
+        var unameProc = Processes.launch("uname", "-a");
+        var exitCodeOpt = Processes.waitForExit(unameProc, 1, TimeUnit.SECONDS);
+        exitCodeOpt.ifPresentOrElse(exitCode -> {
+            var stdout = KiwiIO.readLinesFromInputStreamOf(unameProc);
+            LOG.info("OS info: {}", stdout);
+        }, () -> LOG.warn("The uname command timed out!"));
+    }
 
     @ParameterizedTest
     @NullAndEmptySource

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -138,10 +138,14 @@ class StripedLockTest {
         var recorder1 = new TaskRecorder("task1");
         var recorder2 = new TaskRecorder("task2");
 
+        var threadPool = Executors.newFixedThreadPool(2);
+
         var completableFutures = List.of(
-                Async.doAsync(() -> lock.runWithWriteLock(recorder1.id, () -> recorder1.runTask(task))),
-                Async.doAsync(() -> lock.runWithWriteLock(recorder2.id, () -> recorder2.runTask(task)))
+                Async.doAsync(() -> lock.runWithWriteLock(recorder1.id, () -> recorder1.runTask(task)), threadPool),
+                Async.doAsync(() -> lock.runWithWriteLock(recorder2.id, () -> recorder2.runTask(task)), threadPool)
         );
+
+        threadPool.shutdownNow();
 
         waitForAll(completableFutures);
 
@@ -175,7 +179,7 @@ class StripedLockTest {
         var recorder2 = new TaskRecorder("task2");
 
         // Well damn, this made this test pass...
-        var threadPool = Executors.newFixedThreadPool(10);
+        var threadPool = Executors.newFixedThreadPool(2);
 
         var completableFutures = List.of(
                 Async.doAsync(() -> lock.runWithReadLock(recorder1.id, () -> recorder1.runTask(task)), threadPool),
@@ -183,6 +187,8 @@ class StripedLockTest {
         );
 
         waitForAll(completableFutures);
+
+        threadPool.shutdownNow();
 
         logAndCheckExecutionTimes(recorder1, recorder2, true);
     }
@@ -197,12 +203,16 @@ class StripedLockTest {
         var recorder1 = new TaskRecorder("task1");
         var recorder2 = new TaskRecorder("task2");
 
+        var threadPool = Executors.newFixedThreadPool(2);
+
         var completableFutures = List.of(
-                Async.doAsync(() -> lock.supplyWithReadLock(recorder1.id, () -> recorder1.runTaskAndSupply(task1))),
-                Async.doAsync(() -> lock.supplyWithReadLock(recorder2.id, () -> recorder2.runTaskAndSupply(task2)))
+                Async.doAsync(() -> lock.supplyWithReadLock(recorder1.id, () -> recorder1.runTaskAndSupply(task1)), threadPool),
+                Async.doAsync(() -> lock.supplyWithReadLock(recorder2.id, () -> recorder2.runTaskAndSupply(task2)), threadPool)
         );
 
         waitForAll(completableFutures);
+
+        threadPool.shutdownNow();
 
         logAndCheckExecutionTimes(recorder1, recorder2, true);
 
@@ -241,12 +251,16 @@ class StripedLockTest {
         var recorder1 = new TaskRecorder("task1");
         var recorder2 = new TaskRecorder("task2");
 
+        var threadPool = Executors.newFixedThreadPool(2);
+
         var completableFutures = List.of(
-                Async.doAsync(() -> lock.supplyWithReadLock(recorder1.id, () -> recorder1.runTaskAndSupply(task1))),
-                Async.doAsync(() -> lock.supplyWithWriteLock(recorder2.id, () -> recorder2.runTaskAndSupply(task2)))
+                Async.doAsync(() -> lock.supplyWithReadLock(recorder1.id, () -> recorder1.runTaskAndSupply(task1)), threadPool),
+                Async.doAsync(() -> lock.supplyWithWriteLock(recorder2.id, () -> recorder2.runTaskAndSupply(task2)), threadPool)
         );
 
         waitForAll(completableFutures);
+
+        threadPool.shutdownNow();
 
         logAndCheckExecutionTimes(recorder1, recorder2, true);
 

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -7,8 +7,11 @@ import static org.kiwiproject.collect.KiwiLists.second;
 
 import com.google.common.collect.Range;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.base.DefaultEnvironment;
@@ -26,6 +29,16 @@ import java.util.function.Supplier;
 class StripedLockTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        LOG.info("--- BEGIN: {} ---", testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void tearDown(TestInfo testInfo) {
+        LOG.info("--- END: {} ---", testInfo.getDisplayName());
+    }
 
     @ParameterizedTest
     @NullAndEmptySource

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -103,7 +103,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_NOT_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_NOT_OVERLAP);
         }
 
         @Test
@@ -120,7 +120,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_OVERLAP);
         }
 
         @Test
@@ -137,7 +137,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_NOT_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_NOT_OVERLAP);
         }
 
         @Test
@@ -154,7 +154,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_OVERLAP);
         }
 
         @Test
@@ -172,7 +172,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_OVERLAP);
 
             assertThat(first(completableFutures).getNow(-1L)).isEqualTo(42L);
             assertThat(second(completableFutures).getNow(-1L)).isEqualTo(84L);
@@ -193,7 +193,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_NOT_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_NOT_OVERLAP);
 
             assertThat(first(completableFutures).getNow(-1L)).isEqualTo(42L);
             assertThat(second(completableFutures).getNow(-1L)).isEqualTo(84L);
@@ -214,7 +214,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
+            logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_OVERLAP);
 
             assertThat(first(completableFutures).getNow(-1L)).isEqualTo(42L);
             assertThat(second(completableFutures).getNow(-1L)).isEqualTo(84L);
@@ -245,19 +245,19 @@ class StripedLockTest {
         Async.waitForAll(futures, 300, TimeUnit.MILLISECONDS);
     }
 
-    enum TimeRanges {
+    enum ExecutionTimes {
         SHOULD_OVERLAP(true), SHOULD_NOT_OVERLAP(false);
 
         final boolean expectOverlap;
 
-        TimeRanges(boolean expectOverlap) {
+        ExecutionTimes(boolean expectOverlap) {
             this.expectOverlap = expectOverlap;
         }
     }
 
     private void logAndCheckExecutionTimes(TaskRecorder recorder1,
                                            TaskRecorder recorder2,
-                                           TimeRanges timeRanges) {
+                                           ExecutionTimes executionTimes) {
 
         var range1 = recorder1.timeRange();
         LOG.debug("task 1 execution time range: {}", range1);
@@ -265,7 +265,7 @@ class StripedLockTest {
         var range2 = recorder2.timeRange();
         LOG.debug("task 2 execution time range: {}", range2);
 
-        var expectedOverlap = timeRanges.expectOverlap;
+        var expectedOverlap = executionTimes.expectOverlap;
         var overlap = recorder1.overlaps(recorder2);
         LOG.debug("task 1 and 2 overlap? {} (expecting: {})", overlap, expectedOverlap);
 

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -8,7 +8,6 @@ import static org.kiwiproject.collect.KiwiLists.second;
 import com.google.common.collect.Range;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,8 +16,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
-import org.kiwiproject.base.process.Processes;
-import org.kiwiproject.io.KiwiIO;
 
 import java.time.Instant;
 import java.util.List;
@@ -34,16 +31,6 @@ import java.util.function.Supplier;
 class StripedLockTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
-
-    @BeforeAll
-    static void beforeAll() {
-        var unameProc = Processes.launch("uname", "-a");
-        var exitCodeOpt = Processes.waitForExit(unameProc, 1, TimeUnit.SECONDS);
-        exitCodeOpt.ifPresentOrElse(exitCode -> {
-            var stdout = KiwiIO.readLinesFromInputStreamOf(unameProc);
-            LOG.info("OS info: {}", stdout);
-        }, () -> LOG.warn("The uname command timed out!"));
-    }
 
     @ParameterizedTest
     @NullAndEmptySource

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -44,6 +44,10 @@ class StripedLockTest {
             LOG.info("OS info: {}", stdout);
         }, () -> LOG.warn("The uname command timed out!"));
 
+        reportCommonPoolInfo();
+    }
+
+    private static void reportCommonPoolInfo() {
         var availableProcessors = Runtime.getRuntime().availableProcessors();
         LOG.info("availableProcessors: {}", availableProcessors);
 
@@ -127,6 +131,8 @@ class StripedLockTest {
 
     @Test
     void testRunWithLock_WhenNonBlocking_ForWriteAndWriteLocks() {
+        reportCommonPoolInfo();
+
         var lock = new StripedLock(2);
         var task = createRunnableTask();
         var recorder1 = new TaskRecorder("task1");
@@ -161,6 +167,8 @@ class StripedLockTest {
 
     @Test
     void testRunWithLock_WhenNonBlocking_ForReadAndReadLocks() {
+        reportCommonPoolInfo();
+
         var lock = new StripedLock(1);
         var task = createRunnableTask();
         var recorder1 = new TaskRecorder("task1");
@@ -181,6 +189,8 @@ class StripedLockTest {
 
     @Test
     void testSupplyWithLock_WhenNonBlocking_ForReadAndReadLocks() {
+        reportCommonPoolInfo();
+
         var lock = new StripedLock(1);
         var task1 = createSupplierTask(42L);
         var task2 = createSupplierTask(84L);
@@ -223,6 +233,8 @@ class StripedLockTest {
 
     @Test
     void testSupplyWithLock_WhenNonBlocking_ForReadAndWriteLocks() {
+        reportCommonPoolInfo();
+        
         var lock = new StripedLock(2);
         var task1 = createSupplierTask(42L);
         var task2 = createSupplierTask(84L);

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.base.DefaultEnvironment;
@@ -32,16 +31,6 @@ import java.util.function.Supplier;
 class StripedLockTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
-
-    @BeforeEach
-    void setUp(TestInfo testInfo) {
-        LOG.info("--- BEGIN: {} ---", testInfo.getDisplayName());
-    }
-
-    @AfterEach
-    void tearDown(TestInfo testInfo) {
-        LOG.info("--- END: {} ---", testInfo.getDisplayName());
-    }
 
     @ParameterizedTest
     @NullAndEmptySource

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -145,9 +145,9 @@ class StripedLockTest {
                 Async.doAsync(() -> lock.runWithWriteLock(recorder2.id, () -> recorder2.runTask(task)), threadPool)
         );
 
-        threadPool.shutdownNow();
-
         waitForAll(completableFutures);
+
+        threadPool.shutdownNow();
 
         logAndCheckExecutionTimes(recorder1, recorder2, true);
     }
@@ -289,7 +289,7 @@ class StripedLockTest {
     }
 
     private <T> void waitForAll(List<CompletableFuture<T>> futures) {
-        Async.waitForAll(futures, 1, TimeUnit.SECONDS);
+        Async.waitForAll(futures, 300, TimeUnit.MILLISECONDS);
     }
 
     private void logAndCheckExecutionTimes(TaskRecorder recorder1, TaskRecorder recorder2, boolean expectedOverlap) {

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -42,6 +43,17 @@ class StripedLockTest {
             var stdout = KiwiIO.readLinesFromInputStreamOf(unameProc);
             LOG.info("OS info: {}", stdout);
         }, () -> LOG.warn("The uname command timed out!"));
+
+        var availableProcessors = Runtime.getRuntime().availableProcessors();
+        LOG.info("availableProcessors: {}", availableProcessors);
+
+        var commonPool = ForkJoinPool.commonPool();
+        LOG.info("ForkJoinPool Common Pool Parallelism: {}", commonPool.getParallelism());
+        LOG.info("ForkJoinPool Common Pool Active Thread Count: {}", commonPool.getActiveThreadCount());
+        LOG.info("ForkJoinPool Common Pool Running Thread Count: {}", commonPool.getRunningThreadCount());
+        LOG.info("ForkJoinPool Common Pool Queued Task Count: {}", commonPool.getQueuedTaskCount());
+        LOG.info("ForkJoinPool Common Pool Queued Submission Count: {}", commonPool.getQueuedSubmissionCount());
+        LOG.info("ForkJoinPool Common Pool Pool Size: {}", commonPool.getPoolSize());
     }
 
     @BeforeEach
@@ -154,9 +166,7 @@ class StripedLockTest {
         var recorder1 = new TaskRecorder("task1");
         var recorder2 = new TaskRecorder("task2");
 
-        // TODO: This is to ensure there are definitely more than enough threads to run two async tasks
-        //  and see whether the ForkJoinPool commonPool() implementation isn't causing this (which I
-        //  doubt but let's see anyway...)
+        // Well damn, this made this test pass...
         var threadPool = Executors.newFixedThreadPool(10);
 
         var completableFutures = List.of(

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -103,7 +103,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, false);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_NOT_OVERLAP);
         }
 
         @Test
@@ -120,7 +120,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, true);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
         }
 
         @Test
@@ -137,7 +137,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, false);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_NOT_OVERLAP);
         }
 
         @Test
@@ -154,7 +154,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, true);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
         }
 
         @Test
@@ -172,7 +172,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, true);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
 
             assertThat(first(completableFutures).getNow(-1L)).isEqualTo(42L);
             assertThat(second(completableFutures).getNow(-1L)).isEqualTo(84L);
@@ -193,7 +193,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, false);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_NOT_OVERLAP);
 
             assertThat(first(completableFutures).getNow(-1L)).isEqualTo(42L);
             assertThat(second(completableFutures).getNow(-1L)).isEqualTo(84L);
@@ -214,7 +214,7 @@ class StripedLockTest {
 
             waitForAll(completableFutures);
 
-            logAndCheckExecutionTimes(recorder1, recorder2, true);
+            logAndCheckExecutionTimes(recorder1, recorder2, TimeRanges.SHOULD_OVERLAP);
 
             assertThat(first(completableFutures).getNow(-1L)).isEqualTo(42L);
             assertThat(second(completableFutures).getNow(-1L)).isEqualTo(84L);
@@ -245,13 +245,27 @@ class StripedLockTest {
         Async.waitForAll(futures, 300, TimeUnit.MILLISECONDS);
     }
 
-    private void logAndCheckExecutionTimes(TaskRecorder recorder1, TaskRecorder recorder2, boolean expectedOverlap) {
+    enum TimeRanges {
+        SHOULD_OVERLAP(true), SHOULD_NOT_OVERLAP(false);
+
+        final boolean expectOverlap;
+
+        TimeRanges(boolean expectOverlap) {
+            this.expectOverlap = expectOverlap;
+        }
+    }
+
+    private void logAndCheckExecutionTimes(TaskRecorder recorder1,
+                                           TaskRecorder recorder2,
+                                           TimeRanges timeRanges) {
+
         var range1 = recorder1.timeRange();
         LOG.debug("task 1 execution time range: {}", range1);
 
         var range2 = recorder2.timeRange();
         LOG.debug("task 2 execution time range: {}", range2);
 
+        var expectedOverlap = timeRanges.expectOverlap;
         var overlap = recorder1.overlaps(recorder2);
         LOG.debug("task 1 and 2 overlap? {} (expecting: {})", overlap, expectedOverlap);
 

--- a/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/StripedLockTest.java
@@ -8,6 +8,7 @@ import static org.kiwiproject.collect.KiwiLists.second;
 import com.google.common.collect.Range;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.kiwiproject.base.DefaultEnvironment;
 import org.kiwiproject.base.KiwiEnvironment;
+import org.kiwiproject.base.process.Processes;
+import org.kiwiproject.io.KiwiIO;
 
 import java.time.Instant;
 import java.util.List;
@@ -29,6 +32,16 @@ import java.util.function.Supplier;
 class StripedLockTest {
 
     private static final KiwiEnvironment ENV = new DefaultEnvironment();
+
+    @BeforeAll
+    static void beforeAll() {
+        var unameProc = Processes.launch("uname", "-a");
+        var exitCodeOpt = Processes.waitForExit(unameProc, 1, TimeUnit.SECONDS);
+        exitCodeOpt.ifPresentOrElse(exitCode -> {
+            var stdout = KiwiIO.readLinesFromInputStreamOf(unameProc);
+            LOG.info("OS info: {}", stdout);
+        }, () -> LOG.warn("The uname command timed out!"));
+    }
 
     @BeforeEach
     void setUp(TestInfo testInfo) {


### PR DESCRIPTION
Today the non-blocking tests in StripedLockTest started failing in GitHub actions when I committed some code that was completely unrelated.

I did not change anything in StripedLock, and this test was passing as of the last time a build was run two weeks ago. So, something changed...

The tests work as expected on my MacBook Pro, so there's no help debugging there. And, I am using the same versions of JDK 17 and 21, and both are using the Zulu distribution.

The tests also worked in a GitHub Codespace running Linux, also using the Zulu distro of JDK 17 and 21.

The last time the StripedLock test passed in GH actions was two weeks ago. Between then and now, GH actions changed the Ubuntu runner image from 24.04.1 to 24.04.2. So this led to looking at differences in operating systems.

The Codespace OS information from `uname -a` looks like:

```
Linux codespaces-dd21cf 6.5.0-1025-azure #26~22.04.1-Ubuntu SMP Thu Jul 11 22:33:04 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

The GH action OS information looks like:

```
Linux fv-az1939-493 6.8.0-1021-azure #25-Ubuntu SMP Wed Jan 15 20:45:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
```

So, the kernel versions are significantly different (`6.5.0-1025-azure` in the Codespace, and `6.8.0-1021-azure` in the GH action runner). The GH action runner is a much newer kernel version. I can only guess that there must be something different in the thread and process scheduling that is causing the `ForkJoinPool` common pool to only have one thread available. 

I also tried reverting to Ubuntu 22.04 and the non-blocking tests still failed.

The GH action OS information for Ubuntu 22.04 is:

```
Linux fv-az1152-267 6.8.0-1021-azure #25~22.04.1-Ubuntu SMP Thu Jan 16 21:37:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
```

So even with the older version of Ubuntu, the kernel is the newer 6.8.0 version.

I then added some additional logging about the `ForkJoinPool`. Here's what it looked like:

```
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - availableProcessors: 4
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - ForkJoinPool Common Pool Parallelism: 3
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - ForkJoinPool Common Pool Active Thread Count: 2
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - ForkJoinPool Common Pool Running Thread Count: 0
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - ForkJoinPool Common Pool Queued Task Count: 0
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - ForkJoinPool Common Pool Queued Submission Count: 0
23:27:39.575 [main] INFO  o.k.c.StripedLockTest - ForkJoinPool Common Pool Pool Size: 3
```

This logging seems to indicate that while the common pool parallelism is 3 (meaning 3 available worker threads), there are 2 active threads, leaving only one for the tests.

After a bunch of debugging such as the above with the common pool, I figured that the non-blocking tests were basically acting like the blocking ones.

The original tests code was using the Async#doAsync method variants that use the default `ForkJoinPool.commonPool()`. From the above logging output, I was pretty sure there was only _one thread_ that was available for the two tasks to use. So, I changed one of the non-blocking tests to supply a custom FixedThreadPool and then that test passed, since each task could now execute in its own thread. I then changed the other non-blocking tests the same way, and they all passed too.

After figuring this all out I decided to do a bit of refactoring to clean the test code up. The tests that use the thread pool are now grouped into a `Nested` test class with `BeforeEach` and `AfterEach` methods that initialize and shut down a fixed thread pool with two threads. I also changed _all_ the `Async` calls to accept the custom thread pool so that both blocking and non-blocking tests always have two threads, which allows for two concurrent asynchronous tasks. Last, In changed the `boolean` parameter in the `logAndCheckExecutionTimes` method to an enum named `ExecutionTimes` with values `SHOULD_OVERLAP` and `SHOULD_NOT_OVERLAP`. This the test code more understandable when reading it, since you don't have to go figure out what the `true` and `false` values mean. For example:

```java
logAndCheckExecutionTimes(recorder1, recorder2, false);
```

becomes:

```java
logAndCheckExecutionTimes(recorder1, recorder2, ExecutionTimes.SHOULD_NOT_OVERLAP);
```

Last, I enhanced the code in `logAndCheckExecutionTimes` so that it logs whether the time ranges overlap, and whether we expected them to. And, I added a `describedAs` to the assertion in `logAndCheckExecutionTimes ` so it provides better information than just `true` or `false`.