### PR TITLE
Remove @Beta annotation from stable classes/methods

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiMaps.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiMaps.java
@@ -7,7 +7,6 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.checkEvenItemCount;
 import static org.kiwiproject.base.KiwiStrings.f;
 
-import com.google.common.annotations.Beta;
 import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 
@@ -734,8 +733,6 @@ public class KiwiMaps {
     /**
      * Returns the value associated with the specified key, converted using the provided converter function.
      * <p>
-     * This method is marked as {@link Beta} and may change in future releases.
-     *
      * @param map       the map
      * @param key       the key whose associated value is to be returned
      * @param converter a function that converts the value to the desired type
@@ -743,7 +740,6 @@ public class KiwiMaps {
      * @return the value associated with the key, converted using the provided converter function
      * @throws IllegalArgumentException if the map, key, or converter is null
      */
-    @Beta
     @Nullable
     public static <T> T getConvertedValue(Map<?, ?> map, Object key, Function<Object, T> converter) {
         checkMapAndKeyArgsNotNull(map, key);
@@ -757,8 +753,6 @@ public class KiwiMaps {
      * Returns the value associated with the specified key, converted using the provided converter function.
      * If the conversion fails with an exception, the fallback converter is used to provide an alternative value.
      * <p>
-     * This method is marked as {@link Beta} and may change in future releases.
-     *
      * @param map               the map
      * @param key               the key whose associated value is to be returned
      * @param converter         a function that converts the value to the desired type
@@ -768,7 +762,6 @@ public class KiwiMaps {
      * or the result of the fallback converter if the primary conversion fails
      * @throws IllegalArgumentException if the map, key, converter, or fallbackConverter is null
      */
-    @Beta
     @Nullable
     public static <T> T getConvertedValueWithFallback(Map<?, ?> map,
                                                       Object key,

--- a/src/main/java/org/kiwiproject/mongo/KiwiMongoDbs.java
+++ b/src/main/java/org/kiwiproject/mongo/KiwiMongoDbs.java
@@ -5,7 +5,6 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotBlank;
 import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
-import com.google.common.annotations.Beta;
 import lombok.experimental.UtilityClass;
 
 import java.net.URI;
@@ -14,7 +13,6 @@ import java.net.URI;
  * Static utilities relating to Mongo databases.
  */
 @UtilityClass
-@Beta
 public class KiwiMongoDbs {
 
     /**

--- a/src/main/java/org/kiwiproject/reflect/KiwiReflection.java
+++ b/src/main/java/org/kiwiproject/reflect/KiwiReflection.java
@@ -9,7 +9,6 @@ import static org.kiwiproject.base.KiwiPreconditions.checkArgumentNotNull;
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import static org.kiwiproject.base.KiwiStrings.f;
 
-import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Primitives;
@@ -683,7 +682,6 @@ public class KiwiReflection {
      * @see Class#getDeclaredConstructor(Class...)
      * @see java.lang.reflect.Constructor#newInstance(Object...)
      */
-    @Beta
     public static <T> T newInstanceUsingNoArgsConstructor(Class<T> type) {
         checkArgumentNotNull(type);
         try {
@@ -722,7 +720,6 @@ public class KiwiReflection {
      * @see java.lang.reflect.Constructor#newInstance(Object...)
      */
     @SuppressWarnings("unchecked")
-    @Beta
     public static <T> T newInstanceInferringParamTypes(Class<T> type, Object... arguments) {
         checkArgumentNotNull(type);
         checkArgumentNotNull(arguments);
@@ -795,7 +792,6 @@ public class KiwiReflection {
      * @apiNote This method is named differently than {@link #newInstance(Class, List, List)} to avoid amiguity
      * that happens with method overloads when one (or more) uses varargs and the others don't.
      */
-    @Beta
     public static <T> T newInstanceExactParamTypes(Class<T> type, List<Class<?>> parameterTypes, Object... arguments) {
         checkArgumentNotNull(arguments);
         return newInstance(type, parameterTypes, Lists.newArrayList(arguments));


### PR DESCRIPTION
Closes #1398

## Summary

- Remove `@Beta` from `KiwiMongoDbs` (class-level)
- Remove `@Beta` from `KiwiMaps#getConvertedValue` and `#getConvertedValueWithFallback` (also removes the stale Javadoc sentences referencing Beta)
- Remove `@Beta` from `KiwiReflection#newInstanceUsingNoArgsConstructor`, `#newInstanceInferringParamTypes`, and `#newInstanceExactParamTypes`
- Remove now-unused `import com.google.common.annotations.Beta` from all three files

`PagingQuery#aggregatePage` and `AggregateResult` are intentionally left unchanged — tracked separately in #1379.
