### PR TITLE
feat: allow disabling Spring shutdown hooks in SpringContextBuilder

### DIFF
--- a/src/test/java/org/kiwiproject/spring/context/SpringContextBuilderTest.java
+++ b/src/test/java/org/kiwiproject/spring/context/SpringContextBuilderTest.java
@@ -1,6 +1,7 @@
 package org.kiwiproject.spring.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 
 import java.util.Map;
 
@@ -172,6 +174,78 @@ class SpringContextBuilderTest {
                                             "SpringContextBuilderTest/secondTestApplicationContext.xml")
                                     .build())
                     .withMessageStartingWith("Annotated classes have already been specified");
+        }
+    }
+
+    @Nested
+    class WithoutShutdownHooks {
+
+        // We cannot reliably assert JVM shutdown hook registration, so instead we:
+        // 1. Verify the builder option is applied and context creation succeeds for each context type.
+        // 2. Check that the context is functional.
+        // 3. Ensure the context can be closed without throwing any exceptions.
+
+        @Test
+        void shouldRegisterBeansInParentContext_WhenShutdownHooksDisabled() {
+            var bean = new Object();
+
+            ApplicationContext context = new SpringContextBuilder()
+                    .withoutShutdownHooks()
+                    .addParentContextBean("myBean", bean)
+                    .addAnnotationConfiguration(SampleTestConfiguration.class)
+                    .build();
+
+            assertThat(context.getParent()).isNotNull();
+            assertThat(context.getParent().containsBean("myBean")).isTrue();
+            assertThat(context.getParent().getBean("myBean")).isSameAs(bean);
+
+            assertThat(context.getBean("myBean"))
+                    .describedAs("myBean should also be visible from child context")
+                    .isSameAs(bean);
+
+            assertCanClose(context);
+        }
+
+        @Test
+        void shouldDisableShutdownHooks_ForAnnotationContext() {
+            ApplicationContext context = builder
+                    .withoutShutdownHooks()
+                    .addAnnotationConfiguration(SampleTestConfiguration.class)
+                    .build();
+
+            assertThat(context).isNotNull();
+            assertThat(context.getParent()).isNotNull();
+
+            assertThat(context.getBean(OtherTestBean.class)).isNotNull();
+
+            assertCanClose(context);
+        }
+
+        @Test
+        void shouldDisableShutdownHooks_ForXmlContext() {
+            ApplicationContext context = builder
+                    .withoutShutdownHooks()
+                    .addXmlConfigLocation("SpringContextBuilderTest/testApplicationContext.xml")
+                    .build();
+
+            assertThat(context).isNotNull();
+            assertThat(context.getParent()).isNotNull();
+
+            assertThat(context.getBean(OtherTestBean.class)).isNotNull();
+
+            assertCanClose(context);
+        }
+
+        private static void assertCanClose(ApplicationContext context) {
+            assertThat(context)
+                    .describedAs("The context should be a ConfigurableApplicationContext")
+                    .isInstanceOf(ConfigurableApplicationContext.class);
+
+            var configurableContext = (ConfigurableApplicationContext) context;
+
+            assertThatCode(configurableContext::close)
+                    .describedAs("Closing the context should not throw any exceptions")
+                    .doesNotThrowAnyException();
         }
     }
 }


### PR DESCRIPTION
- Add withoutShutdownHooks to prevent registering JVM shutdown hooks for parent/child contexts.
- This supports managed runtimes (e.g., Dropwizard) where shutdown hooks can close Spring resources such as DataSource and EntityManagerFactory prematurely during application shutdown.
- Add tests verifying contexts build, parent beans are visible, and contexts can be closed cleanly.