### PR TITLE
Don't need embedded mongo cache anymore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Cache Embedded Mongo files
-        uses: actions/cache@v4
-        with:
-          path: ~/.embedmongo
-          key: ${{ runner.os }}-embedmongo
-          restore-keys: ${{ runner.os }}-embedmongo
-
       # Compile the project
       - name: Build
         env:


### PR DESCRIPTION
We switched to testcontainers a while ago.

Closes #1332 