### PR TITLE
Enhancements to KiwiDurationFormatters

### DIFF
--- a/src/main/java/org/kiwiproject/time/KiwiDurationFormatters.java
+++ b/src/main/java/org/kiwiproject/time/KiwiDurationFormatters.java
@@ -1,11 +1,14 @@
 package org.kiwiproject.time;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.isNull;
 
 import io.dropwizard.util.Duration;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.kiwiproject.base.KiwiDeprecated;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utilities for formatting durations of various types.
@@ -21,6 +24,9 @@ public class KiwiDurationFormatters {
     private static final boolean SUPPRESS_LEADING_ZERO_ELEMENTS = true;
     private static final boolean SUPPRESS_TRAILING_ZERO_ELEMENTS = true;
     private static final String LITERAL_NULL = "null";
+    private static final String ZERO_SECONDS_MESSAGE = "0 seconds";
+    private static final int NANOSECONDS_IN_ONE_MILLISECOND = 1_000_000;
+    private static final int MILLISECONDS_IN_ONE_SECOND = 1_000;
 
     /**
      * Formats a Java {@link java.time.Duration Duration} using English words.
@@ -46,17 +52,26 @@ public class KiwiDurationFormatters {
 
     /**
      * Formats a Java {@link java.time.Duration Duration} using English words.
-     * Converts the duration to millis and then calls {@link #formatMillisecondDurationWords(long)}.
+     * Converts the duration to nanos and then calls {@link #formatNanosecondDurationWords(long)}.
+     * <p>
+     * If the duration is null, the literal string {@code "null"} is returned.
+     * If the duration is zero, {@code "0 seconds"} is returned.
      *
      * @param duration the Java duration to format
      * @return the duration in words (e.g., 2 hours 5 minutes)
+     * @throws IllegalArgumentException if the duration is negative
+     * @see #formatNanosecondDurationWords(long)
      */
     public static String formatJavaDurationWords(java.time.Duration duration) {
         if (isNull(duration)) {
             return LITERAL_NULL;
         }
 
-        return formatMillisecondDurationWords(duration.toMillis());
+        if (duration.isZero()) {
+            return ZERO_SECONDS_MESSAGE;
+        }
+
+        return formatNanosecondDurationWords(duration.toNanos());
     }
 
     /**
@@ -84,18 +99,27 @@ public class KiwiDurationFormatters {
 
     /**
      * Formats a Dropwizard {@link io.dropwizard.util.Duration Duration} using English words.
-     * Converts the duration to millis and then calls {@link #formatMillisecondDurationWords(long)}.
+     * Converts the duration to nanos and then calls {@link #formatNanosecondDurationWords(long)}.
+     * <p>
+     * If the duration is null, the literal string {@code "null"} is returned.
+     * If the duration is zero, {@code "0 seconds"} is returned.
      *
      * @param duration the Dropwizard duration to format
      * @return the duration in words (e.g., 1 minute 45 seconds)
+     * @throws IllegalArgumentException if the duration is negative
+     * @see #formatNanosecondDurationWords(long)
      * @implNote You will need the Dropwizard Duration class available at runtime to call this method!
      */
-    public static String formatDropwizardDurationWords(Duration duration) {
+    public static String formatDropwizardDurationWords(io.dropwizard.util.Duration duration) {
         if (isNull(duration)) {
             return LITERAL_NULL;
         }
 
-        return formatMillisecondDurationWords(duration.toMilliseconds());
+        if (duration.getQuantity() == 0) {
+            return ZERO_SECONDS_MESSAGE;
+        }
+
+        return formatNanosecondDurationWords(duration.toNanoseconds());
     }
 
     /**
@@ -127,19 +151,86 @@ public class KiwiDurationFormatters {
     /**
      * A thin wrapper around {@link DurationFormatUtils#formatDurationWords(long, boolean, boolean)} that always
      * suppresses leading and trailing "zero elements" because why would you want to see
-     * "0 days 7 hours 25 minutes 0 seconds" instead of just "7 hours 25 minutes"? (We cannot think of a good reason...)
+     * "0 days 7 hours 25 minutes 0 seconds" instead of just "7 hours 25 minutes"? (We cannot think of a good reason...).
+     * <p>
+     * Unlike {@link DurationFormatUtils}, it also handles durations less than one second down to 1 nanosecond.
+     * <p>
+     * If the duration is zero, {@code "0 milliseconds"} is returned.
+     * <p>
+     * If you need to handle durations less than a millisecond, use {@link #formatNanosecondDurationWords(long)}
      *
      * @param durationMillis the duration in milliseconds to format
      * @return the duration in words (e.g., 10 minutes)
-     * @implNote The only real reason for this method to exist is, so we don't constantly have to pass the two
-     * boolean arguments. Plus, boolean arguments are evil because what exactly does "true, false" tell you without
+     * @throws IllegalArgumentException if the duration is negative
+     * @implNote The main reasons for this method to exist are so that we don't constantly have to pass the two
+     * boolean arguments to {@link DurationFormatUtils} and so that we can handle durations less than one
+     * second. Plus, boolean arguments are evil because what exactly does "true, false" tell you without
      * requiring you to look at the parameter documentation?
      * @see DurationFormatUtils#formatDurationWords(long, boolean, boolean)
+     * @see #formatNanosecondDurationWords(long)
      */
     public static String formatMillisecondDurationWords(long durationMillis) {
+        checkArgument(durationMillis >= 0, "duration must not be negative");
+
+        if (durationMillis == 0) {
+            return "0 milliseconds";
+        }
+
+        if (durationMillis < MILLISECONDS_IN_ONE_SECOND) {
+            return durationMillis + milliUnit(durationMillis);
+        }
+
         return DurationFormatUtils.formatDurationWords(
                 durationMillis,
                 SUPPRESS_LEADING_ZERO_ELEMENTS,
                 SUPPRESS_TRAILING_ZERO_ELEMENTS);
+    }
+
+    /**
+     * A thin wrapper around {@link DurationFormatUtils#formatDurationWords(long, boolean, boolean)} that always
+     * suppresses leading and trailing "zero elements" because why would you want to see
+     * "0 days 7 hours 25 minutes 0 seconds" instead of just "7 hours 25 minutes"? (We cannot think of a good reason...)
+     * <p>
+     * If the duration is zero, {@code "0 nanosecond"} is returned.
+     * <p>
+     * Unlike {@link DurationFormatUtils}, it also handles durations less than one second down to 1 nanosecond.
+     *
+     * @param durationNanos the duration in nanoseconds to format
+     * @return the duration in words (e.g., 10 minutes, 50 milliseconds)
+     * @throws IllegalArgumentException if the duration is negative
+     * @implNote The main reasons for this method to exist are so that we don't constantly have to pass the two
+     * boolean arguments to {@link DurationFormatUtils} and so that we can handle durations less than one
+     * second. Plus, boolean arguments are evil because what exactly does "true, false" tell you without
+     * requiring you to look at the parameter documentation?
+     * @see DurationFormatUtils#formatDurationWords(long, boolean, boolean)
+     */
+    public static String formatNanosecondDurationWords(long durationNanos) {
+        checkArgument(durationNanos >= 0, "duration must not be negative");
+
+        if (durationNanos == 0) {
+            return "0 nanoseconds";
+        }
+
+        if (durationNanos < NANOSECONDS_IN_ONE_MILLISECOND) {
+            return durationNanos + nanoUnit(durationNanos);
+        }
+
+        var durationMillis = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+        if (durationMillis < MILLISECONDS_IN_ONE_SECOND) {
+            return durationMillis + milliUnit(durationMillis);
+        }
+
+        return DurationFormatUtils.formatDurationWords(
+                durationMillis,
+                SUPPRESS_LEADING_ZERO_ELEMENTS,
+                SUPPRESS_TRAILING_ZERO_ELEMENTS);
+    }
+
+    private static String nanoUnit(long durationNanos) {
+        return durationNanos == 1 ? " nanosecond" : " nanoseconds";
+    }
+
+    private static String milliUnit(long durationMillis) {
+        return durationMillis == 1 ? " millisecond" : " milliseconds";
     }
 }

--- a/src/test/java/org/kiwiproject/time/KiwiDurationFormattersTest.java
+++ b/src/test/java/org/kiwiproject/time/KiwiDurationFormattersTest.java
@@ -1,17 +1,22 @@
 package org.kiwiproject.time;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @DisplayName("KiwiDurationFormatters")
 class KiwiDurationFormattersTest {
 
     private static final String SEVEN_HOURS_TWENTY_FIVE_MINUTES = "7 hours 25 minutes";
+    private static final String ONE_SECOND = "1 second";
 
     @SuppressWarnings("removal")
     @Nested
@@ -62,6 +67,41 @@ class KiwiDurationFormattersTest {
             var words = KiwiDurationFormatters.formatJavaDurationWords(null);
             assertThat(words).isEqualTo("null");
         }
+
+        @ParameterizedTest
+        @ValueSource(longs = {-500, -10, -1})
+        void shouldRequireNonNegativeDuration(long seconds) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiDurationFormatters.formatJavaDurationWords(Duration.ofSeconds(seconds)))
+                    .withMessage("duration must not be negative");
+        }
+
+        @Test
+        void shouldFormatZeroDuration() {
+            assertThat(KiwiDurationFormatters.formatJavaDurationWords(Duration.ZERO)).isEqualTo("0 seconds");
+        }
+
+        @Test
+        void shouldFormatOneSecondDuration() {
+            assertThat(KiwiDurationFormatters.formatJavaDurationWords(Duration.ofMillis(1000)))
+                    .isEqualTo(ONE_SECOND);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {1, 2, 50, 500, 999})
+        void shouldFormatMillisecondDurations(long milliseconds) {
+            var units = milliseconds == 1 ? " millisecond" : " milliseconds";
+            assertThat(KiwiDurationFormatters.formatJavaDurationWords(Duration.ofMillis(milliseconds)))
+                    .isEqualTo(milliseconds + units);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { 1, 2, 25_000, 50_000, 500_000, 999_999 })
+        void shouldFormatNanosecondDurations(long nanoseconds) {
+            var units = nanoseconds == 1 ? " nanosecond" : " nanoseconds";
+            assertThat(KiwiDurationFormatters.formatJavaDurationWords(Duration.ofNanos(nanoseconds)))
+                    .isEqualTo(nanoseconds + units);
+        }
     }
 
     @Nested
@@ -78,15 +118,126 @@ class KiwiDurationFormattersTest {
             var words = KiwiDurationFormatters.formatDropwizardDurationWords(null);
             assertThat(words).isEqualTo("null");
         }
+
+        @ParameterizedTest
+        @ValueSource(longs = { -500, -10, -1 })
+        void shouldRequireNonNegativeDuration(long seconds) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiDurationFormatters.formatDropwizardDurationWords(io.dropwizard.util.Duration.seconds(seconds)))
+                    .withMessage("duration must not be negative");
+        }
+
+        @Test
+        void shouldFormatZeroDuration() {
+            assertThat(KiwiDurationFormatters.formatDropwizardDurationWords(io.dropwizard.util.Duration.minutes(0)))
+                    .isEqualTo("0 seconds");
+        }
+
+        @Test
+        void shouldFormatOneSecondDuration() {
+            assertThat(KiwiDurationFormatters.formatDropwizardDurationWords(io.dropwizard.util.Duration.milliseconds(1000)))
+                    .isEqualTo(ONE_SECOND);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { 1, 2, 50, 500, 999 })
+        void shouldFormatMillisecondDurations(long milliseconds) {
+            var units = milliseconds == 1 ? " millisecond" : " milliseconds";
+            assertThat(KiwiDurationFormatters.formatDropwizardDurationWords(io.dropwizard.util.Duration.milliseconds(milliseconds)))
+                    .isEqualTo(milliseconds + units);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { 1, 2, 25_000, 50_000, 500_000, 999_999 })
+        void shouldFormatNanosecondDurations(long nanoseconds) {
+            var units = nanoseconds == 1 ? " nanosecond" : " nanoseconds";
+            assertThat(KiwiDurationFormatters.formatDropwizardDurationWords(io.dropwizard.util.Duration.nanoseconds(nanoseconds)))
+                    .isEqualTo(nanoseconds + units);
+        }
     }
 
     @Nested
-    class FormatMillisecondsDurationWords {
+    class FormatMillisecondDurationWords {
 
         @Test
         void shouldFormatMilliseconds() {
             var words = KiwiDurationFormatters.formatMillisecondDurationWords(Duration.ofMinutes(445).toMillis());
             assertThat(words).isEqualTo(SEVEN_HOURS_TWENTY_FIVE_MINUTES);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { -500, -10, -1 })
+        void shouldRequireNonNegativeDuration(long milliseconds) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiDurationFormatters.formatMillisecondDurationWords(milliseconds))
+                    .withMessage("duration must not be negative");
+        }
+
+        @Test
+        void shouldFormatZeroDuration() {
+            assertThat(KiwiDurationFormatters.formatMillisecondDurationWords(0)).isEqualTo("0 milliseconds");
+        }
+
+        @Test
+        void shouldFormatOneSecondDuration() {
+            assertThat(KiwiDurationFormatters.formatMillisecondDurationWords(1000))
+                    .isEqualTo(ONE_SECOND);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { 1, 2, 50, 500, 999 })
+        void shouldFormatMillisecondDurations(long milliseconds) {
+            var units = milliseconds == 1 ? " millisecond" : " milliseconds";
+            assertThat(KiwiDurationFormatters.formatMillisecondDurationWords(milliseconds))
+                    .isEqualTo(milliseconds + units);
+        }
+    }
+
+    @Nested
+    class FormatNanosecondDurationWords {
+
+        @Test
+        void shouldFormatNanoseconds() {
+            var words = KiwiDurationFormatters.formatNanosecondDurationWords(Duration.ofMinutes(445).toNanos());
+            assertThat(words).isEqualTo(SEVEN_HOURS_TWENTY_FIVE_MINUTES);
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { -500, -10, -1 })
+        void shouldRequireNonNegativeDuration(long nanoseconds) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiDurationFormatters.formatMillisecondDurationWords(nanoseconds))
+                    .withMessage("duration must not be negative");
+        }
+
+        @Test
+        void shouldFormatZeroDuration() {
+            assertThat(KiwiDurationFormatters.formatNanosecondDurationWords(0)).isEqualTo("0 nanoseconds");
+        }
+
+        @Test
+        void shouldFormatOneSecondDuration() {
+            assertThat(KiwiDurationFormatters.formatNanosecondDurationWords(TimeUnit.SECONDS.toNanos(1)))
+                    .isEqualTo(ONE_SECOND);
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(longs = { 1, 2, 50, 500, 999 })
+        void shouldFormatMillisecondDurations(long milliseconds) {
+            var nanos = TimeUnit.MILLISECONDS.toNanos(milliseconds);
+            var units = milliseconds == 1 ? " millisecond" : " milliseconds";
+            assertThat(KiwiDurationFormatters.formatNanosecondDurationWords(nanos))
+                    .isEqualTo(milliseconds + units);
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(longs = { 1, 2, 25_000, 50_000, 500_000, 999_999 })
+        void shouldFormatNanosecondDurations(long nanoseconds) {
+            var units = nanoseconds == 1 ? " nanosecond" : " nanoseconds";
+            assertThat(KiwiDurationFormatters.formatNanosecondDurationWords(nanoseconds))
+                    .isEqualTo(nanoseconds + units);
         }
     }
 }


### PR DESCRIPTION
* Handle durations that are less than one second.
* Add a method to format down to nanosecond durations.
* Change reporting of zero durations to be consistent based on units.
* Update methods that accept Java and Dropwizard Duration to call the new nanosecond method.

Closes #1290
Closes #1291