### PR TITLE
docs: Update KiwiIO implementation notes for closeQuietly methods

### DIFF
--- a/src/main/java/org/kiwiproject/io/KiwiIO.java
+++ b/src/main/java/org/kiwiproject/io/KiwiIO.java
@@ -86,7 +86,10 @@ public class KiwiIO {
      *
      * @param closeable the object to close, may be null or already closed
      * @implNote Copied from Apache Commons I/O's IOUtils once it became deprecated with the message "Please use
-     * the try-with-resources statement or handle suppressed exceptions manually."
+     * the try-with-resources statement or handle suppressed exceptions manually." Since this method was
+     * added, commons-io <a href="https://commons.apache.org/proper/commons-io/changes.html#a2.9.0">2.9.0</a>
+     * <em>un-deprecated</em> the {@code closeQuietly} methods. We plan to leave this here (just in case
+     * they change their minds again).
      * @see Throwable#addSuppressed(java.lang.Throwable)
      */
     public static void closeQuietly(final Closeable closeable) {
@@ -140,7 +143,10 @@ public class KiwiIO {
      *
      * @param closeables the objects to close, may be null or already closed
      * @implNote Copied from Apache Commons I/O's IOUtils once it became deprecated with the message "Please use
-     * the try-with-resources statement or handle suppressed exceptions manually."
+     * the try-with-resources statement or handle suppressed exceptions manually." Since this method was
+     * added, commons-io <a href="https://commons.apache.org/proper/commons-io/changes.html#a2.9.0">2.9.0</a>
+     * <em>un-deprecated</em> the {@code closeQuietly} methods. We plan to leave this here (just in case
+     * they change their minds again).
      * @see #closeQuietly(Closeable)
      * @see Throwable#addSuppressed(java.lang.Throwable)
      */


### PR DESCRIPTION
commons-io un-deprecated the closeQuietly methods in IOUtils in version 2.9.0 released in May 2021 (about a year after they originally deprecated them, and we added them).

We are keeping them in KiwiIO, so update the implNote in the two closeQuietly methods.