### PR TITLE
Updates to WebTargetHelper query parameter filtering

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
+++ b/src/main/java/org/kiwiproject/jaxrs/client/WebTargetHelper.java
@@ -19,6 +19,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.UriBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -141,13 +142,15 @@ public class WebTargetHelper implements WebTarget {
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return a new instance if {@code name} is not blank and {@code values} is not null or empty, otherwise this instance
+     * @see #queryParamFilterListNotNull(String, List)
+     * @see #queryParamFilterStreamNotNull(String, Stream)
      */
     public WebTargetHelper queryParamFilterNotNull(String name, Object... values) {
         if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
         }
 
-        return queryParamFilterNotNull(name, Arrays.stream(values));
+        return queryParamFilterStreamNotNull(name, Arrays.stream(values));
     }
 
     /**
@@ -156,7 +159,13 @@ public class WebTargetHelper implements WebTarget {
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return a new instance if {@code name} is not blank and {@code values} is not null or empty, otherwise this instance
+     * @deprecated use {@link #queryParamFilterListNotNull(String, List)}
      */
+    @Deprecated(since = "4.10.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "#queryParamFilterListNotNull(String name, List<?> values)",
+            removeAt = "5.0.0"
+    )
     public WebTargetHelper queryParamFilterNotNull(String name, List<Object> values) {
         if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
@@ -169,10 +178,51 @@ public class WebTargetHelper implements WebTarget {
      * Adds any non-null values to the given query parameter. If {@code name} is blank, this is a no-op.
      *
      * @param name   the parameter name
+     * @param values one or more parameter values
+     * @return a new instance if {@code name} is not blank and {@code values} is not null or empty, otherwise this instance
+     */
+    public WebTargetHelper queryParamFilterListNotNull(String name, List<?> values) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterStreamNotNull(name, values.stream());
+    }
+
+    /**
+     * Adds any non-null values to the given query parameter. If {@code name} is blank, this is a no-op.
+     *
+     * @param name   the parameter name
+     * @param stream containing one or more parameter values
+     * @return a new instance if {@code name} is not blank and {@code stream} is not null, otherwise this instance
+     * @deprecated use {@link #queryParamFilterStreamNotNull(String, Stream)}
+     */
+    @Deprecated(since = "4.10.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "#queryParamFilterStreamNotNull(String name, Stream<?> stream)",
+            removeAt = "5.0.0"
+    )
+    public WebTargetHelper queryParamFilterNotNull(String name, Stream<Object> stream) {
+        if (isBlank(name) || isNull(stream)) {
+            return this;
+        }
+
+        var nonNullValues = stream
+                .filter(Objects::nonNull)
+                .toArray();
+
+        var newWebTarget = webTarget.queryParam(name, nonNullValues);
+        return new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Adds any non-null values to the given query parameter. If {@code name} is blank, this is a no-op.
+     *
+     * @param name   the parameter name
      * @param stream containing one or more parameter values
      * @return a new instance if {@code name} is not blank and {@code stream} is not null, otherwise this instance
      */
-    public WebTargetHelper queryParamFilterNotNull(String name, Stream<Object> stream) {
+    public WebTargetHelper queryParamFilterStreamNotNull(String name, Stream<?> stream) {
         if (isBlank(name) || isNull(stream)) {
             return this;
         }
@@ -223,13 +273,37 @@ public class WebTargetHelper implements WebTarget {
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return a new instance if {@code name} is not blank and {@code values} is not null or empty, otherwise this instance
+     * @see #queryParamFilterObjectsNotBlank(String, Object...)
+     * @see #queryParamFilterListNotBlank(String, List)
+     * @see #queryParamFilterStreamNotBlank(String, Stream)
      */
     public WebTargetHelper queryParamFilterNotBlank(String name, String... values) {
         if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
         }
 
-        return queryParamFilterNotBlank(name, Arrays.stream(values));
+        return queryParamFilterStreamNotBlank(name, Arrays.stream(values));
+    }
+
+    /**
+     * Adds non-blank query parameters, converting each object to a string if necessary.
+     * <p>
+     * Any {@code null} or blank string values are ignored.
+     * Non-{@link CharSequence} objects are converted using {@link Object#toString()}.
+     *
+     * @param name   the query parameter name
+     * @param values the values to filter and add
+     * @return a new instance with updated query parameters, or this instance if input is empty or invalid
+     * @see #queryParamFilterNotBlank(String, String...)
+     * @see #queryParamFilterListNotBlank(String, List)
+     * @see #queryParamFilterStreamNotBlank(String, Stream)
+     */
+    public WebTargetHelper queryParamFilterObjectsNotBlank(String name, Object... values) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterStreamNotBlank(name, Arrays.stream(values));
     }
 
     /**
@@ -238,7 +312,13 @@ public class WebTargetHelper implements WebTarget {
      * @param name   the parameter name
      * @param values one or more parameter values
      * @return a new instance if {@code name} is not blank and {@code values} is not null or empty, otherwise this instance
+     * @deprecated use {@link #queryParamFilterListNotBlank(String, List)}
      */
+    @Deprecated(since = "4.10.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "#queryParamFilterListNotBlank(String name, List<String> values)",
+            removeAt = "5.0.0"
+    )
     public WebTargetHelper queryParamFilterNotBlank(String name, List<String> values) {
         if (isBlank(name) || isNullOrEmpty(values)) {
             return this;
@@ -251,15 +331,58 @@ public class WebTargetHelper implements WebTarget {
      * Adds any non-blank values to the given query parameter. If {@code name} is blank, this is a no-op.
      *
      * @param name   the parameter name
+     * @param values one or more parameter values
+     * @return a new instance if {@code name} is not blank and {@code values} is not null or empty, otherwise this instance
+     */
+    public WebTargetHelper queryParamFilterListNotBlank(String name, List<?> values) {
+        if (isBlank(name) || isNullOrEmpty(values)) {
+            return this;
+        }
+
+        return queryParamFilterStreamNotBlank(name, values.stream());
+    }
+
+    /**
+     * Adds any non-blank values to the given query parameter. If {@code name} is blank, this is a no-op.
+     *
+     * @param name   the parameter name
      * @param stream containing one or more parameter values
      * @return a new instance if {@code name} is not blank and {@code stream} is not null, otherwise this instance
+     * @deprecated use {@link #queryParamFilterStreamNotBlank(String, Stream)}
      */
+    @Deprecated(since = "4.10.0", forRemoval = true)
+    @KiwiDeprecated(
+            replacedBy = "queryParamFilterStreamNotBlank(String name, Stream<String> stream)",
+            removeAt = "5.0.0"
+    )
     public WebTargetHelper queryParamFilterNotBlank(String name, Stream<String> stream) {
         if (isBlank(name) || isNull(stream)) {
             return this;
         }
 
         var nonBlankValues = stream
+                .filter(StringUtils::isNotBlank)
+                .toArray();
+
+        var newWebTarget = webTarget.queryParam(name, nonBlankValues);
+        return new WebTargetHelper(newWebTarget);
+    }
+
+    /**
+     * Adds any non-blank values to the given query parameter. If {@code name} is blank, this is a no-op.
+     *
+     * @param name   the parameter name
+     * @param stream containing one or more parameter values
+     * @return a new instance if {@code name} is not blank and {@code stream} is not null, otherwise this instance
+     */
+    public WebTargetHelper queryParamFilterStreamNotBlank(String name, Stream<?> stream) {
+        if (isBlank(name) || isNull(stream)) {
+            return this;
+        }
+
+        var nonBlankValues = stream
+                .filter(Objects::nonNull)
+                .map(o -> o instanceof CharSequence cs ? cs : o.toString())
                 .filter(StringUtils::isNotBlank)
                 .toArray();
 
@@ -313,24 +436,18 @@ public class WebTargetHelper implements WebTarget {
      * @implNote See implementation note on {@link #queryParamsFromMap(Map)} for an explanation why this method is
      * named separately and distinctly.
      */
-    @SuppressWarnings({"unchecked"})
     public <V> WebTargetHelper queryParamsFromMultivaluedMap(MultivaluedMap<String, V> parameters) {
         if (isNull(parameters) || parameters.isEmpty()) {
             return this;
         }
 
         // NOTES:
-        // 1. This is effectively a 'foldLeft', which Java Streams does not have. See explanation in the method above.
-        // 2. To properly support the generic V type parameter, we unfortunately have to cast the entry value to
-        //    List<Object> to get the compiler to call queryParamFilterNotNull(String, List<Object>). If
-        //    the cast is not done, the compiler instead "thinks" the value is an Object and selects the
-        //    queryParamFilterNotNull(String, Object...) method, which does not work as expected because the value
-        //    of the MultivaluedMap is supposed to be a List<V>. The real reason this happens is that the type
-        //    erasure of List<V> is simply List. The compiler then (incorrectly from what we'd like to happen) selects
-        //    the vararg method as the one to call, since the raw List type is an Object, not a List<Object>.
+        // This is effectively a 'foldLeft', which Java Streams does not have.
+        // See the full explanation in the method above.
         var targetHelper = this;
         for (var entry : parameters.entrySet()) {
-            targetHelper = targetHelper.queryParamFilterNotNull(entry.getKey(), (List<Object>) entry.getValue());
+            List<V> values = entry.getValue();
+            targetHelper = targetHelper.queryParamFilterListNotNull(entry.getKey(), values);
         }
 
         return targetHelper;

--- a/src/test/java/org/kiwiproject/jaxrs/client/WebTargetHelperTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/client/WebTargetHelperTest.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import lombok.Value;
 import org.glassfish.jersey.client.filter.CsrfProtectionFilter;
 import org.glassfish.jersey.client.filter.EncodingFeature;
 import org.junit.jupiter.api.AfterAll;
@@ -184,104 +185,170 @@ class WebTargetHelperTest {
     }
 
     @Nested
-    class QueryParamFilterNotNull {
+    class QueryParamFilterNotNull_WhenVarargs {
 
-        @Nested
-        class WhenArray {
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull(name, 1, 2, 3);
 
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull(name, 1, 2, 3);
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(Object[] values) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("foo", values);
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @Test
-            void shouldIncludeOnlyNonNullValues() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("lottoNumbers", 42, 84, null, null, 252);
-
-                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
-            }
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
         }
 
-        @Nested
-        class WhenList {
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(Object[] values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("foo", values);
 
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull(name, List.of(1, 2, 3));
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(List<Object> values) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("foo", values);
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @Test
-            void shouldIncludeOnlyNonNullValues() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("lottoNumbers", newArrayList(42, 84, null, null, 252));
-
-                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
-            }
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
         }
 
-        @Nested
-        class WhenStream {
+        @Test
+        void shouldIncludeOnlyNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("lottoNumbers", 42, 84, null, null, 252);
 
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull(name, Stream.of(1, 2, 3));
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
 
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
+    @SuppressWarnings("removal")
+    @Nested
+    class QueryParamFilterNotNull_WhenList_DEPRECATED {
 
-            @ParameterizedTest
-            @NullSource
-            void shouldReturnSameInstanceWithNoQuery_WhenNull(Stream<Object> values) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("foo", values);
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull(name, List.of(1, 2, 3));
 
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
 
-            @Test
-            void shouldReturnNewInstance_WhenEmpty() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("foo", Stream.of());
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(List<Object> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("foo", values);
 
-                assertNotOriginalWebTargetAndNoQuery(newWebTarget);
-            }
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
 
-            @Test
-            void shouldIncludeOnlyNonNullValues() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotNull("lottoNumbers", Stream.of(42, 84, null, null, 252));
+        @Test
+        void shouldIncludeOnlyNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("lottoNumbers", newArrayList(42, 84, null, null, 252));
 
-                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
-            }
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @Nested
+    class QueryParamFilterNotNull_WhenStream_DEPRECATED {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull(name, Stream.of(1, 2, 3));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        void shouldReturnSameInstanceWithNoQuery_WhenNull(Stream<Object> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldReturnNewInstance_WhenEmpty() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("foo", Stream.of());
+
+            assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotNull("lottoNumbers", Stream.of(42, 84, null, null, 252));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterListNotNull {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterListNotNull(name, List.of(1, 2, 3));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNullOrEmpty(List<Object> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterListNotNull("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterListNotNull("lottoNumbers", newArrayList(42, 84, null, null, 252));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterStreamNotNull {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotNull(name, Stream.of(1, 2, 3));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        void shouldReturnSameInstanceWithNoQuery_WhenNull(Stream<Object> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotNull("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldReturnNewInstance_WhenEmpty() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotNull("foo", Stream.of());
+
+            assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonNullValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotNull("lottoNumbers", Stream.of(42, 84, null, null, 252));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
         }
     }
 
@@ -363,107 +430,316 @@ class WebTargetHelperTest {
     }
 
     @Nested
-    class QueryParamFilterNotBlank {
+    class QueryParamFilterNotBlank_WhenVarargs {
 
-        @Nested
-        class WhenArray {
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank(name, "a", "b", "c");
 
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank(name, "a", "b", "c");
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstance_WhenNullOrEmpty(String[] values) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("foo", values);
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @Test
-            void shouldIncludeOnlyNonBlankValues() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("lottoNumbers",
-                                "42", "", "84", null, "  ", null, "252", "\t  \n");
-
-                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
-            }
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
         }
 
-        @Nested
-        class WhenList {
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstance_WhenNullOrEmpty(String[] values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("foo", values);
 
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank(name, List.of("a", "b", "c"));
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstance_WhenNullOrEmpty(List<String> values) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("foo", values);
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
-            }
-
-            @Test
-            void shouldIncludeOnlyNonBlankValues() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("lottoNumbers",
-                                newArrayList("42", "", "84", null, "  ", null, "252", "\t  \n"));
-
-                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
-            }
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
         }
 
-        @Nested
-        class WhenStream {
+        @Test
+        void shouldIncludeOnlyNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("lottoNumbers",
+                            "42", "", "84", null, "  ", null, "252", "\t  \n");
 
-            @ParameterizedTest
-            @NullAndEmptySource
-            void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank(name, Stream.of("a", "b", "c"));
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
 
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+    @SuppressWarnings("removal")
+    @Nested
+    class QueryParamFilterNotBlank_WhenList_DEPRECATED {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank(name, List.of("a", "b", "c"));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstance_WhenNullOrEmpty(List<String> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("lottoNumbers",
+                            newArrayList("42", "", "84", null, "  ", null, "252", "\t  \n"));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @Nested
+    class QueryParamFilterNotBlank_WhenStream_DEPRECATED {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank(name, Stream.of("a", "b", "c"));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        void shouldReturnSameInstance_WhenNull(Stream<String> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldReturnNewInstance_WhenEmpty() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("foo", Stream.of());
+
+            assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterNotBlank("lottoNumbers",
+                            Stream.of("42", "", "84", null, "  ", null, "252", "\t  \n"));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterObjectsNotBlank {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterObjectsNotBlank(name, "a", "b", "c");
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstance_WhenNullOrEmpty(Object[] values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterObjectsNotBlank("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterObjectsNotBlank("lottoNumbers",
+                            "42", "", "84", null, "  ", null, "252", "\t  \n");
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues_CharSequenceOrStringifiedValues() {
+            class Weird {
+                @Override
+                public String toString() {
+                    return "";
+                }
             }
 
-            @ParameterizedTest
-            @NullSource
-            void shouldReturnSameInstance_WhenNull(Stream<String> values) {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("foo", values);
-
-                assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+            class BadActor {
+                @Override
+                public String toString() {
+                    return null;
+                }
             }
 
-            @Test
-            void shouldReturnNewInstance_WhenEmpty() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("foo", Stream.of());
+            @Value
+            class Result<T> {
+                T value;
 
-                assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+                @Override
+                public String toString() {
+                    return value == null ? null : value.toString();
+                }
             }
 
-            @Test
-            void shouldIncludeOnlyNonBlankValues() {
-                var newWebTarget = withWebTarget(originalWebTarget)
-                        .queryParamFilterNotBlank("lottoNumbers",
-                                Stream.of("42", "", "84", null, "  ", null, "252", "\t  \n"));
+            var weird = new Weird();
+            var badActor = new BadActor();
+            CharSequence cs = "168";
+            var result = new Result<>(294);
+            var builder = new StringBuilder().append("3").append("3").append("6");
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterObjectsNotBlank("num",
+                            42,
+                            "",
+                            "84",
+                            null,
+                            badActor,
+                            weird,
+                            "  ",
+                            126.0,
+                            null,
+                            cs,
+                            252,
+                            "\t  \n",
+                            result,
+                            "",
+                            builder,
+                            "\r\n");
 
-                assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+            assertThat(newWebTarget.getUri()).hasQuery(
+                    "num=42&num=84&num=126.0&num=168&num=252&num=294&num=336");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterListNotBlank {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterListNotBlank(name, List.of("a", "b", "c"));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstance_WhenNullOrEmpty(List<String> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterListNotBlank("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterListNotBlank("lottoNumbers",
+                            newArrayList("42", "", "84", null, "  ", null, "252", "\t  \n"));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+    }
+
+    @Nested
+    class QueryParamFilterStreamNotBlank {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnSameInstanceWithNoQuery_WhenNameIsBlank(String name) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotBlank(name, Stream.of("a", "b", "c"));
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        void shouldReturnSameInstance_WhenNull(Stream<String> values) {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotBlank("foo", values);
+
+            assertIsOriginalWebTargetAndHasNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldReturnNewInstance_WhenEmpty() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotBlank("foo", Stream.of());
+
+            assertNotOriginalWebTargetAndNoQuery(newWebTarget);
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues() {
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotBlank("lottoNumbers",
+                            Stream.of("42", "", "84", null, "  ", null, "252", "\t  \n"));
+
+            assertThat(newWebTarget.getUri()).hasQuery("lottoNumbers=42&lottoNumbers=84&lottoNumbers=252");
+        }
+
+        @Test
+        void shouldIncludeOnlyNonBlankValues_CharSequenceOrStringifiedValues() {
+            class Weird {
+                @Override
+                public String toString() {
+                    return "";
+                }
             }
+
+            class BadActor {
+                @Override
+                public String toString() {
+                    return null;
+                }
+            }
+
+            @Value
+            class Result<T> {
+                T value;
+
+                @Override
+                public String toString() {
+                    return value == null ? null : value.toString();
+                }
+            }
+
+            var weird = new Weird();
+            var badActor = new BadActor();
+            CharSequence cs = "168";
+            var result = new Result<>(294);
+            var builder = new StringBuilder().append("3").append("3").append("6");
+            var stream = Stream.of(
+                    42,
+                    "",
+                    "84",
+                    null,
+                    badActor,
+                    weird,
+                    "  ",
+                    126.0,
+                    null,
+                    cs,
+                    252,
+                    "\t  \n",
+                    result,
+                    "",
+                    builder,
+                    "\r\n");
+            var newWebTarget = withWebTarget(originalWebTarget)
+                    .queryParamFilterStreamNotBlank("num", stream);
+
+            assertThat(newWebTarget.getUri()).hasQuery(
+                    "num=42&num=84&num=126.0&num=168&num=252&num=294&num=336"
+            );
         }
     }
 


### PR DESCRIPTION
- Added new methods for filtering query parameters:
  queryParamFilterListNotNull, queryParamFilterStreamNotNull,
  queryParamFilterListNotBlank, queryParamFilterStreamNotBlank, and
  queryParamFilterObjectsNotBlank.
- Marked existing (ambiguous) overloaded methods using List and Stream
  as deprecated for removal in version 5.0.0, recommending the new
  methods for replacements.
- Updated queryParamsFromMultivaluedMap to use the new
  queryParamFilterListNotNull method, and remove the (now
  unnecessary) lengthy code comment explaining why there
  was a cast to List<Object>
- Enhanced unit tests to cover newly added methods and deprecated
  scenarios. Refactored test organization for better clarity by
  splitting out each method into its own nested test class.
  
Closes #1282
Closes #1283
