### PR TITLE
feat: deprecate ListToCsvStringDeserializer in ser package

### DIFF
--- a/src/main/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializer.java
+++ b/src/main/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.kiwiproject.base.KiwiDeprecated;
 
 import java.io.IOException;
 import java.util.stream.IntStream;
@@ -42,7 +43,16 @@ import java.util.stream.IntStream;
  * @implNote The deserialization requires {@link JsonParser#getCodec()} to return a non-null codec and will throw an
  * {@link IllegalStateException} if the returned codec is null.
  * @see CsvStringToStringListSerializer
+ * @deprecated Use {@link org.kiwiproject.jackson.deser.ListToCsvStringDeserializer} instead.
+ * Will be removed in 6.0.0.
  */
+@Deprecated(since = "5.2.0", forRemoval = true)
+@KiwiDeprecated(
+        removeAt = "6.0.0",
+        replacedBy = "org.kiwiproject.jackson.deser.ListToCsvStringDeserializer",
+        reference = "#1371"
+)
+@SuppressWarnings({ "java:S1133", "DeprecatedIsStillUsed" })
 public class ListToCsvStringDeserializer extends StdDeserializer<String> {
 
     @SuppressWarnings("WeakerAccess")

--- a/src/test/java/org/kiwiproject/jackson/deser/ListToCsvStringDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/jackson/deser/ListToCsvStringDeserializerTest.java
@@ -20,6 +20,7 @@ import org.kiwiproject.yaml.YamlHelper;
 class ListToCsvStringDeserializerTest {
 
     @Test
+    @SuppressWarnings("resource")
     void shouldRequireNonNullCodecToReadObjectAsTree() {
         var deserializer = new ListToCsvStringDeserializer();
 

--- a/src/test/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/jackson/ser/ListToCsvStringDeserializerTest.java
@@ -17,9 +17,11 @@ import org.kiwiproject.json.JsonHelper;
 import org.kiwiproject.yaml.YamlHelper;
 
 @DisplayName("ListToCsvStringDeserializer")
+@SuppressWarnings("removal")
 class ListToCsvStringDeserializerTest {
 
     @Test
+    @SuppressWarnings("resource")
     void shouldRequireNonNullCodecToReadObjectAsTree() {
         var deserializer = new ListToCsvStringDeserializer();
 


### PR DESCRIPTION
Deprecate org.kiwiproject.jackson.ser.ListToCsvStringDeserializer in favor of org.kiwiproject.jackson.deser.ListToCsvStringDeserializer. Will be removed in 6.0.0.

Closes #1371