### PR TITLE
feat: add KiwiMaps#replaceIfPresent as alternative to Map#replace

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiMaps.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiMaps.java
@@ -849,6 +849,28 @@ public class KiwiMaps {
         };
     }
 
+    /**
+     * Associates the specified value with the specified key in the map,
+     * but only if the key is already present. Unlike {@link Map#computeIfPresent},
+     * this method operates solely on key presence and is not affected by whether
+     * the current mapped value is null. The new value may itself be null.
+     * <p>
+     * Note: {@link Map#replace(Object, Object)} has the same default behavior,
+     * but its Javadoc states "only if it is currently mapped to some value,"
+     * which can be misleadingly read as excluding null-valued keys. This method
+     * exists to provide unambiguous intent and documentation.
+     *
+     * @see Map#replace(Object, Object)
+     * @see Map#computeIfPresent(Object, BiFunction)
+     */
+    public static <K, V> void replaceIfPresent(Map<K, V> map, K key, V value) {
+        checkArgumentNotNull(map, "map must not be null");
+
+        if (map.containsKey(key)) {
+            map.put(key, value);
+        }
+    }
+
     private static void checkMapAndKeyArgsNotNull(Map<?, ?> map, Object key) {
         checkArgumentNotNull(map, "map must not be null");
         checkArgumentNotNull(key, "key must not be null");

--- a/src/test/java/org/kiwiproject/collect/KiwiMapsTest.java
+++ b/src/test/java/org/kiwiproject/collect/KiwiMapsTest.java
@@ -1623,4 +1623,57 @@ class KiwiMapsTest {
             assertThat(result).containsExactlyInAnyOrderEntriesOf(source);
         }
     }
+
+    @Nested
+    class ReplaceIfPresent {
+
+        @Test
+        void shouldRequireNonNullMap() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> KiwiMaps.replaceIfPresent(null, "aKey", "aValue"))
+                    .withMessage("map must not be null");
+        }
+
+        @Test
+        void shouldDoNothing_WhenKeyDoesNotExist() {
+            var map = newHashMap("a", 1, "b", 2);
+            KiwiMaps.replaceIfPresent(map, "c", 99);
+            assertThat(map).containsOnly(entry("a", 1), entry("b", 2));
+        }
+
+        @Test
+        void shouldDoNothing_WhenMapIsEmpty() {
+            var map = new HashMap<String, Integer>();
+            KiwiMaps.replaceIfPresent(map, "a", 42);
+            assertThat(map).isEmpty();
+        }
+
+        @Test
+        void shouldReplaceValue_WhenKeyExists() {
+            var map = newHashMap("a", 1, "b", 2);
+            KiwiMaps.replaceIfPresent(map, "a", 99);
+            assertThat(map).containsOnly(entry("a", 99), entry("b", 2));
+        }
+
+        @Test
+        void shouldReplaceValue_WhenCurrentValueIsNull() {
+            var map = KiwiMaps.<String, Integer>newHashMap("a", null, "b", 2);
+            KiwiMaps.replaceIfPresent(map, "a", 99);
+            assertThat(map).containsOnly(entry("a", 99), entry("b", 2));
+        }
+
+        @Test
+        void shouldReplaceWithNullValue_WhenKeyExists() {
+            var map = newHashMap("a", 1, "b", 2);
+            KiwiMaps.replaceIfPresent(map, "a", null);
+            assertThat(map).containsOnly(entry("a", null), entry("b", 2));
+        }
+
+        @Test
+        void shouldReplaceWithNullValue_WhenCurrentValueIsAlsoNull() {
+            var map = KiwiMaps.<String, Integer>newHashMap("a", null, "b", 2);
+            KiwiMaps.replaceIfPresent(map, "a", null);
+            assertThat(map).containsOnly(entry("a", null), entry("b", 2));
+        }
+    }
 }


### PR DESCRIPTION
Unlike Map#replace(K, V), this method returns void rather than the previous value, since callers typically only want the side effect and a null return from Map#replace is ambiguous (can mean the key was absent or that the previous value was null).

Also unlike Map#replace, the behavior with respect to null values is explicitly documented: replacement is based solely on key presence, regardless of whether the current mapped value is null. The Javadoc for Map#replace states "only if it is currently mapped to some value," which can be misleadingly read as excluding null-valued keys, similar to the well-known null caveat in Map#computeIfPresent.