### PR TITLE
Add ValidURL annotation and validator for URL validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <kiwi-bom.version>2.0.23</kiwi-bom.version>
 
         <!-- Versions for provided dependencies -->
+        <commons-validator.version>1.9.0</commons-validator.version>
         <retrying-again.version>2.1.6</retrying-again.version>
 
         <!-- Versions for test dependencies -->
@@ -52,7 +53,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>retrying-again</artifactId>
@@ -91,6 +92,13 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>${commons-validator.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/validation/ValidURL.java
+++ b/src/main/java/org/kiwiproject/validation/ValidURL.java
@@ -1,0 +1,119 @@
+package org.kiwiproject.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that a {@link CharSequence} represents a valid URL.
+ * <p>
+ * This annotation can be used to validate that a string field, parameter, etc. contains a valid URL.
+ * By default, only HTTP and HTTPS schemes are allowed, but this can be configured using the
+ * {@link #allowAllSchemes()} and {@link #allowSchemes()} properties.
+ *
+ * @implNote This annotation requires the commons-validator dependency
+ * when using it, since the {@link ValidURLValidator} uses Apache Commons Validator's
+ * {@link org.apache.commons.validator.routines.UrlValidator} internally.
+ */
+@Documented
+@Constraint(validatedBy = {})
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+public @interface ValidURL {
+
+    /**
+     * The error message to use when validation fails.
+     *
+     * @return the error message
+     */
+    String message() default "{org.kiwiproject.validation.ValidURL.message}";
+
+    /**
+     * The validation groups to which this constraint belongs.
+     * <p>
+     * This is a standard property from the Bean Validation API.
+     *
+     * @return the validation groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * The payload associated with the constraint.
+     * <p>
+     * This is a standard property from the Bean Validation API.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+
+    /**
+     * Whether to allow null values.
+     * <p>
+     * If set to true, null values will be considered valid.
+     * If set to false (the default), null values will be considered invalid.
+     *
+     * @return true if null values are allowed, false otherwise
+     */
+    boolean allowNull() default false;
+
+    /**
+     * Whether to allow all URL schemes.
+     * <p>
+     * If set to true, all URL schemes will be allowed.
+     * If set to false (the default), only the schemes specified in {@link #allowSchemes()} will be allowed.
+     *
+     * @return true if all schemes are allowed, false otherwise
+     */
+    boolean allowAllSchemes() default false;
+
+    /**
+     * The allowed URL schemes.
+     * <p>
+     * This property is only used if {@link #allowAllSchemes()} is set to false.
+     * By default, only "http" and "https" schemes are allowed.
+     *
+     * @return the allowed URL schemes
+     */
+    String[] allowSchemes() default { "http", "https" };
+
+    /**
+     * Whether to allow local URLs (e.g., {@code localhost}, {@code localdomain}).
+     * <p>
+     * If set to true (the default), local URLs like {@code http://localhost} will be considered valid.
+     * If set to false, local URLs will be considered invalid.
+     *
+     * @return true if local URLs are allowed, false otherwise
+     */
+    boolean allowLocalUrls() default true;
+
+    /**
+     * Whether to allow URLs with two consecutive slashes.
+     * <p>
+     * If set to true, URLs with two consecutive slashes (other than after the scheme) will be considered valid.
+     * If set to false (the default), such URLs will be considered invalid.
+     *
+     * @return true if URLs with two consecutive slashes are allowed, false otherwise
+     */
+    boolean allowTwoSlashes() default false;
+
+    /**
+     * Whether to allow URLs with fragments.
+     * <p>
+     * If set to true (the default), URLs with fragments (the part after #) will be considered valid.
+     * If set to false, URLs with fragments will be considered invalid.
+     *
+     * @return true if URLs with fragments are allowed, false otherwise
+     */
+    boolean allowFragments() default true;
+}

--- a/src/main/java/org/kiwiproject/validation/ValidURLValidator.java
+++ b/src/main/java/org/kiwiproject/validation/ValidURLValidator.java
@@ -1,0 +1,196 @@
+package org.kiwiproject.validation;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.validator.routines.UrlValidator;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+/**
+ * Validator for the {@link ValidURL} annotation.
+ * <p>
+ * The validator can be configured to allow or disallow null values, to allow all URL schemes or only
+ * specific schemes, and to specify which schemes are allowed.
+ *
+ * @implNote This validator requires the commons-validator dependency
+ * when using it, since it uses Apache Commons Validator's
+ * {@link org.apache.commons.validator.routines.UrlValidator} internally.
+ */
+@Slf4j
+public class ValidURLValidator implements ConstraintValidator<ValidURL, CharSequence> {
+
+    /**
+     * The URL annotation instance that this validator is validating against.
+     */
+    private ValidURL validURL;
+
+    /**
+     * The Apache Commons Validator's UrlValidator instance used for URL validation.
+     */
+    private UrlValidator validator;
+
+    /**
+     * Initializes the validator with the annotation's properties.
+     * <p>
+     * This method is called by the Bean Validation API before validation begins.
+     * It configures the internal {@link UrlValidator} based on the annotation's properties.
+     *
+     * @param constraintAnnotation the annotation instance
+     */
+    @Override
+    public void initialize(ValidURL constraintAnnotation) {
+        this.validURL = constraintAnnotation;
+
+        var options = buildOptionsForCommonsUrlValidator(this.validURL);
+
+        if (validURL.allowAllSchemes()) {
+            this.validator = new UrlValidator(options);
+        } else {
+            this.validator = new UrlValidator(validURL.allowSchemes(), options);
+        }
+    }
+
+    private static long buildOptionsForCommonsUrlValidator(ValidURL url) {
+        var options = url.allowAllSchemes() ? UrlValidator.ALLOW_ALL_SCHEMES : 0L;
+
+        if (url.allowLocalUrls()) {
+            options += UrlValidator.ALLOW_LOCAL_URLS;
+        }
+
+        if (url.allowTwoSlashes()) {
+            options += UrlValidator.ALLOW_2_SLASHES;
+        }
+
+        if (!url.allowFragments()) {
+            options += UrlValidator.NO_FRAGMENTS;
+        }
+
+        return options;
+    }
+
+    /**
+     * Validates that the given value is a valid URL.
+     * <p>
+     * The validation process consists of the following steps:
+     * <ol>
+     *   <li>If the value is null, it is valid only if {@link ValidURL#allowNull()} is true.</li>
+     *   <li>The value is validated using Apache Commons Validator's {@link UrlValidator}.</li>
+     *   <li>If the value passes the initial validation, additional edge cases are checked.</li>
+     * </ol>
+     *
+     * @param value   the value to validate
+     * @param context the constraint validator context
+     * @return true if the value is a valid URL, false otherwise
+     */
+    @Override
+    public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
+        if (isNull(value)) {
+            return validURL.allowNull();
+        }
+
+        var string = value.toString();
+        var valid = validator.isValid(string);
+
+        if (!valid) {
+            LOG.trace("'{}' is NOT valid according to UrlValidator. Skip edge-case checks.", string);
+            return false;
+        }
+
+        LOG.trace("'{}' is valid according to UrlValidator. Check edge-cases.", string);
+
+        return checkEdgeCases(string, validURL.allowLocalUrls());
+    }
+
+    /**
+     * Checks for edge cases that the {@link UrlValidator} might miss.
+     * <p>
+     * This method performs additional validation checks that are not covered by the
+     * Apache Commons Validator's {@link UrlValidator}. Currently, it checks:
+     * <ul>
+     *   <li>If the URL can be parsed as a {@link URI}</li>
+     *   <li>If the authority component ends with a colon but no port</li>
+     *   <li>If the URL hostname is {@code 127.0.0.1} and allowLocalUrls is false</li>
+     *   <li>If the URL hostname {@code ::1} and allowLocalUrls is false</li>
+     * </ul>
+     *
+     * @param string the URL string to check
+     * @return true if the URL passes all edge case checks, false otherwise
+     */
+    @VisibleForTesting
+    static boolean checkEdgeCases(String string, boolean allowLocalUrls) {
+        var result = parseUri(string);
+        var error = result.error();
+        if (nonNull(error)) {
+            LOG.trace("UrlValidator reported valid, but URI#create threw exception for '{}'", string, error);
+            return false;
+        }
+
+        var uri = result.uri();
+
+        // Edge case 1 - Don't let authority end with a colon but no port
+        var authority = uri.getAuthority();
+        if (nonNull(authority) && authority.endsWith(":")) {
+            LOG.trace("Authority should not end with a colon but no port: '{}'", authority);
+            return false;
+        }
+
+        // Edge case 2 - If not allowing local URLS, check for loopback IPs.
+        //  UrlValidator doesn't consider these as local addresses.
+        var host = uri.getHost();
+        if (!allowLocalUrls && nonNull(host)) {
+
+            // don't allow IPv4 or IPv6 loopback
+            var loopbackResult = checkLoopbackIpAddress(host);
+            if (loopbackResult.isLoopbackOrError()) {
+                LOG.trace("Loopback check for host '{}' failed. Is loopback? {}, Error? {}",
+                        host,
+                        loopbackResult.isLoopback(),
+                        loopbackResult.isError(),
+                        loopbackResult.error());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private record UriParseResult(URI uri, Exception error) {
+    }
+
+    private static UriParseResult parseUri(String string) {
+        try {
+            return new UriParseResult(URI.create(string), null);
+        } catch (Exception e) {
+            return new UriParseResult(null, e);
+        }
+    }
+
+    @VisibleForTesting
+    record LoopbackCheckResult(boolean isLoopback, Exception error) {
+        boolean isLoopbackOrError() {
+            return isLoopback || isError();
+        }
+        
+        boolean isError() {
+            return nonNull(error);
+        }
+    }
+
+    @VisibleForTesting
+    static LoopbackCheckResult checkLoopbackIpAddress(String host) {
+        try {
+            var isLoopback = InetAddress.getByName(host).isLoopbackAddress();
+            return new LoopbackCheckResult(isLoopback, null);
+        } catch (UnknownHostException e) {
+            LOG.trace("Error getting InetAddress by name for host: {}", host, e);
+            return new LoopbackCheckResult(false, e);
+        }
+    }
+}

--- a/src/main/resources/ContributorValidationMessages.properties
+++ b/src/main/resources/ContributorValidationMessages.properties
@@ -23,3 +23,4 @@ org.kiwiproject.validation.Range.greaterThanOrEq.message.minMaxValues=must be gr
 org.kiwiproject.validation.Range.greaterThanOrEq.message.minMaxLabels=must be greater than or equal to {minLabel}
 org.kiwiproject.validation.Range.lessThanOrEq.message.minMaxValues=must be less than or equal to {max}
 org.kiwiproject.validation.Range.lessThanOrEq.message.minMaxLabels=must be less than or equal to {maxLabel}
+org.kiwiproject.validation.ValidURL.message=is not a valid URL

--- a/src/main/resources/META-INF/services/jakarta.validation.ConstraintValidator
+++ b/src/main/resources/META-INF/services/jakarta.validation.ConstraintValidator
@@ -8,3 +8,4 @@ org.kiwiproject.validation.Ipv4AndPortValidator
 org.kiwiproject.validation.LongValueValidator
 org.kiwiproject.validation.RequiredValidator
 org.kiwiproject.validation.RangeValidator
+org.kiwiproject.validation.ValidURLValidator

--- a/src/test/java/org/kiwiproject/validation/ValidURLValidatorTest.java
+++ b/src/test/java/org/kiwiproject/validation/ValidURLValidatorTest.java
@@ -1,0 +1,393 @@
+package org.kiwiproject.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.kiwiproject.validation.ValidationTestHelper.assertNoViolations;
+import static org.kiwiproject.validation.ValidationTestHelper.assertOnePropertyViolation;
+import static org.kiwiproject.validation.ValidationTestHelper.assertPropertyViolations;
+
+import jakarta.validation.Validator;
+import lombok.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.UnknownHostException;
+
+@DisplayName("URLValidator")
+@SuppressWarnings("HttpUrlsUsage")
+class ValidURLValidatorTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = KiwiValidations.getValidator();
+    }
+
+    @Nested
+    class ShouldBeValid {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://example.com",
+                "https://example.com",
+                "http://example.com/path",
+                "http://example.com/path?query=value",
+                "http://example.com/path?query=value#fragment",
+                "http://example.com:8080",
+                "http://localhost",
+                "http://127.0.0.1",
+                "http://127.0.0.2",
+                "http://127.255.255.255",
+                "http://192.168.1.1",
+                "https://192.168.1.1",
+                "http://10.0.0.1",
+                "http://172.16.0.1",
+                "http://192.168.1.1:8080",
+                "http://192.168.1.1/path",
+                "http://192.168.1.1/path?query=value",
+                "http://192.168.1.1/path?query=value#fragment",
+                "http://user:password@192.168.1.1",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "http://[2001:db8::1]",
+                "http://[::1]",
+                "http://[2001:db8::1]:8080",
+                "http://[2001:db8::1]/path",
+                "http://[2001:db8::1]/path?query=value",
+                "http://[2001:db8::1]/path?query=value#fragment",
+                "http://user:password@example.com",
+                "http://example.com/path/to/resource.html",
+                "https://example.co.uk",
+                "https://subdomain.example.com"
+        })
+        void whenUrlIsValid(String url) {
+            var object = new UrlObject(url);
+            assertNoViolations(validator, object);
+        }
+
+        @Test
+        void whenAllowingNull_AndValueIsNull() {
+            var object = new AllowNullUrlObject(null);
+            assertNoViolations(validator, object);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "ftp://example.com",
+                "sftp://example.com",
+                "file:///path/to/file",
+                "ldap://ldap.example.org"
+        })
+        void whenAllowingAllSchemes_AndSchemeIsNotHttpOrHttps(String url) {
+            var object = new AllowAllSchemesUrlObject(url);
+            assertNoViolations(validator, object);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "ftp://example.com",
+                "sftp://example.com"
+        })
+        void whenSpecificSchemesAllowed_AndSchemeIsInAllowedList(String url) {
+            var object = new SpecificSchemesUrlObject(url);
+            assertNoViolations(validator, object);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://example.com/api//users",
+                "https://example.com/api//users",
+                "http://example.com:9050/api//users",
+                "https://example.com:951/api//users",
+                "http://10.116.78.128:10050/api//users",
+                "https://10.116.78.128:10051/api//users"
+        })
+        void whenAllowingTwoSlashesInPathComponent(String url) {
+            var object = new AllowTwoSlashesUrlObject(url);
+            assertNoViolations(validator, object);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://example.com",
+                "https://example.com",
+                "http://example.com:8000",
+                "https://example.com:8001",
+                "http://10.116.78.128:9050",
+                "https://10.116.78.128:9051",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]",
+                "https://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"
+        })
+        void whenNotAllowingLocalUrls_AndUrlIsNotLocal(String url) {
+            var object = new NotAllowingLocalUrlsObject(url);
+            assertNoViolations(validator, object);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "file:///etc/hosts",
+                "file:///path/to/file.txt",
+        })
+        void whenNotAllowingLocalUrls_AndSchemeDoesNotRequireHost(String url) {
+            var object = new AllSchemesButNotAllowingLocalUrlsObject(url);
+            assertNoViolations(validator, object);
+        }
+    }
+
+    @Nested
+    class ShouldNotBeValid {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                // General invalid URLs
+                " ",
+                "not-a-url",
+                "http",
+                "http://",
+                "http:/example.com",
+                "http:example.com",
+                "example.com",
+                "://example.com",
+
+                // URLs with schemes other than HTTP or HTTPS (when not allowing all schemes)
+                "ftp://example.com",
+                "sftp://example.com",
+                "file:///path/to/file",
+                "mailto:user@example.com",
+
+                // URLs with authority ending with colon but no port
+                "http://example.com:",
+                "https://example.com:",
+
+                // Invalid IP addresses (IPv4)
+                "http://256.0.0.1",
+                "http://192.168.1.256",
+                "http://192.168.1",
+                "http://192.168.1.1.1",
+                "http://192.168.1.a",
+                "http://192.168.1.-1",
+                "http://192.168.1",
+                "http://192.168..1",
+
+                // Invalid IP addresses (IPv6)
+                "http://2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:73341]",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:733g]",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370]",
+                "http://[2001::85a3::7334]",
+
+                // Invalid IP addresses with port
+                "http://192.168.1.1:65536",
+                "http://192.168.1.1:-1",
+                "http://192.168.1.1:port",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:-1",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:port",
+
+                // URLs with two slashes in the path component
+                "http://10.116.56.42/api//users",
+                "https://10.116.56.42/api//users",
+                "http://example.com/api//users",
+                "https://example.com/api//users"
+        })
+        void whenUrlIsInvalid_ForVariousReasons(String url) {
+            var object = new UrlObject(url);
+            assertOnePropertyViolation(validator, object, "url");
+        }
+
+        @Test
+        void whenNotAllowingNull_AndValueIsNull() {
+            var object = new UrlObject(null);
+            assertPropertyViolations(validator, object, "url", "is not a valid URL");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "ldap://ldap.example.org",
+                "news:comp.lang.java"
+        })
+        void whenSpecificSchemesAllowed_AndSchemeIsNotInAllowedList(String url) {
+            var object = new SpecificSchemesUrlObject(url);
+            assertOnePropertyViolation(validator, object, "url");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://127.0.0.42",
+
+                "http://localhost",
+                "https://localhost",
+                "http://localhost:9090",
+                "https://localhost:9091",
+                "http://localdomain",
+                "https://localdomain",
+                "http://localdomain:9090",
+                "https://localdomain:9091",
+                "http://foo",
+                "https://foo",
+                "http://foo:7070",
+                "https://foo:7071",
+                "http://foo:7070/bar",
+                "https://foo:7071/bar",
+                "http://127.0.0.1",
+                "https://127.0.0.1",
+                "http://127.0.0.1:3000",
+                "https://127.0.0.1:3001",
+                "http://127.0.0.1:3000/app",
+                "https://127.0.0.1:3001/app",
+                "http://127.0.0.2",
+                "http://127.255.255.255",
+                "http://[::1]",
+                "https://[::1]",
+                "http://[::1]:4000",
+                "https://[::1]:4001",
+                "http://[::1]:4000/path",
+                "https://[::1]:4001/path",
+        })
+        void whenNotAllowingLocalUrls_AndUrlIsLocal(String url) {
+            var object = new NotAllowingLocalUrlsObject(url);
+            assertOnePropertyViolation(validator, object, "url");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://example.com#fragment",
+                "https://example.com#fragment",
+                "http://example.com/path#fragment",
+                "https://example.com/path#fragment",
+                "http://example.com:9000/path#fragment",
+                "https://example.com:9001/path#fragment",
+        })
+        void whenNotAllowingFragments_AndUrlContainsFragment(String url) {
+            var object = new NotAllowingFragmentsUrlObject(url);
+            assertOnePropertyViolation(validator, object, "url");
+
+        }
+    }
+
+    @Nested
+    class DirectMethodTests {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://example.com:",
+                "https://example.com:"
+        })
+        void checkEdgeCases_ShouldReturnFalse_WhenAuthorityEndsWithColonButNoPort(String url) {
+            assertThat(ValidURLValidator.checkEdgeCases(url, true)).isFalse();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://example.com",
+                "https://example.com:8080",
+                "http://127.0.0.1",
+                "https://192.168.1.1",
+                "http://10.0.0.1:8080",
+                "http://172.16.0.1/path",
+                "http://[2001:db8::1]",
+                "https://[::1]:8080",
+                "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/path"
+        })
+        void checkEdgeCases_ShouldReturnTrue_WhenUrlIsValid(String url) {
+            assertThat(ValidURLValidator.checkEdgeCases(url, true)).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "http://[invalid",
+                "http://example.com/path[invalid"
+        })
+        void checkEdgeCases_ShouldReturnFalse_WhenUriCannotBeParsed(String url) {
+            assertThat(ValidURLValidator.checkEdgeCases(url, true)).isFalse();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "127.0.0.1",
+                "127.0.0.2",
+                "127.255.255.255",
+                "::1",
+                "[::1]",
+                "localhost"
+        })
+        void checkLoopbackIpAddress_ShouldBeLoopback_WhenHostIsLoopback(String host) {
+            var result = ValidURLValidator.checkLoopbackIpAddress(host);
+            assertAll(
+                    () -> assertThat(result.isLoopback()).isTrue(),
+                    () -> assertThat(result.isLoopbackOrError()).isTrue(),
+                    () -> assertThat(result.isError()).isFalse(),
+                    () -> assertThat(result.error()).isNull()
+            );
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "foo",
+                "bar"
+        })
+        void checkLoopbackIpAddress_ShouldBeError_WhenThrowsException(String host) {
+            var result = ValidURLValidator.checkLoopbackIpAddress(host);
+            assertAll(
+                    () -> assertThat(result.isLoopback()).isFalse(),
+                    () -> assertThat(result.isLoopbackOrError()).isTrue(),
+                    () -> assertThat(result.isError()).isTrue(),
+                    () -> assertThat(result.error()).isExactlyInstanceOf(UnknownHostException.class)
+            );
+        }
+    }
+
+    @Value
+    private static class UrlObject {
+        @ValidURL
+        String url;
+    }
+
+    @Value
+    private static class AllowNullUrlObject {
+        @ValidURL(allowNull = true)
+        String url;
+    }
+
+    @Value
+    private static class AllowAllSchemesUrlObject {
+        @ValidURL(allowAllSchemes = true)
+        String url;
+    }
+
+    @Value
+    private static class SpecificSchemesUrlObject {
+        @ValidURL(allowSchemes = { "http", "https", "ftp", "sftp" })
+        String url;
+    }
+
+    @Value
+    private static class NotAllowingLocalUrlsObject {
+        @ValidURL(allowLocalUrls = false)
+        String url;
+    }
+
+    @Value
+    private static class AllSchemesButNotAllowingLocalUrlsObject {
+        @ValidURL(allowAllSchemes = true, allowLocalUrls = false)
+        String url;
+    }
+
+    @Value
+    private static class AllowTwoSlashesUrlObject {
+        @ValidURL(allowTwoSlashes = true)
+        String url;
+    }
+
+    @Value
+    private static class NotAllowingFragmentsUrlObject {
+        @ValidURL(allowFragments = false)
+        String url;
+    }
+}


### PR DESCRIPTION
* Add ValidURL validation annotation for validating URLs. It allows configuration of the allowed schemes, fragments, and local URLs.
* Add the validation message to ContributorValidationMessages.properties for ValidURL.
* Update jakarta.validation.ConstraintValidator with the validation implementation class for ValidURL.
* Add corresponding ValidURLValidator and tests.
* Add commons-validator dependency with 'provided' scope.

Closes #1257