### PR TITLE
Add sleep and sleepQuietly to KiwiEnvironment with Duration argument

### DIFF
--- a/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/DefaultEnvironment.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -170,6 +171,11 @@ public class DefaultEnvironment implements KiwiEnvironment {
     }
 
     @Override
+    public void sleep(Duration duration) throws InterruptedException {
+        TimeUnit.NANOSECONDS.sleep(duration.toNanos());
+    }
+
+    @Override
     public boolean sleepQuietly(long milliseconds) {
         try {
             sleep(milliseconds);
@@ -201,6 +207,18 @@ public class DefaultEnvironment implements KiwiEnvironment {
         } catch (InterruptedException e) {
             LOG.warn("Interrupted sleeping for {} milliseconds with {} nanos", millis, nanos);
             Thread.currentThread().interrupt();
+            return true;
+        }
+    }
+
+    @Override
+    public boolean sleepQuietly(Duration duration) {
+        try {
+            sleep(duration);
+            return false;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOG.warn("Interrupted sleeping for {}", duration);
             return true;
         }
     }

--- a/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
+++ b/src/main/java/org/kiwiproject/base/KiwiEnvironment.java
@@ -3,6 +3,7 @@ package org.kiwiproject.base;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -241,6 +242,14 @@ public interface KiwiEnvironment {
     void sleep(long millis, int nanos) throws InterruptedException;
 
     /**
+     * Sleep for the specified amount of time.
+     *
+     * @param duration the amount of time to sleep
+     * @throws InterruptedException if interrupted
+     */
+    void sleep(Duration duration) throws InterruptedException;
+
+    /**
      * Sleep for the given number of milliseconds. Will never throw an {@link InterruptedException}.
      *
      * @param milliseconds the number of milliseconds to sleep
@@ -269,6 +278,14 @@ public interface KiwiEnvironment {
      * @see Thread#sleep(long, int)
      */
     boolean sleepQuietly(long millis, int nanos);
+
+    /**
+     * Sleep for the specified amount of time. Will never throw an {@link InterruptedException}.
+     *
+     * @param duration the amount of time to sleep
+     * @return false if the sleep was not interrupted, and true if it was interrupted
+     */
+    boolean sleepQuietly(Duration duration);
 
     /**
      * Gets the value of the specified environment variable.

--- a/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
+++ b/src/test/java/org/kiwiproject/base/DefaultEnvironmentTest.java
@@ -22,6 +22,7 @@ import org.kiwiproject.collect.KiwiMaps;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -322,6 +323,15 @@ class DefaultEnvironmentTest {
     }
 
     @Test
+    void shouldSleep_WithDuration() throws InterruptedException {
+        var sleepMillis = 50;
+        var start = System.currentTimeMillis();
+        env.sleep(Duration.ofMillis(sleepMillis));
+        var end = System.currentTimeMillis();
+        assertElapsedTimeInMillisMeetsMinimum(sleepMillis, start, end);
+    }
+
+    @Test
     void testSleepQuietly() {
         long sleepTime = 50;
         long start = System.currentTimeMillis();
@@ -395,6 +405,31 @@ class DefaultEnvironmentTest {
         assertThat(interrupted).isTrue();
 
         verify(envSpy).sleepQuietly(millis, nanos);
+    }
+
+    @Test
+    void shouldSleepQuietly_WithDuration() {
+        var sleepMillis = 50;
+        var start = System.currentTimeMillis();
+        var interrupted = env.sleepQuietly(Duration.ofMillis(sleepMillis));
+        var end = System.currentTimeMillis();
+        assertThat(interrupted).isFalse();
+        assertElapsedTimeInMillisMeetsMinimum(sleepMillis, start, end);
+    }
+
+    @Test
+    void shouldSleepQuietly_WithDuration_WhenThrowsInterruptedException() throws InterruptedException {
+        var envSpy = spy(env);
+        doThrow(new InterruptedException())
+                .when(envSpy)
+                .sleep(any(Duration.class));
+
+        var duration = Duration.ofMillis(50);
+        var interrupted = envSpy.sleepQuietly(duration);
+
+        assertThat(interrupted).isTrue();
+
+        verify(envSpy).sleepQuietly(duration);
     }
 
     /**


### PR DESCRIPTION
* Add sleep(Duration) to KiwiEnvironment
* Add sleepQuietly(Duration) to KiwiEnvironment
* Add implementations in DefaultEnvironment. The sleep implementation converts the Duration to nanoseconds and uses the sleep method on the TimeUnit enum.