### PR TITLE
feat: add LocalDateTimeEpochTimeDeserializer

### DIFF
--- a/src/main/java/org/kiwiproject/jackson/deser/LocalDateTimeEpochTimeDeserializer.java
+++ b/src/main/java/org/kiwiproject/jackson/deser/LocalDateTimeEpochTimeDeserializer.java
@@ -1,0 +1,55 @@
+package org.kiwiproject.jackson.deser;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.kiwiproject.jackson.ser.LocalDateTimeEpochTimeSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+/**
+ * Jackson deserializer that converts milliseconds since the epoch into a
+ * {@link LocalDateTime}, using UTC by default or a zone specified in the constructor.
+ * Returns {@code null} if the JSON value is {@code null}.
+ *
+ * @see LocalDateTimeEpochTimeSerializer
+ */
+public class LocalDateTimeEpochTimeDeserializer extends StdDeserializer<LocalDateTime> {
+
+    private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+
+    private final ZoneId zoneId;
+
+    /**
+     * Create a new instance that deserializes in the UTC time zone.
+     */
+    public LocalDateTimeEpochTimeDeserializer() {
+        this(UTC_ZONE);
+    }
+
+    /**
+     * Create a new instance that deserializes in the specified time zone.
+     *
+     * @param zoneId the ID of the time zone
+     */
+    public LocalDateTimeEpochTimeDeserializer(ZoneId zoneId) {
+        super(LocalDateTime.class);
+        this.zoneId = zoneId;
+    }
+
+    /**
+     * @throws com.fasterxml.jackson.databind.JsonMappingException if the JSON value is not numeric
+     */
+    @Override
+    public LocalDateTime deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        return Instant.ofEpochMilli(parser.getLongValue()).atZone(zoneId).toLocalDateTime();
+    }
+
+    @Override
+    public LocalDateTime getNullValue(DeserializationContext context) {
+        return null;
+    }
+}

--- a/src/main/java/org/kiwiproject/jackson/ser/LocalDateTimeEpochTimeSerializer.java
+++ b/src/main/java/org/kiwiproject/jackson/ser/LocalDateTimeEpochTimeSerializer.java
@@ -11,6 +11,8 @@ import java.time.ZoneId;
 /**
  * Jackson serializer that converts a {@link java.time.LocalDateTime} into milliseconds since the epoch
  * in the UTC zone by default, or in a zone specified in the constructor.
+ *
+ * @see org.kiwiproject.jackson.deser.LocalDateTimeEpochTimeDeserializer
  */
 public class LocalDateTimeEpochTimeSerializer extends StdSerializer<LocalDateTime> {
 

--- a/src/test/java/org/kiwiproject/jackson/deser/LocalDateTimeEpochTimeDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/jackson/deser/LocalDateTimeEpochTimeDeserializerTest.java
@@ -1,0 +1,177 @@
+package org.kiwiproject.jackson.deser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import lombok.Builder;
+import lombok.Value;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+
+@DisplayName("LocalDateTimeEpochTimeDeserializer")
+class LocalDateTimeEpochTimeDeserializerTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    private LocalDateTimeEpochTimeDeserializer deserializer;
+    private LocalDateTime nowUtc;
+
+    @BeforeEach
+    void setUp() {
+        deserializer = new LocalDateTimeEpochTimeDeserializer();
+        nowUtc = LocalDateTime.now(UTC).truncatedTo(ChronoUnit.MILLIS);
+    }
+
+    @Test
+    void shouldDeserializeFromEpochMillis_WhenJsonContainsOnlyTimestamp() throws JsonProcessingException {
+        var epochMillis = nowUtc.atZone(UTC).toInstant().toEpochMilli();
+        var json = """
+                {"createdAt":%d}""".formatted(epochMillis);
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(nowUtc);
+    }
+
+    @Test
+    void shouldDeserializeFromEpochMillis_WhenJsonContainsOtherFields() throws JsonProcessingException {
+        var epochMillis = nowUtc.atZone(UTC).toInstant().toEpochMilli();
+        var json = """
+                {
+                    "name":"Alice",
+                    "text":"Today we went sledding...",
+                    "createdAt":%d
+                }""".formatted(epochMillis);
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(nowUtc);
+    }
+
+    @Test
+    void shouldDeserializeWhenUsingJsonDeserializeAnnotationOnClass() throws JsonProcessingException {
+        var epochMillis = nowUtc.atZone(UTC).toInstant().toEpochMilli();
+        var json = """
+                {
+                    "name":"Bob",
+                    "text":"Yesterday we went fishing...",
+                    "createdAt":%d
+                }""".formatted(epochMillis);
+
+        var objectMapper = new ObjectMapper();
+        var post = objectMapper.readValue(json, Post.class);
+
+        assertThat(post.getCreatedAt()).isEqualTo(nowUtc);
+    }
+
+    @Test
+    void shouldDeserializeDirectly() throws IOException {
+        var epochMillis = nowUtc.atZone(UTC).toInstant().toEpochMilli();
+        var parser = new JsonFactory().createParser(String.valueOf(epochMillis));
+        parser.nextToken();
+
+        var localDateTime = deserializer.deserialize(parser, null);
+
+        assertThat(localDateTime).isEqualTo(nowUtc);
+    }
+
+    @Test
+    void shouldDeserializeInSpecifiedZone() throws JsonProcessingException {
+        var newYorkZoneId = ZoneId.of("America/New_York");
+        var zoneDeserializer = new LocalDateTimeEpochTimeDeserializer(newYorkZoneId);
+        var epochMillis = nowUtc.atZone(UTC).toInstant().toEpochMilli();
+        var json = """
+                {"createdAt":%d}""".formatted(epochMillis);
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, zoneDeserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        var expectedInNewYork = Instant.ofEpochMilli(epochMillis).atZone(newYorkZoneId).toLocalDateTime();
+        assertThat(entry.getCreatedAt()).isEqualTo(expectedInNewYork);
+    }
+
+    @Test
+    void shouldDeserializeEpochZero() throws JsonProcessingException {
+        var json = """
+                {"createdAt":0}""";
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(LocalDateTime.ofInstant(Instant.EPOCH, UTC));
+    }
+
+    @Test
+    void shouldDeserializeNegativeEpochMillis() throws JsonProcessingException {
+        var beforeEpoch = Instant.parse("1960-01-01T00:00:00Z");
+        var json = """
+                {"createdAt":%d}""".formatted(beforeEpoch.toEpochMilli());
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isEqualTo(LocalDateTime.ofInstant(beforeEpoch, UTC));
+    }
+
+    @Test
+    void shouldReturnNull_WhenJsonValueIsNull() throws JsonProcessingException {
+        var json = """
+                {"createdAt":null}""";
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+        var entry = objectMapper.readValue(json, Entry.class);
+
+        assertThat(entry.getCreatedAt()).isNull();
+    }
+
+    @Test
+    void shouldThrow_WhenJsonValueIsNonNumeric() {
+        var json = """
+                {"createdAt":"not-a-number"}""";
+
+        var module = new SimpleModule().addDeserializer(LocalDateTime.class, deserializer);
+        var objectMapper = new ObjectMapper().registerModule(module);
+
+        assertThatThrownBy(() -> objectMapper.readValue(json, Entry.class))
+                .isInstanceOf(JsonMappingException.class);
+    }
+
+    @Value
+    @Builder
+    private static class Entry {
+        String name;
+        String text;
+        LocalDateTime createdAt;
+    }
+
+    @Value
+    @Builder
+    private static class Post {
+        String name;
+        String text;
+
+        @JsonDeserialize(using = LocalDateTimeEpochTimeDeserializer.class)
+        LocalDateTime createdAt;
+    }
+}


### PR DESCRIPTION
Add a Jackson deserializer that converts milliseconds since the epoch
into a LocalDateTime, the inverse of LocalDateTimeEpochTimeSerializer.
Uses UTC by default, with an overloaded constructor to specify a zone.
Returns null when the JSON value is null, and throws
JsonMappingException when the value is not numeric.

Also add a @see cross-reference from LocalDateTimeEpochTimeSerializer
to the new deserializer.

Closes #539