### PR TITLE
feat: deprecate SpringContextBuilder#build method

### DIFF
--- a/src/main/java/org/kiwiproject/spring/context/SpringContextBuilder.java
+++ b/src/main/java/org/kiwiproject/spring/context/SpringContextBuilder.java
@@ -140,11 +140,16 @@ public class SpringContextBuilder {
 
     /**
      * Generate the {@link ApplicationContext}.
+     * <p>
+     * As of 5.1.0, it is recommended to use {@link #buildConfigurableContext()} instead.
      *
      * @return the ApplicationContext defined by this builder
      * @implNote This method delegates to {@link #buildConfigurableContext()} to create the ApplicationContext,
      * therefore the returned instance is a {@link ConfigurableApplicationContext}.
+     * @deprecated since 5.1.0 - Use {@link #buildConfigurableContext()} instead
      */
+    @Deprecated(since = "5.1.0")
+    @SuppressWarnings({ "java:S1133" })
     public ApplicationContext build() {
         return buildConfigurableContext();
     }

--- a/src/test/java/org/kiwiproject/spring/context/SpringContextBuilderTest.java
+++ b/src/test/java/org/kiwiproject/spring/context/SpringContextBuilderTest.java
@@ -25,6 +25,7 @@ class SpringContextBuilderTest {
     @Nested
     class Contexts {
 
+        @SuppressWarnings("deprecation")
         @Test
         void shouldBeCreatedUsingBuild() {
             var context = builder


### PR DESCRIPTION
- Mark build() method as deprecated since 5.1.0 and recommend using buildConfigurableContext() instead.
- Add @SuppressWarnings("deprecation") to silence warnings in tests.