### PR TITLE
feat: add InstantEpochTimeDeserializer to jackson deser package

### DIFF
--- a/src/main/java/org/kiwiproject/jackson/deser/InstantEpochTimeDeserializer.java
+++ b/src/main/java/org/kiwiproject/jackson/deser/InstantEpochTimeDeserializer.java
@@ -1,0 +1,38 @@
+package org.kiwiproject.jackson.deser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.kiwiproject.jackson.ser.InstantEpochTimeSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+
+/**
+ * Jackson deserializer that converts milliseconds since the epoch into an {@link Instant}.
+ * Returns {@code null} if the JSON value is {@code null}.
+ *
+ * @see InstantEpochTimeSerializer
+ */
+public class InstantEpochTimeDeserializer extends StdDeserializer<Instant> {
+
+    /**
+     * Create a new instance that deserializes epoch millis to {@link Instant}.
+     */
+    public InstantEpochTimeDeserializer() {
+        super(Instant.class);
+    }
+
+    /**
+     * @throws com.fasterxml.jackson.databind.JsonMappingException if the JSON value is not numeric
+     */
+    @Override
+    public Instant deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        return Instant.ofEpochMilli(parser.getLongValue());
+    }
+
+    @Override
+    public Instant getNullValue(DeserializationContext context) {
+        return null;
+    }
+}

--- a/src/main/java/org/kiwiproject/jackson/ser/InstantEpochTimeSerializer.java
+++ b/src/main/java/org/kiwiproject/jackson/ser/InstantEpochTimeSerializer.java
@@ -9,6 +9,8 @@ import java.time.Instant;
 
 /**
  * Jackson serializer that converts an {@link Instant} into milliseconds since the epoch.
+ *
+ * @see org.kiwiproject.jackson.deser.InstantEpochTimeDeserializer
  */
 public class InstantEpochTimeSerializer extends StdSerializer<Instant> {
 

--- a/src/test/java/org/kiwiproject/jackson/deser/InstantEpochTimeDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/jackson/deser/InstantEpochTimeDeserializerTest.java
@@ -1,0 +1,157 @@
+package org.kiwiproject.jackson.deser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import lombok.Builder;
+import lombok.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.time.KiwiInstants;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@DisplayName("InstantEpochTimeDeserializer")
+class InstantEpochTimeDeserializerTest {
+
+    private InstantEpochTimeDeserializer deserializer;
+    private Instant now;
+
+    @BeforeEach
+    void setUp() {
+        deserializer = new InstantEpochTimeDeserializer();
+        now = KiwiInstants.truncatedToMillis(Instant.now());
+    }
+
+    @Test
+    void shouldDeserializeFromEpochMillis_WhenJsonContainsOnlyTimestamp() throws JsonProcessingException {
+        var epochMillis = now.toEpochMilli();
+        var json = """
+                {"createdAt":%d}""".formatted(epochMillis);
+
+        var module = new SimpleModule().addDeserializer(Instant.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    void shouldDeserializeFromEpochMillis_WhenJsonContainsOtherFields() throws JsonProcessingException {
+        var epochMillis = now.toEpochMilli();
+        var json = """
+                {
+                    "name":"Diane",
+                    "text":"Today we went sledding...",
+                    "createdAt":%d
+                }""".formatted(epochMillis);
+
+        var module = new SimpleModule().addDeserializer(Instant.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    void shouldDeserializeWhenUsingJsonDeserializeAnnotationOnClass() throws JsonProcessingException {
+        var epochMillis = now.toEpochMilli();
+        var json = """
+                {
+                    "name":"Carlos",
+                    "text":"Yesterday we went fishing...",
+                    "createdAt":%d
+                }""".formatted(epochMillis);
+
+        var objectMapper = new ObjectMapper();
+        var post = objectMapper.readValue(json, Post.class);
+
+        assertThat(post.getCreatedAt()).isEqualTo(now);
+    }
+
+    @Test
+    void shouldDeserializeDirectly() throws IOException {
+        var epochMillis = now.toEpochMilli();
+        var parser = new JsonFactory().createParser(String.valueOf(epochMillis));
+        parser.nextToken();
+
+        var instant = deserializer.deserialize(parser, null);
+
+        assertThat(instant).isEqualTo(now);
+    }
+
+    @Test
+    void shouldDeserializeEpochZero() throws JsonProcessingException {
+        var json = """
+                {"createdAt":0}""";
+
+        var module = new SimpleModule().addDeserializer(Instant.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(Instant.EPOCH);
+    }
+
+    @Test
+    void shouldDeserializeNegativeEpochMillis() throws JsonProcessingException {
+        var beforeEpoch = Instant.parse("1960-01-01T00:00:00Z");
+        var json = """
+                {"createdAt":%d}""".formatted(beforeEpoch.toEpochMilli());
+
+        var module = new SimpleModule().addDeserializer(Instant.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(beforeEpoch);
+    }
+
+    @Test
+    void shouldReturnNull_WhenJsonValueIsNull() throws JsonProcessingException {
+        var json = """
+                {"createdAt":null}""";
+
+        var module = new SimpleModule().addDeserializer(Instant.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isNull();
+    }
+
+    @Test
+    void shouldThrow_WhenJsonValueIsNonNumeric() {
+        var json = """
+                {"createdAt":"not-a-number"}""";
+
+        var module = new SimpleModule().addDeserializer(Instant.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, Entry.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Value
+    @Builder
+    private static class Entry {
+        String name;
+        String text;
+        Instant createdAt;
+    }
+
+    @Value
+    @Builder
+    private static class Post {
+        String name;
+        String text;
+
+        @JsonDeserialize(using = InstantEpochTimeDeserializer.class)
+        Instant createdAt;
+    }
+}


### PR DESCRIPTION
Add InstantEpochTimeDeserializer as the inverse of InstantEpochTimeSerializer.
Reads epoch milliseconds from JSON and returns an Instant. Returns null for
JSON null values. Throws JsonMappingException for non-numeric values.

Add cross-references via @see in both classes. The deserializer lives in the
new org.kiwiproject.jackson.deser package, mirroring Jackson's own
databind.ser/databind.deser split.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>