### PR TITLE
Add new KiwiMaps methods for type-safe value retrieval from maps

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiMaps.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiMaps.java
@@ -6,17 +6,24 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkEvenItemCount;
 import static org.kiwiproject.base.KiwiStrings.f;
 
+import com.google.common.annotations.Beta;
 import lombok.experimental.UtilityClass;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -347,7 +354,438 @@ public class KiwiMaps {
         throw exceptionSupplier.get();
     }
 
-    private static <K, V> void checkMapAndKeyArgsNotNull(Map<K, V> map, K key) {
+    /**
+     * Returns the value associated with the specified key as a String, or null if the key doesn't exist,
+     * or the value is null.
+     * <p>
+     * If the (non-null) value is not a String, it is converted using {@link Object#toString()}.
+     *
+     * @param map the map
+     * @param key the key whose associated value is to be returned as a String
+     * @return the value associated with the key as a String, or null if the key doesn't exist or the value is null
+     */
+    @Nullable
+    public static String getAsStringOrNull(Map<?, ?> map, Object key) {
+        return getAsString(map, key, null);
+    }
+
+    /**
+     * Returns the value associated with the specified key as a String, or the provided default value
+     * if the key doesn't exist or the value is null.
+     * <p>
+     * If the (non-null) value is not a String, it is converted using {@link Object#toString()}.
+     *
+     * @param map          the map
+     * @param key          the key whose associated value is to be returned as a String
+     * @param defaultValue the default value to return if the key doesn't exist or the value is null
+     * @return the value associated with the key as a String, or the default value if the key doesn't exist or the value is null
+     */
+    @Nullable
+    public static String getAsString(Map<?, ?> map, Object key, @Nullable String defaultValue) {
+        return getConvertedValue(map, key, v -> isNull(v) ? defaultValue : v.toString());
+    }
+
+    /**
+     * Returns the value associated with the specified key cast, to the specified type,
+     * or null if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type to cast the value to
+     * @param <T>       the type of the value to be returned
+     * @return the value associated with the key, cast to the specified type, or null if the key doesn't exist or the value is null
+     * @throws MapTypeMismatchException if the value cannot be cast to the specified type
+     */
+    @Nullable
+    public static <T> T getTypedValueOrNull(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedValue(map, key, valueType, null);
+    }
+
+    /**
+     * Returns the value associated with the specified key, cast to the specified type,
+     * or the provided default value if the key doesn't exist or the value is null.
+     *
+     * @param map          the map
+     * @param key          the key whose associated value is to be returned
+     * @param valueType    the class representing the type to cast the value to
+     * @param defaultValue the default value to return if the key doesn't exist or the value is null
+     * @param <T>          the type of the value to be returned
+     * @return the value associated with the key, cast to the specified type, or the default value if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to the specified type
+     */
+    @Nullable
+    public static <T> T getTypedValue(Map<?, ?> map, Object key, Class<T> valueType, @Nullable T defaultValue) {
+        checkMapAndKeyArgsNotNull(map, key);
+        checkValueTypeNotNull(valueType);
+
+        try {
+            return getConvertedValue(map, key, v -> isNull(v) ? defaultValue : valueType.cast(v));
+        } catch (ClassCastException e) {
+            throw MapTypeMismatchException.forTypeMismatch(key, valueType, e);
+        }
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Collection of the specified type,
+     * or null if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type of elements in the collection
+     * @param <T>       the type of elements in the collection
+     * @return the value associated with the key as a Collection of the specified type, or null if
+     * the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Collection
+     * @implNote see implementation note in {@link #getTypedCollection(Map, Object, Class, Collection)}
+     */
+    @Nullable
+    public static <T> Collection<T> getTypedCollectionOrNull(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedCollection(map, key, valueType, null);
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Collection of the specified type,
+     * or an empty Collection if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type of elements in the collection
+     * @param <T>       the type of elements in the collection
+     * @return the value associated with the key as a Collection of the specified type, or an empty Collection
+     * if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Collection
+     * @implNote see implementation note in {@link #getTypedCollection(Map, Object, Class, Collection)}
+     */
+    public static <T> Collection<T> getTypedCollectionOrEmpty(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedCollection(map, key, valueType, List.of());
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Collection of the specified type,
+     * or the provided default value if the key doesn't exist, or the value is null.
+     *
+     * @param map          the map
+     * @param key          the key whose associated value is to be returned
+     * @param valueType    the class representing the type of elements in the collection
+     * @param defaultValue the default value to return if the key doesn't exist or the value is null
+     * @param <T>          the type of elements in the collection
+     * @return the value associated with the key as a Collection of the specified type, or the default value
+     * if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Collection
+     * @implNote Internally this performs an unchecked cast of the value to {@code Collection<T>}. If the
+     * values in the collection are not actually of type {@code T}, a {@code ClassCastException} will
+     * be thrown when the collection is accessed, which may be downstream from the original call site
+     * and therefore be challenging to diagnose the root cause.
+     */
+    @Nullable
+    public static <T> Collection<T> getTypedCollection(Map<?, ?> map,
+                                                       Object key,
+                                                       Class<T> valueType,
+                                                       @Nullable Collection<T> defaultValue) {
+        checkMapAndKeyArgsNotNull(map, key);
+        checkValueTypeNotNull(valueType);
+
+        try {
+            return getConvertedValue(map, key, v -> isNull(v) ? defaultValue : uncheckedCast(v));
+        } catch (ClassCastException e) {
+            throw MapTypeMismatchException.forTypeMismatch(key, Collection.class, e);
+        }
+    }
+
+    /**
+     * Returns the value associated with the specified key as a List of the specified type,
+     * or null if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type of elements in the list
+     * @param <T>       the type of elements in the list
+     * @return the value associated with the key as a List of the specified type, or null if
+     * the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a List
+     * @implNote see implementation note in {@link #getTypedList(Map, Object, Class, List)}
+     */
+    @Nullable
+    public static <T> List<T> getTypedListOrNull(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedList(map, key, valueType, null);
+    }
+
+    /**
+     * Returns the value associated with the specified key as a List of the specified type,
+     * or an empty List if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type of elements in the list
+     * @param <T>       the type of elements in the list
+     * @return the value associated with the key as a List of the specified type, or an empty List
+     * if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a List
+     * @implNote see implementation note in {@link #getTypedList(Map, Object, Class, List)}
+     */
+    public static <T> List<T> getTypedListOrEmpty(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedList(map, key, valueType, List.of());
+    }
+
+    /**
+     * Returns the value associated with the specified key as a List of the specified type,
+     * or the provided default value if the key doesn't exist, or the value is null.
+     *
+     * @param map          the map
+     * @param key          the key whose associated value is to be returned
+     * @param valueType    the class representing the type of elements in the list
+     * @param defaultValue the default value to return if the key doesn't exist or the value is null
+     * @param <T>          the type of elements in the list
+     * @return the value associated with the key as a List of the specified type, or the default value
+     * if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a List
+     * @implNote Internally this performs an unchecked cast of the value to {@code List<T>}. If the
+     * values in the list are not actually of type {@code T}, a {@code ClassCastException} will
+     * be thrown when the list is accessed, which may be downstream from the original call site
+     * and therefore be challenging to diagnose the root cause.
+     */
+    @Nullable
+    public static <T> List<T> getTypedList(Map<?, ?> map,
+                                           Object key,
+                                           Class<T> valueType,
+                                           @Nullable List<T> defaultValue) {
+        checkMapAndKeyArgsNotNull(map, key);
+        checkValueTypeNotNull(valueType);
+
+        try {
+            return getConvertedValue(map, key, v -> isNull(v) ? defaultValue : uncheckedCast(v));
+        } catch (ClassCastException e) {
+            throw MapTypeMismatchException.forTypeMismatch(key, List.class, e);
+        }
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Set of the specified type,
+     * or null if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type of elements in the set
+     * @param <T>       the type of elements in the set
+     * @return the value associated with the key as a Set of the specified type, or null if
+     * the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Set
+     * @implNote see implementation note in {@link #getTypedSet(Map, Object, Class, Set)}
+     */
+    @Nullable
+    public static <T> Set<T> getTypedSetOrNull(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedSet(map, key, valueType, null);
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Set of the specified type,
+     * or an empty Set if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param valueType the class representing the type of elements in the set
+     * @param <T>       the type of elements in the set
+     * @return the value associated with the key as a Set of the specified type, or an empty Set if
+     * the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Set
+     * @implNote see implementation note in {@link #getTypedSet(Map, Object, Class, Set)}
+     */
+    public static <T> Set<T> getTypedSetOrEmpty(Map<?, ?> map, Object key, Class<T> valueType) {
+        return getTypedSet(map, key, valueType, Set.of());
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Set of the specified type,
+     * or the provided default value if the key doesn't exist, or the value is null.
+     *
+     * @param map          the map
+     * @param key          the key whose associated value is to be returned
+     * @param valueType    the class representing the type of elements in the set
+     * @param defaultValue the default value to return if the key doesn't exist or the value is null
+     * @param <T>          the type of elements in the set
+     * @return the value associated with the key as a Set of the specified type, or the default value if
+     * the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Set
+     * @implNote Internally this performs an unchecked cast of the value to {@code Set<T>}. If the
+     * values in the list are not actually of type {@code T}, a {@code ClassCastException} will
+     * be thrown when the set is accessed, which may be downstream from the original call site
+     * and therefore be challenging to diagnose the root cause.
+     */
+    @Nullable
+    public static <T> Set<T> getTypedSet(Map<?, ?> map,
+                                         Object key,
+                                         Class<T> valueType,
+                                         @Nullable Set<T> defaultValue) {
+        checkMapAndKeyArgsNotNull(map, key);
+        checkValueTypeNotNull(valueType);
+
+        try {
+            return getConvertedValue(map, key, v -> isNull(v) ? defaultValue : uncheckedCast(v));
+        } catch (ClassCastException e) {
+            throw MapTypeMismatchException.forTypeMismatch(key, Set.class, e);
+        }
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Map with keys and values of the specified types,
+     * or null if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param keyType   the class representing the type of keys in the returned map
+     * @param valueType the class representing the type of values in the returned map
+     * @param <K>       the type of keys in the returned map
+     * @param <V>       the type of values in the returned map
+     * @return the value associated with the key as a Map with the specified key and value types, or null if
+     * the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, keyType, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Map
+     * @implNote see implementation note in {@link #getTypedMap(Map, Object, Class, Class, Map)}
+     */
+    @Nullable
+    public static <K, V> Map<K, V> getTypedMapOrNull(Map<?, ?> map,
+                                                     Object key,
+                                                     Class<K> keyType,
+                                                     Class<V> valueType) {
+        return getTypedMap(map, key, keyType, valueType, null);
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Map with keys and values of the specified types,
+     * or an empty Map if the key doesn't exist, or the value is null.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param keyType   the class representing the type of keys in the returned map
+     * @param valueType the class representing the type of values in the returned map
+     * @param <K>       the type of keys in the returned map
+     * @param <V>       the type of values in the returned map
+     * @return the value associated with the key as a Map with the specified key and value types, or an empty Map
+     * if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, keyType, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Map
+     * @implNote see implementation note in {@link #getTypedMap(Map, Object, Class, Class, Map)}
+     */
+    public static <K, V> Map<K, V> getTypedMapOrEmpty(Map<?, ?> map,
+                                                      Object key,
+                                                      Class<K> keyType,
+                                                      Class<V> valueType) {
+        return getTypedMap(map, key, keyType, valueType, Map.of());
+    }
+
+    /**
+     * Returns the value associated with the specified key as a Map with keys and values of the specified types,
+     * or the provided default value if the key doesn't exist, or the value is null.
+     *
+     * @param map          the map
+     * @param key          the key whose associated value is to be returned
+     * @param keyType      the class representing the type of keys in the returned map
+     * @param valueType    the class representing the type of values in the returned map
+     * @param defaultValue the default value to return if the key doesn't exist or the value is null
+     * @param <K>          the type of keys in the returned map
+     * @param <V>          the type of values in the returned map
+     * @return the value associated with the key as a Map with the specified key and value types, or the default
+     * value if the key doesn't exist or the value is null
+     * @throws IllegalArgumentException if the map, key, keyType, or valueType is null
+     * @throws MapTypeMismatchException if the value cannot be cast to a Map
+     * @implNote Internally this performs an unchecked cast of the value to {@code Map<K, V>}. If the
+     * keys and values in the map are not actually of type {@code K} and {@code V}, respectively, a
+     * {@code ClassCastException} will be thrown when the map is accessed, which may be downstream from
+     * the original call site and therefore be challenging to diagnose the root cause.
+     */
+    @Nullable
+    public static <K, V> Map<K, V> getTypedMap(Map<?, ?> map,
+                                               Object key,
+                                               Class<K> keyType,
+                                               Class<V> valueType,
+                                               @Nullable Map<K, V> defaultValue) {
+        checkMapAndKeyArgsNotNull(map, key);
+        checkArgumentNotNull(keyType, "keyType must not be null");
+        checkValueTypeNotNull(valueType);
+
+        try {
+            return getConvertedValue(map, key, v -> isNull(v) ? defaultValue : uncheckedCast(v));
+        } catch (ClassCastException e) {
+            throw MapTypeMismatchException.forTypeMismatch(key, Map.class, e);
+        }
+    }
+
+    private static <V> void checkValueTypeNotNull(Class<V> valueType) {
+        checkArgumentNotNull(valueType, "valueType must not be null");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T uncheckedCast(Object object) {
+        return (T) object;
+    }
+
+    /**
+     * Returns the value associated with the specified key, converted using the provided converter function.
+     * <p>
+     * This method is marked as {@link Beta} and may change in future releases.
+     *
+     * @param map       the map
+     * @param key       the key whose associated value is to be returned
+     * @param converter a function that converts the value to the desired type
+     * @param <T>       the type of the value to be returned
+     * @return the value associated with the key, converted using the provided converter function
+     * @throws IllegalArgumentException if the map, key, or converter is null
+     */
+    @Beta
+    @Nullable
+    public static <T> T getConvertedValue(Map<?, ?> map, Object key, Function<Object, T> converter) {
+        checkMapAndKeyArgsNotNull(map, key);
+        checkArgumentNotNull(converter, "converter function must not be null");
+
+        var v = map.getOrDefault(key, null);
+        return converter.apply(v);
+    }
+
+    /**
+     * Returns the value associated with the specified key, converted using the provided converter function.
+     * If the conversion fails with an exception, the fallback converter is used to provide an alternative value.
+     * <p>
+     * This method is marked as {@link Beta} and may change in future releases.
+     *
+     * @param map               the map
+     * @param key               the key whose associated value is to be returned
+     * @param converter         a function that converts the value to the desired type
+     * @param fallbackConverter a function that provides a fallback value when the primary converter throws an exception
+     * @param <T>               the type of the value to be returned
+     * @return the value associated with the key, converted using the provided converter function,
+     * or the result of the fallback converter if the primary conversion fails
+     * @throws IllegalArgumentException if the map, key, converter, or fallbackConverter is null
+     */
+    @Beta
+    @Nullable
+    public static <T> T getConvertedValueWithFallback(Map<?, ?> map,
+                                                      Object key,
+                                                      Function<Object, T> converter,
+                                                      BiFunction<Object, Exception, T> fallbackConverter) {
+
+        checkMapAndKeyArgsNotNull(map, key);
+        checkArgumentNotNull(converter, "converter function must not be null");
+        checkArgumentNotNull(fallbackConverter, "fallbackConverter must not be null");
+
+        var v = map.getOrDefault(key, null);
+        try {
+            return converter.apply(v);
+        } catch (Exception e) {
+            return fallbackConverter.apply(v, e);
+        }
+    }
+
+    private static void checkMapAndKeyArgsNotNull(Map<?, ?> map, Object key) {
         checkArgumentNotNull(map, "map must not be null");
         checkArgumentNotNull(key, "key must not be null");
     }

--- a/src/main/java/org/kiwiproject/collect/MapTypeMismatchException.java
+++ b/src/main/java/org/kiwiproject/collect/MapTypeMismatchException.java
@@ -1,0 +1,58 @@
+package org.kiwiproject.collect;
+
+import static org.kiwiproject.base.KiwiStrings.f;
+
+/**
+ * Exception thrown when a value in a {@link java.util.Map} cannot be cast to the expected type.
+ */
+public class MapTypeMismatchException extends RuntimeException {
+
+    /**
+     * Constructs a new instance with no detail message.
+     */
+    public MapTypeMismatchException() {
+    }
+
+    /**
+     * Constructs a new instance with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public MapTypeMismatchException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new instance with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public MapTypeMismatchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new instance with the specified cause and a detail message
+     * of {@code (cause==null ? null : cause.toString())}.
+     *
+     * @param cause the cause
+     */
+    public MapTypeMismatchException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Factory method to create a new instance with a standardized message for a type mismatch.
+     *
+     * @param key       the map key whose value could not be cast to the expected type
+     * @param valueType the expected type of the value
+     * @param cause     the ClassCastException that occurred during the cast attempt
+     * @return a new instance with a descriptive message
+     */
+    public static MapTypeMismatchException forTypeMismatch(Object key, Class<?> valueType, ClassCastException cause) {
+        return new MapTypeMismatchException(
+                f("Cannot cast value for key '{}' to type {}", key, valueType.getName()),
+                cause);
+    }
+}

--- a/src/test/java/org/kiwiproject/collect/KiwiMapsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiMapsTest.java
@@ -25,10 +25,12 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -580,6 +582,898 @@ class KiwiMapsTest {
 
         @StandardException
         static class MyException extends Exception {
+        }
+    }
+
+    @Nested
+    class GetAsStringOrNull {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getAsStringOrNull(null, "aKey")),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getAsStringOrNull(Map.of("count", 42), null))
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", 1, "b", 2);
+            assertThat(KiwiMaps.getAsStringOrNull(map, "c")).isNull();
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", 12);
+            assertThat(KiwiMaps.getAsStringOrNull(map, "a")).isNull();
+        }
+
+        @Test
+        void shouldReturnValue_WhenItIsString() {
+            var map = Map.of(1, "a", 2, "b", 3, "c");
+            assertThat(KiwiMaps.getAsStringOrNull(map, 2)).isEqualTo("b");
+        }
+
+        @Test
+        void shouldReturnValueAsString_WhenItIsNotString() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            assertThat(KiwiMaps.getAsStringOrNull(map, "c")).isEqualTo("3");
+        }
+    }
+
+    @Nested
+    class GetAsString {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getAsString(null, "aKey", "theDefault")),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getAsString(Map.of("count", 42), null, "theDefault"))
+            );
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", 1, "b", 2);
+            var defaultValue = "42";
+            assertThat(KiwiMaps.getAsString(map, "c", defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", 12);
+            var defaultValue = "84";
+            assertThat(KiwiMaps.getAsString(map, "a", defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnValue_WhenItIsString() {
+            var map = Map.of(1, "a", 2, "b", 3, "c");
+            var defaultValue = "z";
+            assertThat(KiwiMaps.getAsString(map, 3, defaultValue)).isEqualTo("c");
+        }
+
+        @Test
+        void shouldReturnValueAsString_WhenItIsNotString() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var defaultValue = "z";
+            assertThat(KiwiMaps.getAsString(map, "b", defaultValue)).isEqualTo("2");
+        }
+    }
+
+    @Nested
+    class GetTypedValueOrNull {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedValueOrNull(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedValueOrNull(Map.of("count", 42L), null, Long.class))
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", 1, "b", 2);
+            assertThat(KiwiMaps.getTypedValueOrNull(map, "c", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", 12L);
+            assertThat(KiwiMaps.getTypedValueOrNull(map, "a", Long.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnValue_WhenItExists() {
+            var map = Map.of(1, "a", 2, "b", 3, "c");
+            assertThat(KiwiMaps.getTypedValueOrNull(map, 2, String.class)).isEqualTo("b");
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not an integer", "b", "also not an integer");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedValueOrNull(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.lang.Integer")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedValue {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedValue(null, "aKey", Integer.class, 84)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedValue(Map.of("count", 42L), null, Long.class, 126L))
+            );
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var defaultValue = 42;
+            assertThat(KiwiMaps.getTypedValue(map, "d", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", 12);
+            var defaultValue = 84;
+            assertThat(KiwiMaps.getTypedValue(map, "a", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var defaultValue = 84;
+            assertThat(KiwiMaps.getTypedValue(map, "c", Integer.class, defaultValue)).isEqualTo(3);
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not an integer", "b", "also not an integer");
+            var defaultValue = 42;
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedValue(map, "a", Integer.class, defaultValue))
+                    .withMessage("Cannot cast value for key 'a' to type java.lang.Integer")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedCollection {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollection(null, "aKey", Integer.class, List.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollection(Map.of("items", List.of(1, 2, 3)), null, Integer.class, List.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollection(Map.of("items", List.of(1, 2, 3)), "items", null, List.of()))
+            );
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            var defaultValue = List.of(7, 8, 9);
+            assertThat(KiwiMaps.getTypedCollection(map, "c", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", List.of(1, 2, 3));
+            var defaultValue = List.of(4, 5, 6);
+            assertThat(KiwiMaps.getTypedCollection(map, "a", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            var defaultValue = List.of(7, 8, 9);
+            assertThat(KiwiMaps.getTypedCollection(map, "a", Integer.class, defaultValue)).isEqualTo(List.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a collection", "b", "also not a collection");
+            var defaultValue = List.of(1, 2, 3);
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedCollection(map, "a", Integer.class, defaultValue))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Collection")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedCollectionOrNull {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollectionOrNull(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollectionOrNull(Map.of("items", List.of(1, 2, 3)), null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollectionOrNull(Map.of("items", List.of(1, 2, 3)), "items", null))
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedCollectionOrNull(map, "c", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", List.of(1, 2, 3));
+            assertThat(KiwiMaps.getTypedCollectionOrNull(map, "a", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedCollectionOrNull(map, "a", Integer.class)).isEqualTo(List.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a collection", "b", "also not a collection");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedCollectionOrNull(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Collection")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedCollectionOrEmpty {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollectionOrEmpty(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollectionOrEmpty(Map.of("items", List.of(1, 2, 3)), null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedCollectionOrEmpty(Map.of("items", List.of(1, 2, 3)), "items", null))
+            );
+        }
+
+        @Test
+        void shouldReturnEmptyCollection_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedCollectionOrEmpty(map, "c", Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyCollection_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", List.of(1, 2, 3));
+            assertThat(KiwiMaps.getTypedCollectionOrEmpty(map, "a", Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedCollectionOrEmpty(map, "a", Integer.class)).isEqualTo(List.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a collection", "b", "also not a collection");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedCollectionOrEmpty(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Collection")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedList {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedList(null, "aKey", Integer.class, List.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedList(Map.of("items", List.of(1, 2, 3)), null, Integer.class, List.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedList(Map.of("items", List.of(1, 2, 3)), "items", null, List.of()))
+            );
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            var defaultValue = List.of(7, 8, 9);
+            assertThat(KiwiMaps.getTypedList(map, "c", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", List.of(1, 2, 3));
+            var defaultValue = List.of(4, 5, 6);
+            assertThat(KiwiMaps.getTypedList(map, "a", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            var defaultValue = List.of(7, 8, 9);
+            assertThat(KiwiMaps.getTypedList(map, "a", Integer.class, defaultValue)).isEqualTo(List.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a list", "b", "also not a list");
+            var defaultValue = List.of(1, 2, 3);
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedList(map, "a", Integer.class, defaultValue))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.List")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedListOrNull {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedListOrNull(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedListOrNull(Map.of("items", List.of(1, 2, 3)), null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedListOrNull(Map.of("items", List.of(1, 2, 3)), "items", null))
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedListOrNull(map, "c", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", List.of(1, 2, 3));
+            assertThat(KiwiMaps.getTypedListOrNull(map, "a", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedListOrNull(map, "a", Integer.class)).isEqualTo(List.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a list", "b", "also not a list");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedListOrNull(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.List")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedListOrEmpty {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedListOrEmpty(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedListOrEmpty(Map.of("items", List.of(1, 2, 3)), null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedListOrEmpty(Map.of("items", List.of(1, 2, 3)), "items", null))
+            );
+        }
+
+        @Test
+        void shouldReturnEmptyList_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedListOrEmpty(map, "c", Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyList_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", List.of(1, 2, 3));
+            assertThat(KiwiMaps.getTypedListOrEmpty(map, "a", Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", List.of(1, 2, 3), "b", List.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedListOrEmpty(map, "a", Integer.class)).isEqualTo(List.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a list", "b", "also not a list");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedListOrEmpty(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.List")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedSet {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSet(null, "aKey", Integer.class, Set.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSet(Map.of("items", Set.of(1, 2, 3)), null, Integer.class, Set.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSet(Map.of("items", Set.of(1, 2, 3)), "items", null, Set.of()))
+            );
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", Set.of(1, 2, 3), "b", Set.of(4, 5, 6));
+            var defaultValue = Set.of(7, 8, 9);
+            assertThat(KiwiMaps.getTypedSet(map, "c", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", Set.of(1, 2, 3));
+            var defaultValue = Set.of(4, 5, 6);
+            assertThat(KiwiMaps.getTypedSet(map, "a", Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", Set.of(1, 2, 3), "b", Set.of(4, 5, 6));
+            var defaultValue = Set.of(7, 8, 9);
+            assertThat(KiwiMaps.getTypedSet(map, "a", Integer.class, defaultValue)).isEqualTo(Set.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a set", "b", "also not a set");
+            var defaultValue = Set.of(1, 2, 3);
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedSet(map, "a", Integer.class, defaultValue))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Set")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedSetOrNull {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSetOrNull(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSetOrNull(Map.of("items", Set.of(1, 2, 3)), null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSetOrNull(Map.of("items", Set.of(1, 2, 3)), "items", null))
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", Set.of(1, 2, 3), "b", Set.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedSetOrNull(map, "c", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", Set.of(1, 2, 3));
+            assertThat(KiwiMaps.getTypedSetOrNull(map, "a", Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", Set.of(1, 2, 3), "b", Set.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedSetOrNull(map, "a", Integer.class)).isEqualTo(Set.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a set", "b", "also not a set");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedSetOrNull(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Set")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedSetOrEmpty {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSetOrEmpty(null, "aKey", Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSetOrEmpty(Map.of("items", Set.of(1, 2, 3)), null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedSetOrEmpty(Map.of("items", Set.of(1, 2, 3)), "items", null))
+            );
+        }
+
+        @Test
+        void shouldReturnEmptySet_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", Set.of(1, 2, 3), "b", Set.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedSetOrEmpty(map, "c", Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptySet_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", Set.of(1, 2, 3));
+            assertThat(KiwiMaps.getTypedSetOrEmpty(map, "a", Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var map = Map.of("a", Set.of(1, 2, 3), "b", Set.of(4, 5, 6));
+            assertThat(KiwiMaps.getTypedSetOrEmpty(map, "a", Integer.class)).isEqualTo(Set.of(1, 2, 3));
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a set", "b", "also not a set");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedSetOrEmpty(map, "a", Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Set")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedMap {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMap(null, "aKey", String.class, Integer.class, Map.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMap(Map.of("items", Map.of("a", 1, "b", 2)), null, String.class, Integer.class, Map.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMap(Map.of("items", Map.of("a", 1, "b", 2)), "items", null, Integer.class, Map.of())),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMap(Map.of("items", Map.of("a", 1, "b", 2)), "items", String.class, null, Map.of()))
+            );
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", Map.of("x", 1, "y", 2), "b", Map.of("p", 3, "q", 4));
+            var defaultValue = Map.of("default", 42);
+            assertThat(KiwiMaps.getTypedMap(map, "c", String.class, Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnDefaultValue_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", Map.of("p", 3, "q", 4));
+            var defaultValue = Map.of("default", 42);
+            assertThat(KiwiMaps.getTypedMap(map, "a", String.class, Integer.class, defaultValue)).isEqualTo(defaultValue);
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var nestedMap = Map.of("x", 1, "y", 2);
+            var map = Map.of("a", nestedMap, "b", Map.of("p", 3, "q", 4));
+            var defaultValue = Map.of("default", 42);
+            assertThat(KiwiMaps.getTypedMap(map, "a", String.class, Integer.class, defaultValue)).isEqualTo(nestedMap);
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a map", "b", "also not a map");
+            var defaultValue = Map.of("default", 42);
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedMap(map, "a", String.class, Integer.class, defaultValue))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Map")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedMapOrNull {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrNull(null, "aKey", String.class, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrNull(Map.of("items", Map.of("a", 1, "b", 2)), null, String.class, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrNull(Map.of("items", Map.of("a", 1, "b", 2)), "items", null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrNull(Map.of("items", Map.of("a", 1, "b", 2)), "items", String.class, null))
+            );
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", Map.of("x", 1, "y", 2), "b", Map.of("p", 3, "q", 4));
+            assertThat(KiwiMaps.getTypedMapOrNull(map, "c", String.class, Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnNull_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", Map.of("p", 3, "q", 4));
+            assertThat(KiwiMaps.getTypedMapOrNull(map, "a", String.class, Integer.class)).isNull();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var nestedMap = Map.of("x", 1, "y", 2);
+            var map = Map.of("a", nestedMap, "b", Map.of("p", 3, "q", 4));
+            assertThat(KiwiMaps.getTypedMapOrNull(map, "a", String.class, Integer.class)).isEqualTo(nestedMap);
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a map", "b", "also not a map");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedMapOrNull(map, "a", String.class, Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Map")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetTypedMapOrEmpty {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrEmpty(null, "aKey", String.class, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrEmpty(Map.of("items", Map.of("a", 1, "b", 2)), null, String.class, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrEmpty(Map.of("items", Map.of("a", 1, "b", 2)), "items", null, Integer.class)),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getTypedMapOrEmpty(Map.of("items", Map.of("a", 1, "b", 2)), "items", String.class, null))
+            );
+        }
+
+        @Test
+        void shouldReturnEmptyMap_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", Map.of("x", 1, "y", 2), "b", Map.of("p", 3, "q", 4));
+            assertThat(KiwiMaps.getTypedMapOrEmpty(map, "c", String.class, Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnEmptyMap_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", Map.of("p", 3, "q", 4));
+            assertThat(KiwiMaps.getTypedMapOrEmpty(map, "a", String.class, Integer.class)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnValue_WhenMapContainsKeyOfExpectedType() {
+            var nestedMap = Map.of("x", 1, "y", 2);
+            var map = Map.of("a", nestedMap, "b", Map.of("p", 3, "q", 4));
+            assertThat(KiwiMaps.getTypedMapOrEmpty(map, "a", String.class, Integer.class)).isEqualTo(nestedMap);
+        }
+
+        @Test
+        void shouldThrowMapTypeMismatchException_WhenCastFails() {
+            var map = Map.of("a", "not a map", "b", "also not a map");
+
+            assertThatExceptionOfType(MapTypeMismatchException.class)
+                    .isThrownBy(() -> KiwiMaps.getTypedMapOrEmpty(map, "a", String.class, Integer.class))
+                    .withMessage("Cannot cast value for key 'a' to type java.util.Map")
+                    .withCauseExactlyInstanceOf(ClassCastException.class);
+        }
+    }
+
+    @Nested
+    class GetConvertedValue {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getConvertedValue(null, "aKey", Object::toString))
+                            .withMessage("map must not be null"),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getConvertedValue(Map.of("count", 42L), null, Object::toString))
+                            .withMessage("key must not be null"),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getConvertedValue(Map.of("count", 42L), "count", null))
+                            .withMessage("converter function must not be null")
+            );
+        }
+
+        @Test
+        void shouldApplyConverter_WhenMapContainsKey() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var result = KiwiMaps.getConvertedValue(map, "b", value -> "Number: " + value);
+            assertThat(result).isEqualTo("Number: 2");
+        }
+
+        @Test
+        void shouldApplyConverter_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var result = KiwiMaps.getConvertedValue(map, "d", value -> value == null ? "Key not found" : value.toString());
+            assertThat(result).isEqualTo("Key not found");
+        }
+
+        @Test
+        void shouldApplyConverter_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", 12);
+            var result = KiwiMaps.getConvertedValue(map, "a", value -> value == null ? "NULL" : value.toString());
+            assertThat(result).isEqualTo("NULL");
+        }
+
+        @Test
+        void shouldPropagateException_WhenConverterThrows() {
+            var map = Map.of("a", "not a number", "b", "also not a number");
+
+            assertThatThrownBy(() -> KiwiMaps.getConvertedValue(map, "a", value -> Integer.parseInt(value.toString())))
+                    .isInstanceOf(NumberFormatException.class)
+                    .hasMessageContaining("For input string: \"not a number\"");
+        }
+    }
+
+    @Nested
+    class GetConvertedValueWithFallback {
+
+        @Test
+        void shouldRequireArguments() {
+            assertAll(
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getConvertedValueWithFallback(null, "aKey", Object::toString, (v, e) -> "fallback"))
+                            .withMessage("map must not be null"),
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getConvertedValueWithFallback(Map.of("count", 42L), null, Object::toString, (v, e) -> "fallback"))
+                            .withMessage("key must not be null"),
+                    () -> {
+                        Function<Object, String> nullConverter = null;
+                        //noinspection ConstantValue
+                        assertThatIllegalArgumentException()
+                                .isThrownBy(() -> KiwiMaps.getConvertedValueWithFallback(Map.of("count", 42L), "count", nullConverter, (v, e) -> "fallback"))
+                                .withMessage("converter function must not be null");
+                    },
+                    () -> assertThatIllegalArgumentException()
+                            .isThrownBy(() -> KiwiMaps.getConvertedValueWithFallback(Map.of("count", 42L), "count", Object::toString, null))
+                            .withMessage("fallbackConverter must not be null")
+            );
+        }
+
+        @Test
+        void shouldApplyConverter_WhenMapContainsKey() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var result = KiwiMaps.getConvertedValueWithFallback(map, "b",
+                    value -> "Number: " + value,
+                    (value, ex) -> "Fallback: " + value);
+            assertThat(result).isEqualTo("Number: 2");
+        }
+
+        @Test
+        void shouldApplyConverter_WhenMapDoesNotContainKey() {
+            var map = Map.of("a", 1, "b", 2, "c", 3);
+            var result = KiwiMaps.getConvertedValueWithFallback(map, "d",
+                    value -> value == null ? "Key not found" : value.toString(),
+                    (value, ex) -> "Fallback: " + value);
+            assertThat(result).isEqualTo("Key not found");
+        }
+
+        @Test
+        void shouldApplyConverter_WhenMapContainsNullValueForKey() {
+            var map = KiwiMaps.newHashMap("a", null, "b", 12);
+            var result = KiwiMaps.getConvertedValueWithFallback(map, "a",
+                    value -> value == null ? "NULL" : value.toString(),
+                    (value, ex) -> "Fallback: " + value);
+            assertThat(result).isEqualTo("NULL");
+        }
+
+        @Test
+        void shouldApplyFallbackConverter_WhenConverterThrows() {
+            var map = Map.of("a", "not a number", "b", "also not a number");
+
+            var result = KiwiMaps.getConvertedValueWithFallback(map, "a",
+                    value -> Integer.parseInt(value.toString()),
+                    (value, ex) -> 42);
+
+            assertThat(result).isEqualTo(42);
+        }
+
+        @Test
+        void shouldIncludeExceptionInFallback() {
+            var map = Map.of("a", "not a number", "b", "also not a number");
+
+            var result = KiwiMaps.getConvertedValueWithFallback(map, "a",
+                    value -> Integer.parseInt(value.toString()),
+                    (value, ex) -> ex instanceof NumberFormatException ? 84 : 42);
+
+            assertThat(result).isEqualTo(84);
+        }
+
+        @Test
+        void shouldHandleComplexConversionScenario() {
+            var map = KiwiMaps.newHashMap(
+                    "validInt", "42",
+                    "invalidInt", "not a number",
+                    "nullValue", null
+            );
+
+            assertAll(
+                    () -> {
+                        var validResult = KiwiMaps.getConvertedValueWithFallback(map, "validInt",
+                                value -> Integer.parseInt(value.toString()),
+                                (value, ex) -> -1);
+                        assertThat(validResult)
+                                .describedAs("valid values should be converted")
+                                .isEqualTo(42);
+                    },
+
+                    () -> {
+                        var invalidResult = KiwiMaps.getConvertedValueWithFallback(map, "invalidInt",
+                                value -> Integer.parseInt(value.toString()),
+                                (value, ex) -> -1);
+                        assertThat(invalidResult)
+                                .describedAs("invalid values should be converted using fallback")
+                                .isEqualTo(-1);
+                    },
+
+                    () -> {
+                        var nullResult = KiwiMaps.getConvertedValueWithFallback(map, "nullValue",
+                                value -> value == null ? 0 : Integer.parseInt(value.toString()),
+                                (value, ex) -> -1);
+                        assertThat(nullResult)
+                                .describedAs("null values should be handled by converter")
+                                .isZero();
+                    },
+
+                    () -> {
+                        var missingResult = KiwiMaps.getConvertedValueWithFallback(map, "nonExistent",
+                                value -> value == null ? 0 : Integer.parseInt(value.toString()),
+                                (value, ex) -> -1);
+                        assertThat(missingResult)
+                                .describedAs("missing keys should be handled by fallback")
+                                .isZero();
+                    }
+            );
         }
     }
 }

--- a/src/test/java/org/kiwiproject/collect/MapTypeMismatchExceptionTest.java
+++ b/src/test/java/org/kiwiproject/collect/MapTypeMismatchExceptionTest.java
@@ -1,0 +1,58 @@
+package org.kiwiproject.collect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MapTypeMismatchException")
+class MapTypeMismatchExceptionTest {
+
+    @Test
+    void shouldConstructWithNoArgs() {
+        var ex = new MapTypeMismatchException();
+        
+        assertThat(ex.getMessage()).isNull();
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void shouldConstructWithMessage() {
+        var message = "Cannot cast map value";
+        var ex = new MapTypeMismatchException(message);
+        
+        assertThat(ex.getMessage()).isEqualTo(message);
+        assertThat(ex.getCause()).isNull();
+    }
+
+    @Test
+    void shouldConstructWithMessageAndCause() {
+        var message = "Cannot cast map value";
+        var cause = new ClassCastException("Cannot cast String to Integer");
+        var ex = new MapTypeMismatchException(message, cause);
+        
+        assertThat(ex.getMessage()).isEqualTo(message);
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void shouldConstructWithCause() {
+        var cause = new ClassCastException("Cannot cast String to Integer");
+        var ex = new MapTypeMismatchException(cause);
+        
+        assertThat(ex.getMessage()).contains(cause.toString());
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void shouldCreateForTypeMismatchWithKeyAndValueTypeAndCause() {
+        var key = "count";
+        var valueType = Integer.class;
+        var cause = new ClassCastException("Cannot cast String to Integer");
+        
+        var ex = MapTypeMismatchException.forTypeMismatch(key, valueType, cause);
+        
+        assertThat(ex.getMessage()).isEqualTo("Cannot cast value for key 'count' to type java.lang.Integer");
+        assertThat(ex.getCause()).isSameAs(cause);
+    }
+}


### PR DESCRIPTION
- Introduced `MapTypeMismatchException` to handle type mismatch scenarios when casting map values.
- Added new utility methods in `KiwiMaps` for safely retrieving typed values, collections, lists, and maps from a map.
- Added overloads for retrieving string, typed values, collections, lists, and maps with null or default values.

Closes #1258
Closes #1259
Closes #1260
Closes #1261 
Closes #1262
Closes #1263
Closes #1264
Closes #1265
Closes #1266
Closes #1267
Closes #1268
Closes #1269
Closes #1270
Closes #1271
Closes #1272
Closes #1273
Closes #1274
Closes #1275
Closes #1276