### PR TITLE
Add additional tests in KiwiEnumsTest for lowercaseName

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiEnums.java
+++ b/src/main/java/org/kiwiproject/base/KiwiEnums.java
@@ -176,9 +176,11 @@ public class KiwiEnums {
      * @param enumValue the enum value to lowercase
      * @param locale    the Locale to use for the lowercase conversion
      * @return the lowercase value of the enum value
+     * @throws IllegalArgumentException if enumValue or locale is null
      */
     public static <E extends Enum<E>> String lowercaseName(Enum<E> enumValue, Locale locale) {
         checkEnumNotNull(enumValue);
+        checkArgumentNotNull(locale, "locale must not be null");
         return enumValue.name().toLowerCase(locale);
     }
 

--- a/src/test/java/org/kiwiproject/base/KiwiEnumsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiEnumsTest.java
@@ -326,7 +326,7 @@ class KiwiEnumsTest {
             RETURN_REQUESTED
         }
 
-        // IntelliJ warning about "No implicit conversion found to convert 'Xyz' to 'Enum<E>' is NOT correct
+        // IntelliJ warning about "No implicit conversion found to convert 'Xyz' to 'Enum<E>' is NOT correct"
         @SuppressWarnings("JUnitMalformedDeclaration")
         @ParameterizedTest
         @EnumSource(Season.class)
@@ -335,10 +335,55 @@ class KiwiEnumsTest {
         @EnumSource(OrderStatus.class)
         <E extends Enum<E>> void shouldConvertTheEnumNamesToLowercase(Enum<E> enumValue) {
             var value = KiwiEnums.lowercaseName(enumValue);
-
-            com.google.common.base.Enums.getIfPresent(Season.class, "winter");
-
             assertThat(value).isEqualTo(enumValue.name().toLowerCase(Locale.ENGLISH));
+        }
+
+        @Test
+        void shouldNotAllowNullEnumValue() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiEnums.lowercaseName(null))
+                    .withMessage("enumValue must not be null");
+        }
+
+        @Test
+        void shouldNotAllowNullEnumValueWithLocale() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiEnums.lowercaseName(null, Locale.ENGLISH))
+                    .withMessage("enumValue must not be null");
+        }
+
+        @Test
+        void shouldNotAllowNullLocale() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiEnums.lowercaseName(Season.FALL, null))
+                    .withMessage("locale must not be null");
+        }
+
+        @SuppressWarnings("JUnitMalformedDeclaration")
+        @ParameterizedTest
+        @EnumSource(Season.class)
+        @EnumSource(Color.class)
+        @EnumSource(DrinkType.class)
+        @EnumSource(OrderStatus.class)
+        <E extends Enum<E>> void shouldConvertTheEnumNamesToLowercaseWithSpecificLocale(Enum<E> enumValue) {
+            assertAll(
+                    () -> {
+                        var value = KiwiEnums.lowercaseName(enumValue, Locale.ENGLISH);
+                        assertThat(value).isEqualTo(enumValue.name().toLowerCase(Locale.ENGLISH));
+                    },
+                    () -> {
+                        var value = KiwiEnums.lowercaseName(enumValue, Locale.FRENCH);
+                        assertThat(value).isEqualTo(enumValue.name().toLowerCase(Locale.FRENCH));
+                    },
+                    () -> {
+                        var value = KiwiEnums.lowercaseName(enumValue, Locale.GERMAN);
+                        assertThat(value).isEqualTo(enumValue.name().toLowerCase(Locale.GERMAN));
+                    },
+                    () -> {
+                        var value = KiwiEnums.lowercaseName(enumValue, Locale.JAPANESE);
+                        assertThat(value).isEqualTo(enumValue.name().toLowerCase(Locale.JAPANESE));
+                    }
+            );
         }
     }
 }


### PR DESCRIPTION
I asked Junie to add some tests for a few new methods I was working on. It did not find those methods, but instead it thought there needed to be more tests for lowercaseName. It also added an argument check for the Locale.

It also found and removed a random line of code in one of the tests...and it looks like something I had messed around with but forgot to remove before committing.

So, I am going ahead and committing the additions, because why not?