### PR TITLE
feat(lifecycle): add ManagedSpringContext for Dropwizard lifecycle management

### DIFF
--- a/src/main/java/org/kiwiproject/dropwizard/lifecycle/ManagedSpringContext.java
+++ b/src/main/java/org/kiwiproject/dropwizard/lifecycle/ManagedSpringContext.java
@@ -1,0 +1,98 @@
+package org.kiwiproject.dropwizard.lifecycle;
+
+import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
+
+import io.dropwizard.lifecycle.Managed;
+import org.kiwiproject.io.KiwiIO;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * A Dropwizard {@link Managed} that manages the lifecycle of a Spring
+ * {@link ConfigurableApplicationContext}, closing it (and optionally its
+ * parent contexts) during application shutdown.
+ * <p>
+ * Use the static factory methods to create instances:
+ * <ul>
+ *   <li>{@link #notClosingParents(ConfigurableApplicationContext)} - closes only the given context</li>
+ *   <li>{@link #closingParents(ConfigurableApplicationContext)} - closes the given context and walks
+ *       up the parent chain, closing any parent contexts that are also
+ *       {@link ConfigurableApplicationContext} instances</li>
+ * </ul>
+ * <p>
+ * This is intended for use with {@link org.kiwiproject.spring.context.SpringContextBuilder}.
+ * When using {@link org.kiwiproject.spring.context.SpringContextBuilder#withoutShutdownHooks()},
+ * use {@link #closingParents(ConfigurableApplicationContext)} to ensure both the child and parent
+ * contexts created by the builder are properly closed during shutdown.
+ */
+public class ManagedSpringContext implements Managed {
+
+    private final ConfigurableApplicationContext context;
+    private final boolean closeParents;
+
+    private ManagedSpringContext(ConfigurableApplicationContext context, boolean closeParents) {
+        checkArgumentNotNull(context, "context must not be null");
+        this.context = context;
+        this.closeParents = closeParents;
+    }
+
+    /**
+     * Creates a new {@link ManagedSpringContext} that closes only the given context when stopped,
+     * leaving any parent contexts open.
+     *
+     * @param context the Spring context to manage
+     * @return a new ManagedSpringContext
+     * @throws IllegalArgumentException if context is null
+     */
+    public static ManagedSpringContext notClosingParents(ConfigurableApplicationContext context) {
+        return new ManagedSpringContext(context, false);
+    }
+
+    /**
+     * Creates a new {@link ManagedSpringContext} that closes the given context and walks up the
+     * parent chain, closing any parent contexts that are also
+     * {@link ConfigurableApplicationContext} instances.
+     * <p>
+     * Use this when the Spring context was built with
+     * {@link org.kiwiproject.spring.context.SpringContextBuilder#withoutShutdownHooks()}, which
+     * creates a parent context that must be explicitly closed.
+     *
+     * @param context the Spring context to manage
+     * @return a new ManagedSpringContext
+     * @throws IllegalArgumentException if context is null
+     */
+    public static ManagedSpringContext closingParents(ConfigurableApplicationContext context) {
+        return new ManagedSpringContext(context, true);
+    }
+
+    /**
+     * No-op. The Spring context is expected to already be started when this managed object is created.
+     */
+    @Override
+    public void start() {
+        // no-op: the context is already started
+    }
+
+    /**
+     * Closes the managed Spring context. If this instance was created with
+     * {@link #closingParents(ConfigurableApplicationContext)}, also walks up the parent chain and
+     * closes any parent contexts that are {@link ConfigurableApplicationContext} instances.
+     */
+    @Override
+    public void stop() {
+        if (closeParents) {
+            closeContextAndParents(context);
+        } else {
+            KiwiIO.closeQuietly(context);
+        }
+    }
+
+    private static void closeContextAndParents(ConfigurableApplicationContext context) {
+        KiwiIO.closeQuietly(context);
+        ApplicationContext parent = context.getParent();
+        while (parent instanceof ConfigurableApplicationContext configurableParent) {
+            KiwiIO.closeQuietly(configurableParent);
+            parent = configurableParent.getParent();
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/dropwizard/lifecycle/ManagedSpringContextTest.java
+++ b/src/test/java/org/kiwiproject/dropwizard/lifecycle/ManagedSpringContextTest.java
@@ -1,0 +1,120 @@
+package org.kiwiproject.dropwizard.lifecycle;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+
+@DisplayName("ManagedSpringContext")
+class ManagedSpringContextTest {
+
+    @Nested
+    class NotClosingParents {
+
+        @Test
+        void shouldRequireNonNullContext() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> ManagedSpringContext.notClosingParents(null))
+                    .withMessage("context must not be null");
+        }
+
+        @Test
+        void start_shouldBeNoOp() {
+            var context = mock(ConfigurableApplicationContext.class);
+            ManagedSpringContext.notClosingParents(context).start();
+            verifyNoInteractions(context);
+        }
+
+        @Test
+        void stop_shouldCloseOnlyTheContext() {
+            var parent = mock(ConfigurableApplicationContext.class);
+            var context = mock(ConfigurableApplicationContext.class);
+            when(context.getParent()).thenReturn(parent);
+
+            ManagedSpringContext.notClosingParents(context).stop();
+
+            verify(context).close();
+            verifyNoInteractions(parent);
+        }
+    }
+
+    @Nested
+    class ClosingParents {
+
+        @Test
+        void shouldRequireNonNullContext() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> ManagedSpringContext.closingParents(null))
+                    .withMessage("context must not be null");
+        }
+
+        @Test
+        void start_shouldBeNoOp() {
+            var context = mock(ConfigurableApplicationContext.class);
+            ManagedSpringContext.closingParents(context).start();
+            verifyNoInteractions(context);
+        }
+
+        @Test
+        void stop_shouldCloseContextWhenThereAreNoParents() {
+            var context = mock(ConfigurableApplicationContext.class);
+            when(context.getParent()).thenReturn(null);
+
+            ManagedSpringContext.closingParents(context).stop();
+
+            verify(context).close();
+        }
+
+        @Test
+        void stop_shouldCloseContextAndSingleConfigurableParent() {
+            var parent = mock(ConfigurableApplicationContext.class);
+            when(parent.getParent()).thenReturn(null);
+
+            var context = mock(ConfigurableApplicationContext.class);
+            when(context.getParent()).thenReturn(parent);
+
+            ManagedSpringContext.closingParents(context).stop();
+
+            verify(context).close();
+            verify(parent).close();
+        }
+
+        @Test
+        void stop_shouldCloseContextAndMultipleConfigurableParents() {
+            var grandparent = mock(ConfigurableApplicationContext.class);
+            when(grandparent.getParent()).thenReturn(null);
+
+            var parent = mock(ConfigurableApplicationContext.class);
+            when(parent.getParent()).thenReturn(grandparent);
+
+            var context = mock(ConfigurableApplicationContext.class);
+            when(context.getParent()).thenReturn(parent);
+
+            ManagedSpringContext.closingParents(context).stop();
+
+            verify(context).close();
+            verify(parent).close();
+            verify(grandparent).close();
+        }
+
+        @Test
+        void stop_shouldStopWalkingParentChain_WhenParentIsNotConfigurable() {
+            var nonConfigurableParent = mock(ApplicationContext.class);
+
+            var context = mock(ConfigurableApplicationContext.class);
+            when(context.getParent()).thenReturn(nonConfigurableParent);
+
+            ManagedSpringContext.closingParents(context).stop();
+
+            verify(context).close();
+            verifyNoInteractions(nonConfigurableParent);
+        }
+    }
+}


### PR DESCRIPTION
Add ManagedSpringContext, a Dropwizard Managed that closes a Spring
ConfigurableApplicationContext during application shutdown. Two static
factory methods control whether parent contexts are also closed:
notClosingParents closes only the given context, while closingParents
walks up the parent chain closing any ConfigurableApplicationContext
instances. Intended for use with SpringContextBuilder.withoutShutdownHooks().