### PR TITLE
refactor: use DEFAULT_ENVIRONMENT constant for builder default in SimpleRetryer

### DIFF
--- a/src/main/java/org/kiwiproject/retry/SimpleRetryer.java
+++ b/src/main/java/org/kiwiproject/retry/SimpleRetryer.java
@@ -62,6 +62,8 @@ import java.util.function.Supplier;
 @Builder
 public class SimpleRetryer {
 
+    private static final KiwiEnvironment KIWI_ENVIRONMENT = new DefaultEnvironment();
+
     /**
      * Default maximum attempts.
      */
@@ -92,7 +94,7 @@ public class SimpleRetryer {
      */
     @VisibleForTesting
     @Builder.Default
-    final KiwiEnvironment environment = new DefaultEnvironment();
+    final KiwiEnvironment environment = KIWI_ENVIRONMENT;
 
     /**
      * The maximum number of attempts before giving up.


### PR DESCRIPTION
Replace the inline `new DefaultEnvironment()` builder default with a shared static constant, consistent with the other DEFAULT_* constants in the class. And, it avoids creating a new DefaultEnvironment instance every time. This is thread-safe because DefaultEnvironment is thread-safe.