### PR TITLE
Add Jdbi3GeneratedKeys to kiwi

### DIFF
--- a/src/main/java/org/kiwiproject/jdbi/Jdbi3GeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbi/Jdbi3GeneratedKeys.java
@@ -1,0 +1,51 @@
+package org.kiwiproject.jdbi;
+
+import lombok.experimental.UtilityClass;
+import org.jdbi.v3.core.statement.Update;
+
+/**
+ * Utilities for executing statements and extracting generated keys from JDBI 3 {@link Update} objects.
+ */
+@UtilityClass
+public class Jdbi3GeneratedKeys {
+
+    /**
+     * Execute the given {@link Update} and extract the value of the generated key named "id" as a {@code Long}.
+     *
+     * @param update the {@link Update} object
+     * @return the Long value of the generated key
+     * @see #executeAndGenerateKey(Update, String, Class)
+     */
+    public static Long executeAndGenerateId(Update update) {
+        return executeAndGenerateId(update, "id");
+    }
+
+    /**
+     * Execute the given {@link Update} and extract the value of the generated key with the given
+     * {@code fieldName} as a {@code Long}.
+     *
+     * @param update    the {@link Update} object
+     * @param fieldName the name of the generated key field
+     * @return the Long value of the generated key
+     * @see #executeAndGenerateKey(Update, String, Class)
+     */
+    public static Long executeAndGenerateId(Update update, String fieldName) {
+        return executeAndGenerateKey(update, fieldName, Long.class);
+    }
+
+    /**
+     * Execute the given {@link Update} and extract the value of the generated key with the given
+     * {@code fieldName} as an instance of the given class.
+     *
+     * @param update    the {@link Update} object
+     * @param fieldName the name of the generated key field
+     * @param clazz     the target class of the generated key
+     * @param <T>       the key type
+     * @return the value of the generated key
+     */
+    public static <T> T executeAndGenerateKey(Update update, String fieldName, Class<T> clazz) {
+        return update.executeAndReturnGeneratedKeys(fieldName)
+                .mapTo(clazz)
+                .one();
+    }
+}

--- a/src/test/java/org/kiwiproject/jdbi/Jdbi3GeneratedKeysTest.java
+++ b/src/test/java/org/kiwiproject/jdbi/Jdbi3GeneratedKeysTest.java
@@ -1,0 +1,76 @@
+package org.kiwiproject.jdbi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.Update;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.IntStream;
+
+@SuppressWarnings("SqlNoDataSourceInspection")
+@DisplayName("Jdbi3GeneratedKeys")
+class Jdbi3GeneratedKeysTest {
+
+    private Jdbi jdbi;
+
+    @BeforeEach
+    void setUp() {
+        jdbi = Jdbi.create("jdbc:h2:mem:test");
+    }
+
+    @Test
+    void shouldExecuteAndGenerateIdWithImplicitFieldName() {
+        jdbi.useHandle(handle -> {
+            createUsersTable(handle);
+            IntStream.range(1, 6).forEach(i -> assertExecuteAndGenerateIdWithImplicitFieldName(handle, i));
+        });
+    }
+
+    private void assertExecuteAndGenerateIdWithImplicitFieldName(Handle handle, int i) {
+        var update = createUserInsert(handle, i);
+        var id = Jdbi3GeneratedKeys.executeAndGenerateId(update);
+        assertThat(id).isEqualTo(i);
+    }
+
+    @Test
+    void shouldExecuteAndGenerateIdWithExplicitFieldName() {
+        jdbi.useHandle(handle -> {
+            createUsersTable(handle);
+            IntStream.range(1, 6).forEach(i -> assertExecuteAndGenerateIdWithExplicitFieldName(handle, i));
+        });
+    }
+
+    private static void assertExecuteAndGenerateIdWithExplicitFieldName(Handle handle, int i) {
+        var update = createUserInsert(handle, i);
+        var id = Jdbi3GeneratedKeys.executeAndGenerateId(update, "id");
+        assertThat(id).isEqualTo(i);
+    }
+
+    @Test
+    void shouldExecuteAndGenerateKey() {
+        jdbi.useHandle(handle -> {
+            createUsersTable(handle);
+            IntStream.range(1, 8).forEach(i -> assertExecuteAndGenerateKey(handle, i));
+        });
+    }
+
+    private void assertExecuteAndGenerateKey(Handle handle, int i) {
+        var update = createUserInsert(handle, i);
+        var id = Jdbi3GeneratedKeys.executeAndGenerateKey(update, "id", Long.class);
+        assertThat(id).isEqualTo(i);
+    }
+
+    private static void createUsersTable(Handle handle) {
+        handle.execute("CREATE TABLE users (id BIGINT PRIMARY KEY AUTO_INCREMENT, name VARCHAR)");
+    }
+
+    @SuppressWarnings("SqlResolve")
+    private static Update createUserInsert(Handle handle, int i) {
+        return handle.createUpdate("INSERT INTO users (name) VALUES (:name)")
+                .bind("name", "Adam" + i);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Jdbi3GeneratedKeys` to `org.kiwiproject.jdbi` in kiwi proper
- This utility previously existed only in kiwi-test, but its functionality is not test-specific — extracting generated keys from a JDBI3 `Update` is a production use case
- `dropwizard-jdbi3` is already a `provided` dependency in kiwi, so no new dependency is required
- Test is ported directly from kiwi-test (package updated to `org.kiwiproject.jdbi`)

Closes #1402