### PR TITLE
feat: Add ReadEntityResult and safeReadEntityResult methods to KiwiEntities

### DIFF
--- a/src/main/java/org/kiwiproject/jaxrs/KiwiEntities.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiEntities.java
@@ -90,7 +90,7 @@ public class KiwiEntities {
     }
 
     private static <T> Optional<T> emptyOptional(Exception e) {
-        LOG.error("Error reading response entity", e);
+        logErrorReadingResponse(e);
         return Optional.empty();
     }
 
@@ -114,8 +114,7 @@ public class KiwiEntities {
             var entity = response.readEntity(entityType);
             return new ReadEntityResult<>(entity, null);
         } catch (Exception e) {
-            LOG.error("Error reading response entity", e);
-            return new ReadEntityResult<>(null, e);
+            return exceptionalResult(e);
         }
     }
 
@@ -139,8 +138,16 @@ public class KiwiEntities {
             var entity = response.readEntity(entityType);
             return new ReadEntityResult<>(entity, null);
         } catch (Exception e) {
-            LOG.error("Error reading response entity", e);
-            return new ReadEntityResult<>(null, e);
+            return exceptionalResult(e);
         }
+    }
+
+    private static <T> ReadEntityResult<T> exceptionalResult(Exception e) {
+        logErrorReadingResponse(e);
+        return new ReadEntityResult<>(null, e);
+    }
+
+    private static void logErrorReadingResponse(Exception e) {
+        LOG.error("Error reading response entity", e);
     }
 }

--- a/src/main/java/org/kiwiproject/jaxrs/KiwiEntities.java
+++ b/src/main/java/org/kiwiproject/jaxrs/KiwiEntities.java
@@ -93,4 +93,54 @@ public class KiwiEntities {
         LOG.error("Error reading response entity", e);
         return Optional.empty();
     }
+
+    /**
+     * Read an entity as an instance of the given {@link Class} specified by {@code entityType},
+     * returning a {@link ReadEntityResult} that contains either the entity or the exception
+     * that prevented it from being read.
+     * <p>
+     * Unlike {@link #safeReadEntity(Response, Class)}, this method surfaces the exception
+     * to the caller rather than only logging it, allowing callers to inspect or handle
+     * the failure reason.
+     *
+     * @param response   the response object
+     * @param entityType the type of entity the response is expected to contain
+     * @param <T>        the entity type
+     * @return a {@link ReadEntityResult} containing either the entity or the exception
+     * @see #safeReadEntityResult(Response, GenericType)
+     */
+    public static <T> ReadEntityResult<T> safeReadEntityResult(Response response, Class<T> entityType) {
+        try {
+            var entity = response.readEntity(entityType);
+            return new ReadEntityResult<>(entity, null);
+        } catch (Exception e) {
+            LOG.error("Error reading response entity", e);
+            return new ReadEntityResult<>(null, e);
+        }
+    }
+
+    /**
+     * Read an entity as an instance of the given {@link GenericType} specified by {@code entityType},
+     * returning a {@link ReadEntityResult} that contains either the entity or the exception
+     * that prevented it from being read.
+     * <p>
+     * Unlike {@link #safeReadEntity(Response, GenericType)}, this method surfaces the exception
+     * to the caller rather than only logging it, allowing callers to inspect or handle
+     * the failure reason.
+     *
+     * @param response   the response object
+     * @param entityType the type of entity the response is expected to contain
+     * @param <T>        the entity type
+     * @return a {@link ReadEntityResult} containing either the entity or the exception
+     * @see #safeReadEntityResult(Response, Class)
+     */
+    public static <T> ReadEntityResult<T> safeReadEntityResult(Response response, GenericType<T> entityType) {
+        try {
+            var entity = response.readEntity(entityType);
+            return new ReadEntityResult<>(entity, null);
+        } catch (Exception e) {
+            LOG.error("Error reading response entity", e);
+            return new ReadEntityResult<>(null, e);
+        }
+    }
 }

--- a/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
+++ b/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
@@ -1,0 +1,56 @@
+package org.kiwiproject.jaxrs;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the result of a {@link KiwiEntities#safeReadEntityResult} call, containing either
+ * a successfully read entity or the exception that prevented it from being read.
+ * <p>
+ * At most one of {@code entity} or {@code exception} will be non-null at any given time.
+ * If the read succeeded, {@code exception} will be null, though {@code entity} may also
+ * be null if the response had no body (e.g. a 204 No Content response).
+ * If the read failed, {@code exception} will be non-null and {@code entity} will be null.
+ * <p>
+ * Use {@link #hasEntity()} or {@link #hasException()} to determine the outcome
+ * before accessing the value.
+ *
+ * @param <T>       the type of the entity
+ * @param entity    the entity read from the response, or null if the response had no body or an exception occurred
+ * @param exception the exception that occurred while reading the entity, or null if successful
+ */
+public record ReadEntityResult<T>(@Nullable T entity, @Nullable Exception exception) {
+
+    /**
+     * Compact constructor that enforces the invariant that entity and exception
+     * cannot both be non-null.
+     *
+     * @throws IllegalArgumentException if both entity and exception are non-null
+     */
+    public ReadEntityResult {
+         checkArgument(!(nonNull(entity) && nonNull(exception)),
+            "entity and exception cannot both be non-null");
+    }
+
+    /**
+     * Returns true if the read succeeded, i.e., no exception occurred.
+     * Note that the entity itself may still be null if the response had no body,
+     * such as a 204 No Content response.
+     *
+     * @return true if no exception occurred, false otherwise
+     */
+    public boolean hasEntity() {
+        return isNull(exception);
+    }
+
+    /**
+     * Returns true if an exception occurred while reading the entity.
+     *
+     * @return true if an exception is present, false otherwise
+     */
+    public boolean hasException() {
+        return nonNull(exception);
+    }
+}

--- a/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
+++ b/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
@@ -3,7 +3,6 @@ package org.kiwiproject.jaxrs;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the result of a {@link KiwiEntities#safeReadEntityResult} call, containing either
@@ -21,7 +20,7 @@ import org.jspecify.annotations.Nullable;
  * @param entity    the entity read from the response, or null if the response had no body or an exception occurred
  * @param exception the exception that occurred while reading the entity, or null if successful
  */
-public record ReadEntityResult<T>(@Nullable T entity, @Nullable Exception exception) {
+public record ReadEntityResult<T>(T entity, Exception exception) {
 
     /**
      * Compact constructor that enforces the invariant that entity and exception

--- a/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
+++ b/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
@@ -10,14 +10,15 @@ import static java.util.Objects.nonNull;
  * <p>
  * At most one of {@code entity} or {@code exception} will be non-null at any given time.
  * If the read succeeded, {@code exception} will be null, though {@code entity} may also
- * be null if the response had no body (e.g. a 204 No Content response).
+ * be null if the response did not have a body (e.g., a 204 No Content response).
  * If the read failed, {@code exception} will be non-null and {@code entity} will be null.
  * <p>
  * Use {@link #hasEntity()} or {@link #hasException()} to determine the outcome
  * before accessing the value.
  *
  * @param <T>       the type of the entity
- * @param entity    the entity read from the response, or null if the response had no body or an exception occurred
+ * @param entity    the entity read from the response, or null if the response did not have a body
+ *                  or an exception occurred
  * @param exception the exception that occurred while reading the entity, or null if successful
  */
 public record ReadEntityResult<T>(T entity, Exception exception) {
@@ -29,14 +30,14 @@ public record ReadEntityResult<T>(T entity, Exception exception) {
      * @throws IllegalArgumentException if both entity and exception are non-null
      */
     public ReadEntityResult {
-         checkArgument(!(nonNull(entity) && nonNull(exception)),
-            "entity and exception cannot both be non-null");
+        checkArgument(!(nonNull(entity) && nonNull(exception)),
+                "entity and exception cannot both be non-null");
     }
 
     /**
      * Returns true if the read succeeded, i.e., no exception occurred.
-     * Note that the entity itself may still be null if the response had no body,
-     * such as a 204 No Content response.
+     * Note that the entity itself may still be null if the response did not
+     * have a body, such as a 204 No Content response.
      *
      * @return true if no exception occurred, false otherwise
      */

--- a/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
+++ b/src/main/java/org/kiwiproject/jaxrs/ReadEntityResult.java
@@ -30,8 +30,8 @@ public record ReadEntityResult<T>(T entity, Exception exception) {
      * @throws IllegalArgumentException if both entity and exception are non-null
      */
     public ReadEntityResult {
-        checkArgument(!(nonNull(entity) && nonNull(exception)),
-                "entity and exception cannot both be non-null");
+        var hasEntityAndException = nonNull(entity) && nonNull(exception);
+        checkArgument(!hasEntityAndException, "entity and exception cannot both be non-null");
     }
 
     /**

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiEntitiesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiEntitiesTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -151,9 +152,11 @@ class KiwiEntitiesTest {
 
             ReadEntityResult<String> result = KiwiEntities.safeReadEntityResult(response, String.class);
 
-            assertThat(result.hasEntity()).isTrue();
-            assertThat(result.entity()).isEqualTo("the entity");
-            assertThat(result.exception()).isNull();
+            assertAll(
+                    () -> assertThat(result.hasEntity()).isTrue(),
+                    () -> assertThat(result.entity()).isEqualTo("the entity"),
+                    () -> assertThat(result.exception()).isNull()
+            );
         }
 
         @Test
@@ -163,9 +166,11 @@ class KiwiEntitiesTest {
 
             ReadEntityResult<String> result = KiwiEntities.safeReadEntityResult(response, String.class);
 
-            assertThat(result.hasException()).isTrue();
-            assertThat(result.exception()).isInstanceOf(RuntimeException.class);
-            assertThat(result.entity()).isNull();
+            assertAll(
+                    () -> assertThat(result.hasException()).isTrue(),
+                    () -> assertThat(result.exception()).isInstanceOf(RuntimeException.class),
+                    () -> assertThat(result.entity()).isNull()
+            );
         }
 
         @Test
@@ -175,8 +180,10 @@ class KiwiEntitiesTest {
 
             ReadEntityResult<String> result = KiwiEntities.safeReadEntityResult(response, String.class);
 
-            assertThat(result.hasEntity()).isTrue();
-            assertThat(result.entity()).isNull();
+            assertAll(
+                    () -> assertThat(result.hasEntity()).isTrue(),
+                    () -> assertThat(result.entity()).isNull()
+            );
         }
     }
 
@@ -192,9 +199,11 @@ class KiwiEntitiesTest {
 
             ReadEntityResult<List<String>> result = KiwiEntities.safeReadEntityResult(response, genericType);
 
-            assertThat(result.hasEntity()).isTrue();
-            assertThat(result.entity()).containsExactly("a", "b", "c");
-            assertThat(result.exception()).isNull();
+            assertAll(
+                    () -> assertThat(result.hasEntity()).isTrue(),
+                    () -> assertThat(result.entity()).containsExactly("a", "b", "c"),
+                    () -> assertThat(result.exception()).isNull()
+            );
         }
 
         @Test
@@ -205,9 +214,11 @@ class KiwiEntitiesTest {
 
             ReadEntityResult<List<String>> result = KiwiEntities.safeReadEntityResult(response, genericType);
 
-            assertThat(result.hasException()).isTrue();
-            assertThat(result.exception()).isInstanceOf(RuntimeException.class);
-            assertThat(result.entity()).isNull();
+            assertAll(
+                    () -> assertThat(result.hasException()).isTrue(),
+                    () -> assertThat(result.exception()).isInstanceOf(RuntimeException.class),
+                    () -> assertThat(result.entity()).isNull()
+            );
         }
     }
 }

--- a/src/test/java/org/kiwiproject/jaxrs/KiwiEntitiesTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/KiwiEntitiesTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -138,5 +139,75 @@ class KiwiEntitiesTest {
         String make;
         String model;
         int year;
+    }
+
+    @Nested
+    class SafeReadEntityResultWithClass {
+
+        @Test
+        void shouldReturnResultWithEntity_WhenReadSucceeds() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenReturn("the entity");
+
+            ReadEntityResult<String> result = KiwiEntities.safeReadEntityResult(response, String.class);
+
+            assertThat(result.hasEntity()).isTrue();
+            assertThat(result.entity()).isEqualTo("the entity");
+            assertThat(result.exception()).isNull();
+        }
+
+        @Test
+        void shouldReturnResultWithException_WhenReadThrows() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenThrow(new RuntimeException("read failed"));
+
+            ReadEntityResult<String> result = KiwiEntities.safeReadEntityResult(response, String.class);
+
+            assertThat(result.hasException()).isTrue();
+            assertThat(result.exception()).isInstanceOf(RuntimeException.class);
+            assertThat(result.entity()).isNull();
+        }
+
+        @Test
+        void shouldReturnResultWithEntity_WhenReadReturnsNull() {
+            var response = mock(Response.class);
+            when(response.readEntity(String.class)).thenReturn(null);
+
+            ReadEntityResult<String> result = KiwiEntities.safeReadEntityResult(response, String.class);
+
+            assertThat(result.hasEntity()).isTrue();
+            assertThat(result.entity()).isNull();
+        }
+    }
+
+    @Nested
+    class SafeReadEntityResultWithGenericType {
+
+        @Test
+        void shouldReturnResultWithEntity_WhenReadSucceeds() {
+            var response = mock(Response.class);
+            var genericType = new GenericType<List<String>>() {};
+            var entityValue = List.of("a", "b", "c");
+            when(response.readEntity(genericType)).thenReturn(entityValue);
+
+            ReadEntityResult<List<String>> result = KiwiEntities.safeReadEntityResult(response, genericType);
+
+            assertThat(result.hasEntity()).isTrue();
+            assertThat(result.entity()).containsExactly("a", "b", "c");
+            assertThat(result.exception()).isNull();
+        }
+
+        @Test
+        void shouldReturnResultWithException_WhenReadThrows() {
+            var response = mock(Response.class);
+            var genericType = new GenericType<List<String>>() {};
+            when(response.readEntity(genericType)).thenThrow(new RuntimeException("read failed"));
+
+            ReadEntityResult<List<String>> result = KiwiEntities.safeReadEntityResult(response, genericType);
+
+            assertThat(result.hasException()).isTrue();
+            assertThat(result.exception()).isInstanceOf(RuntimeException.class);
+            assertThat(result.entity()).isNull();
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/jaxrs/ReadEntityResultTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/ReadEntityResultTest.java
@@ -1,0 +1,81 @@
+package org.kiwiproject.jaxrs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ReadEntityResult")
+class ReadEntityResultTest {
+
+    @Nested
+    class Construction {
+
+        @Test
+        void shouldAllowNullEntity() {
+            var result = new ReadEntityResult<>(null, new RuntimeException("oops"));
+            assertThat(result.entity()).isNull();
+            assertThat(result.exception()).isNotNull();
+        }
+
+        @Test
+        void shouldAllowNullException() {
+            var result = new ReadEntityResult<>("the entity", null);
+            assertThat(result.entity()).isEqualTo("the entity");
+            assertThat(result.exception()).isNull();
+        }
+
+        @Test
+        void shouldAllowBothNull_WhenResponseHadNoBody() {
+            var result = new ReadEntityResult<>(null, null);
+            assertThat(result.entity()).isNull();
+            assertThat(result.exception()).isNull();
+        }
+
+        @Test
+        void shouldThrowIllegalArgumentException_WhenBothAreNonNull() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new ReadEntityResult<>("the entity", new RuntimeException("oops")));
+        }
+    }
+
+    @Nested
+    class HasEntity {
+
+        @Test
+        void shouldReturnTrue_WhenEntityIsPresent() {
+            var result = new ReadEntityResult<>("the entity", null);
+            assertThat(result.hasEntity()).isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_WhenBothAreNull_SuchAsA204Response() {
+            var result = new ReadEntityResult<>(null, null);
+            assertThat(result.hasEntity()).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_WhenExceptionIsPresent() {
+            var result = new ReadEntityResult<>(null, new RuntimeException("oops"));
+            assertThat(result.hasEntity()).isFalse();
+        }
+    }
+
+    @Nested
+    class HasException {
+
+        @Test
+        void shouldReturnTrue_WhenExceptionIsPresent() {
+            var result = new ReadEntityResult<>(null, new RuntimeException("oops"));
+            assertThat(result.hasException()).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalse_WhenEntityIsPresent() {
+            var result = new ReadEntityResult<>("the entity", null);
+            assertThat(result.hasException()).isFalse();
+        }
+    }
+}

--- a/src/test/java/org/kiwiproject/jaxrs/ReadEntityResultTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/ReadEntityResultTest.java
@@ -87,5 +87,11 @@ class ReadEntityResultTest {
             var result = new ReadEntityResult<>("the entity", null);
             assertThat(result.hasException()).isFalse();
         }
+
+        @Test
+        void shouldReturnFalse_WhenBothAreNull_SuchAsA204Response() {
+            var result = new ReadEntityResult<>(null, null);
+            assertThat(result.hasException()).isFalse();
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/jaxrs/ReadEntityResultTest.java
+++ b/src/test/java/org/kiwiproject/jaxrs/ReadEntityResultTest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.jaxrs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,22 +17,31 @@ class ReadEntityResultTest {
         @Test
         void shouldAllowNullEntity() {
             var result = new ReadEntityResult<>(null, new RuntimeException("oops"));
-            assertThat(result.entity()).isNull();
-            assertThat(result.exception()).isNotNull();
+
+            assertAll(
+                    () -> assertThat(result.entity()).isNull(),
+                    () -> assertThat(result.exception()).isNotNull()
+            );
         }
 
         @Test
         void shouldAllowNullException() {
             var result = new ReadEntityResult<>("the entity", null);
-            assertThat(result.entity()).isEqualTo("the entity");
-            assertThat(result.exception()).isNull();
+
+            assertAll(
+                    () -> assertThat(result.entity()).isEqualTo("the entity"),
+                    () -> assertThat(result.exception()).isNull()
+            );
         }
 
         @Test
         void shouldAllowBothNull_WhenResponseHadNoBody() {
             var result = new ReadEntityResult<>(null, null);
-            assertThat(result.entity()).isNull();
-            assertThat(result.exception()).isNull();
+
+            assertAll(
+                    () -> assertThat(result.entity()).isNull(),
+                    () -> assertThat(result.exception()).isNull()
+            );
         }
 
         @Test


### PR DESCRIPTION
* Add ReadEntityResult<T> record to org.kiwiproject.jaxrs, containing either the entity read from a response or the exception that prevented it from being read
* Add safeReadEntityResult(Response, Class<T>) to KiwiEntities
* Add safeReadEntityResult(Response, GenericType<T>) to KiwiEntities
* Add ReadEntityResultTest and nested test classes to KiwiEntitiesTest

Closes #1396