### PR TITLE
Add KiwiJdbcGeneratedKeys utility class

### DIFF
--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -9,16 +9,20 @@ import java.sql.Statement;
 /**
  * Utilities for extracting generated keys from a JDBC {@link Statement} after an insert operation.
  *
- * <p><strong>Requesting generated keys:</strong> The caller must request generated keys at execution
- * time, otherwise {@link Statement#getGeneratedKeys()} returns an empty {@link java.sql.ResultSet}
- * and these methods will throw. There are two ways to request them:
+ * <p><strong>Requesting generated keys:</strong> The caller must request generated keys before
+ * or at execution time, otherwise {@link Statement#getGeneratedKeys()} returns an empty
+ * {@link java.sql.ResultSet} and these methods will throw. There are three ways to request them:
  *
  * <pre>{@code
- * // Option 1: flag-based (works with index-based retrieval methods)
+ * // Option 1: PreparedStatement, flag-based (works with index-based retrieval methods)
  * var ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
  *
- * // Option 2: column-name-based (works with both index- and name-based retrieval)
+ * // Option 2: PreparedStatement, column-name-based (works with both index- and name-based retrieval)
  * var ps = connection.prepareStatement(sql, new String[]{"id"});
+ *
+ * // Option 3: plain Statement, flag-based at execute time
+ * var stmt = connection.createStatement();
+ * stmt.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS);
  * }</pre>
  *
  * <p>Since {@link PreparedStatement} and {@link java.sql.CallableStatement} both extend
@@ -46,7 +50,7 @@ public class KiwiJdbcGeneratedKeys {
 
     private static final String NO_KEYS_MESSAGE =
             "No generated keys were returned; ensure keys were requested using" +
-            " Statement.RETURN_GENERATED_KEYS or by specifying column names or column indexes at prepare time";
+            " Statement.RETURN_GENERATED_KEYS, by specifying column names, or by specifying column indexes";
 
     /**
      * Extract the generated key at column index 1 as a {@link Long}.

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -62,6 +62,7 @@ public class KiwiJdbcGeneratedKeys {
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
      * @see #generatedKey(Statement, int, Class)
+     * @see Statement#getGeneratedKeys()
      */
     public static Long generatedId(Statement statement) throws SQLException {
         return generatedId(statement, 1);
@@ -81,6 +82,7 @@ public class KiwiJdbcGeneratedKeys {
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
      * @see #generatedKey(Statement, int, Class)
+     * @see Statement#getGeneratedKeys()
      */
     public static Long generatedId(Statement statement, int columnIndex) throws SQLException {
         return generatedKey(statement, columnIndex, Long.class);
@@ -102,6 +104,7 @@ public class KiwiJdbcGeneratedKeys {
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
      * @see #generatedKey(Statement, String, Class)
+     * @see Statement#getGeneratedKeys()
      */
     public static Long generatedId(Statement statement, String columnName) throws SQLException {
         return generatedKey(statement, columnName, Long.class);
@@ -122,6 +125,7 @@ public class KiwiJdbcGeneratedKeys {
      * @return the value of the generated key
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
+     * @see Statement#getGeneratedKeys()
      */
     public static <T> T generatedKey(Statement statement, int columnIndex, Class<T> keyType)
             throws SQLException {
@@ -148,6 +152,7 @@ public class KiwiJdbcGeneratedKeys {
      * @return the value of the generated key
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
+     * @see Statement#getGeneratedKeys()
      */
     public static <T> T generatedKey(Statement statement, String columnName, Class<T> keyType)
             throws SQLException {

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -20,7 +20,10 @@ import java.sql.Statement;
  * // Option 2: PreparedStatement, column-name-based (works with both index- and name-based retrieval)
  * var ps = connection.prepareStatement(sql, new String[]{"id"});
  *
- * // Option 3: plain Statement, flag-based at execute time
+ * // Option 3: PreparedStatement, column-index-based (works with index-based retrieval methods)
+ * var ps = connection.prepareStatement(sql, new int[]{1});
+ *
+ * // Option 4: plain Statement, flag-based at execute time
  * var stmt = connection.createStatement();
  * stmt.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS);
  * }</pre>

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -25,15 +25,17 @@ import java.sql.Statement;
  * {@link Statement}, all methods in this class accept those types as well.
  *
  * <p><strong>Driver compatibility for name-based methods:</strong> Index-based methods are the most
- * portable across JDBC drivers. Name-based methods have varying support:
+ * portable across JDBC drivers. Name-based methods have varying support. The following table
+ * reflects documented driver behavior and general community experience rather than
+ * test-verified guarantees across all listed databases:
  *
  * <table border="1">
- *   <caption>Name-based generated key access by database</caption>
+ *   <caption>Name-based generated key access by database (based on documented driver behavior)</caption>
  *   <tr><th>Database</th><th>Name-based access</th></tr>
- *   <tr><td>PostgreSQL</td><td>Supported</td></tr>
+ *   <tr><td>PostgreSQL</td><td>Generally supported</td></tr>
  *   <tr><td>H2</td><td>Supported</td></tr>
- *   <tr><td>SQL Server</td><td>Supported</td></tr>
- *   <tr><td>Oracle</td><td>Supported (requires column names specified at prepare time)</td></tr>
+ *   <tr><td>SQL Server</td><td>Generally supported</td></tr>
+ *   <tr><td>Oracle</td><td>Generally supported (requires column names specified at prepare time)</td></tr>
  *   <tr><td>MySQL / MariaDB</td><td>Unreliable — column may be named {@code GENERATED_KEY}
  *       rather than the actual column name</td></tr>
  *   <tr><td>SQLite</td><td>Not supported — use index-based methods</td></tr>
@@ -100,6 +102,8 @@ public class KiwiJdbcGeneratedKeys {
      * Extract the generated key at the given column index as an instance of the given type.
      * <p>
      * Index-based access is the most portable option across JDBC drivers.
+     * <p>
+     * The generated keys {@link java.sql.ResultSet} is closed before this method returns.
      *
      * @param statement   the {@link Statement}, which must have been executed with generated
      *                    key retrieval enabled
@@ -112,9 +116,10 @@ public class KiwiJdbcGeneratedKeys {
      */
     public static <T> T generatedKey(Statement statement, int columnIndex, Class<T> keyType)
             throws SQLException {
-        var keys = statement.getGeneratedKeys();
-        KiwiJdbc.nextOrThrow(keys, NO_KEYS_MESSAGE);
-        return keys.getObject(columnIndex, keyType);
+        try (var keys = statement.getGeneratedKeys()) {
+            KiwiJdbc.nextOrThrow(keys, NO_KEYS_MESSAGE);
+            return keys.getObject(columnIndex, keyType);
+        }
     }
 
     /**
@@ -123,6 +128,8 @@ public class KiwiJdbcGeneratedKeys {
      * Name-based access is not supported by all JDBC drivers. Prefer
      * {@link #generatedKey(Statement, int, Class)} for maximum portability. See the
      * class-level Javadoc for driver compatibility details.
+     * <p>
+     * The generated keys {@link java.sql.ResultSet} is closed before this method returns.
      *
      * @param statement  the {@link Statement}, which must have been executed with generated
      *                   key retrieval enabled
@@ -135,8 +142,9 @@ public class KiwiJdbcGeneratedKeys {
      */
     public static <T> T generatedKey(Statement statement, String columnName, Class<T> keyType)
             throws SQLException {
-        var keys = statement.getGeneratedKeys();
-        KiwiJdbc.nextOrThrow(keys, NO_KEYS_MESSAGE);
-        return keys.getObject(columnName, keyType);
+        try (var keys = statement.getGeneratedKeys()) {
+            KiwiJdbc.nextOrThrow(keys, NO_KEYS_MESSAGE);
+            return keys.getObject(columnName, keyType);
+        }
     }
 }

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -53,12 +53,15 @@ public class KiwiJdbcGeneratedKeys {
      * <p>
      * This is the most portable option, as all major JDBC drivers support index-based
      * access on the generated keys {@link java.sql.ResultSet}.
+     * <p>
+     * The generated keys {@link java.sql.ResultSet} is closed before this method returns.
      *
      * @param statement the {@link Statement}, which must have been executed with generated
      *                  key retrieval enabled
      * @return the Long value of the generated key
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
+     * @see #generatedKey(Statement, int, Class)
      */
     public static Long generatedId(Statement statement) throws SQLException {
         return generatedId(statement, 1);
@@ -68,6 +71,8 @@ public class KiwiJdbcGeneratedKeys {
      * Extract the generated key at the given column index as a {@link Long}.
      * <p>
      * Index-based access is the most portable option across JDBC drivers.
+     * <p>
+     * The generated keys {@link java.sql.ResultSet} is closed before this method returns.
      *
      * @param statement   the {@link Statement}, which must have been executed with generated
      *                    key retrieval enabled
@@ -75,6 +80,7 @@ public class KiwiJdbcGeneratedKeys {
      * @return the Long value of the generated key
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
+     * @see #generatedKey(Statement, int, Class)
      */
     public static Long generatedId(Statement statement, int columnIndex) throws SQLException {
         return generatedKey(statement, columnIndex, Long.class);
@@ -86,6 +92,8 @@ public class KiwiJdbcGeneratedKeys {
      * Name-based access is not supported by all JDBC drivers. Prefer
      * {@link #generatedId(Statement, int)} for maximum portability. See the
      * class-level Javadoc for driver compatibility details.
+     * <p>
+     * The generated keys {@link java.sql.ResultSet} is closed before this method returns.
      *
      * @param statement  the {@link Statement}, which must have been executed with generated
      *                   key retrieval enabled
@@ -93,6 +101,7 @@ public class KiwiJdbcGeneratedKeys {
      * @return the Long value of the generated key
      * @throws SQLException          if a database access error occurs
      * @throws IllegalStateException if no generated keys were returned
+     * @see #generatedKey(Statement, String, Class)
      */
     public static Long generatedId(Statement statement, String columnName) throws SQLException {
         return generatedKey(statement, columnName, Long.class);

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -46,7 +46,7 @@ public class KiwiJdbcGeneratedKeys {
 
     private static final String NO_KEYS_MESSAGE =
             "No generated keys were returned; ensure keys were requested using" +
-            " Statement.RETURN_GENERATED_KEYS or by specifying column names at prepare time";
+            " Statement.RETURN_GENERATED_KEYS or by specifying column names or column indexes at prepare time";
 
     /**
      * Extract the generated key at column index 1 as a {@link Long}.

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -1,0 +1,142 @@
+package org.kiwiproject.jdbc;
+
+import lombok.experimental.UtilityClass;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Utilities for extracting generated keys from a JDBC {@link Statement} after an insert operation.
+ *
+ * <p><strong>Requesting generated keys:</strong> The caller must request generated keys at execution
+ * time, otherwise {@link Statement#getGeneratedKeys()} returns an empty {@link java.sql.ResultSet}
+ * and these methods will throw. There are two ways to request them:
+ *
+ * <pre>{@code
+ * // Option 1: flag-based (works with index-based retrieval methods)
+ * var ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+ *
+ * // Option 2: column-name-based (works with both index- and name-based retrieval)
+ * var ps = connection.prepareStatement(sql, new String[]{"id"});
+ * }</pre>
+ *
+ * <p>Since {@link PreparedStatement} and {@link java.sql.CallableStatement} both extend
+ * {@link Statement}, all methods in this class accept those types as well.
+ *
+ * <p><strong>Driver compatibility for name-based methods:</strong> Index-based methods are the most
+ * portable across JDBC drivers. Name-based methods have varying support:
+ *
+ * <table border="1">
+ *   <caption>Name-based generated key access by database</caption>
+ *   <tr><th>Database</th><th>Name-based access</th></tr>
+ *   <tr><td>PostgreSQL</td><td>Supported</td></tr>
+ *   <tr><td>H2</td><td>Supported</td></tr>
+ *   <tr><td>SQL Server</td><td>Supported</td></tr>
+ *   <tr><td>Oracle</td><td>Supported (requires column names specified at prepare time)</td></tr>
+ *   <tr><td>MySQL / MariaDB</td><td>Unreliable — column may be named {@code GENERATED_KEY}
+ *       rather than the actual column name</td></tr>
+ *   <tr><td>SQLite</td><td>Not supported — use index-based methods</td></tr>
+ * </table>
+ */
+@UtilityClass
+public class KiwiJdbcGeneratedKeys {
+
+    private static final String NO_KEYS_MESSAGE =
+            "No generated keys were returned; ensure keys were requested using" +
+            " Statement.RETURN_GENERATED_KEYS or by specifying column names at prepare time";
+
+    /**
+     * Extract the generated key at column index 1 as a {@link Long}.
+     * <p>
+     * This is the most portable option, as all major JDBC drivers support index-based
+     * access on the generated keys {@link java.sql.ResultSet}.
+     *
+     * @param statement the {@link Statement}, which must have been executed with generated
+     *                  key retrieval enabled
+     * @return the Long value of the generated key
+     * @throws SQLException          if a database access error occurs
+     * @throws IllegalStateException if no generated keys were returned
+     */
+    public static Long generatedId(Statement statement) throws SQLException {
+        return generatedId(statement, 1);
+    }
+
+    /**
+     * Extract the generated key at the given column index as a {@link Long}.
+     * <p>
+     * Index-based access is the most portable option across JDBC drivers.
+     *
+     * @param statement   the {@link Statement}, which must have been executed with generated
+     *                    key retrieval enabled
+     * @param columnIndex the 1-based index of the generated key column
+     * @return the Long value of the generated key
+     * @throws SQLException          if a database access error occurs
+     * @throws IllegalStateException if no generated keys were returned
+     */
+    public static Long generatedId(Statement statement, int columnIndex) throws SQLException {
+        return generatedKey(statement, columnIndex, Long.class);
+    }
+
+    /**
+     * Extract the generated key with the given column name as a {@link Long}.
+     * <p>
+     * Name-based access is not supported by all JDBC drivers. Prefer
+     * {@link #generatedId(Statement, int)} for maximum portability. See the
+     * class-level Javadoc for driver compatibility details.
+     *
+     * @param statement  the {@link Statement}, which must have been executed with generated
+     *                   key retrieval enabled
+     * @param columnName the name of the generated key column
+     * @return the Long value of the generated key
+     * @throws SQLException          if a database access error occurs
+     * @throws IllegalStateException if no generated keys were returned
+     */
+    public static Long generatedId(Statement statement, String columnName) throws SQLException {
+        return generatedKey(statement, columnName, Long.class);
+    }
+
+    /**
+     * Extract the generated key at the given column index as an instance of the given type.
+     * <p>
+     * Index-based access is the most portable option across JDBC drivers.
+     *
+     * @param statement   the {@link Statement}, which must have been executed with generated
+     *                    key retrieval enabled
+     * @param columnIndex the 1-based index of the generated key column
+     * @param keyType     the target type of the generated key
+     * @param <T>         the key type
+     * @return the value of the generated key
+     * @throws SQLException          if a database access error occurs
+     * @throws IllegalStateException if no generated keys were returned
+     */
+    public static <T> T generatedKey(Statement statement, int columnIndex, Class<T> keyType)
+            throws SQLException {
+        var keys = statement.getGeneratedKeys();
+        KiwiJdbc.nextOrThrow(keys, NO_KEYS_MESSAGE);
+        return keys.getObject(columnIndex, keyType);
+    }
+
+    /**
+     * Extract the generated key with the given column name as an instance of the given type.
+     * <p>
+     * Name-based access is not supported by all JDBC drivers. Prefer
+     * {@link #generatedKey(Statement, int, Class)} for maximum portability. See the
+     * class-level Javadoc for driver compatibility details.
+     *
+     * @param statement  the {@link Statement}, which must have been executed with generated
+     *                   key retrieval enabled
+     * @param columnName the name of the generated key column
+     * @param keyType    the target type of the generated key
+     * @param <T>        the key type
+     * @return the value of the generated key
+     * @throws SQLException          if a database access error occurs
+     * @throws IllegalStateException if no generated keys were returned
+     */
+    public static <T> T generatedKey(Statement statement, String columnName, Class<T> keyType)
+            throws SQLException {
+        var keys = statement.getGeneratedKeys();
+        KiwiJdbc.nextOrThrow(keys, NO_KEYS_MESSAGE);
+        return keys.getObject(columnName, keyType);
+    }
+}

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -42,7 +42,7 @@ import java.sql.Statement;
  *   <tr><td>PostgreSQL</td><td>Generally supported</td></tr>
  *   <tr><td>H2</td><td>Supported</td></tr>
  *   <tr><td>SQL Server</td><td>Generally supported</td></tr>
- *   <tr><td>Oracle</td><td>Generally supported (requires column names specified at prepare time)</td></tr>
+ *   <tr><td>Oracle</td><td>Generally supported (requires column names specified at "prepare" time)</td></tr>
  *   <tr><td>MySQL / MariaDB</td><td>Unreliable — column may be named {@code GENERATED_KEY}
  *       rather than the actual column name</td></tr>
  *   <tr><td>SQLite</td><td>Not supported — use index-based methods</td></tr>
@@ -98,7 +98,7 @@ public class KiwiJdbcGeneratedKeys {
     /**
      * Extract the generated key with the given column name as a {@link Long}.
      * <p>
-     * Name-based access is not supported by all JDBC drivers. Prefer
+     * Not all JDBC drivers support column name-based access. Prefer
      * {@link #generatedId(Statement, int)} for maximum portability. See the
      * class-level Javadoc for driver compatibility details.
      * <p>
@@ -145,7 +145,7 @@ public class KiwiJdbcGeneratedKeys {
     /**
      * Extract the generated key with the given column name as an instance of the given type.
      * <p>
-     * Name-based access is not supported by all JDBC drivers. Prefer
+     * Not all JDBC drivers support column name-based access. Prefer
      * {@link #generatedKey(Statement, int, Class)} for maximum portability. See the
      * class-level Javadoc for driver compatibility details.
      * <p>

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeys.java
@@ -11,7 +11,7 @@ import java.sql.Statement;
  *
  * <p><strong>Requesting generated keys:</strong> The caller must request generated keys before
  * or at execution time, otherwise {@link Statement#getGeneratedKeys()} returns an empty
- * {@link java.sql.ResultSet} and these methods will throw. There are three ways to request them:
+ * {@link java.sql.ResultSet} and these methods will throw. There are four ways to request them:
  *
  * <pre>{@code
  * // Option 1: PreparedStatement, flag-based (works with index-based retrieval methods)

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeysTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeysTest.java
@@ -64,7 +64,7 @@ class KiwiJdbcGeneratedKeysTest {
         @Test
         void shouldReturnGeneratedIdAtGivenColumnIndex() throws SQLException {
             try (var ps = connection.prepareStatement(
-                    "INSERT INTO test_items (name) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                    "INSERT INTO test_items (name) VALUES (?)", new int[]{1})) {
                 ps.setString(1, "item");
                 ps.executeUpdate();
                 var id = KiwiJdbcGeneratedKeys.generatedId(ps, 1);
@@ -94,7 +94,7 @@ class KiwiJdbcGeneratedKeysTest {
         @Test
         void shouldReturnGeneratedKeyAsLong() throws SQLException {
             try (var ps = connection.prepareStatement(
-                    "INSERT INTO test_items (name) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                    "INSERT INTO test_items (name) VALUES (?)", new int[]{1})) {
                 ps.setString(1, "item");
                 ps.executeUpdate();
                 var id = KiwiJdbcGeneratedKeys.generatedKey(ps, 1, Long.class);

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeysTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeysTest.java
@@ -126,5 +126,15 @@ class KiwiJdbcGeneratedKeysTest {
                 assertThat(id).isPositive();
             }
         }
+
+        @Test
+        void shouldThrowWhenNoGeneratedKeysRequested() throws SQLException {
+            try (var ps = connection.prepareStatement("INSERT INTO test_items (name) VALUES (?)")) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                assertThatIllegalStateException()
+                        .isThrownBy(() -> KiwiJdbcGeneratedKeys.generatedKey(ps, "id", Long.class));
+            }
+        }
     }
 }

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeysTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcGeneratedKeysTest.java
@@ -1,0 +1,130 @@
+package org.kiwiproject.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+@SuppressWarnings("SqlNoDataSourceInspection")
+@DisplayName("KiwiJdbcGeneratedKeys")
+class KiwiJdbcGeneratedKeysTest {
+
+    private static Connection connection;
+
+    @BeforeAll
+    static void setUpDatabase() throws SQLException {
+        connection = DriverManager.getConnection("jdbc:h2:mem:KiwiJdbcGeneratedKeysTest;DB_CLOSE_DELAY=-1");
+        try (var stmt = connection.createStatement()) {
+            stmt.execute("CREATE TABLE test_items (id BIGINT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(255))");
+        }
+    }
+
+    @AfterAll
+    static void tearDownDatabase() throws SQLException {
+        connection.close();
+    }
+
+    @Nested
+    class GeneratedId_DefaultColumnIndex {
+
+        @Test
+        void shouldReturnGeneratedIdAtColumnIndex1() throws SQLException {
+            try (var ps = connection.prepareStatement(
+                    "INSERT INTO test_items (name) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                var id = KiwiJdbcGeneratedKeys.generatedId(ps);
+                assertThat(id).isPositive();
+            }
+        }
+
+        @Test
+        void shouldThrowWhenNoGeneratedKeysRequested() throws SQLException {
+            try (var ps = connection.prepareStatement("INSERT INTO test_items (name) VALUES (?)")) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                assertThatIllegalStateException()
+                        .isThrownBy(() -> KiwiJdbcGeneratedKeys.generatedId(ps));
+            }
+        }
+    }
+
+    @Nested
+    class GeneratedId_ByColumnIndex {
+
+        @Test
+        void shouldReturnGeneratedIdAtGivenColumnIndex() throws SQLException {
+            try (var ps = connection.prepareStatement(
+                    "INSERT INTO test_items (name) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                var id = KiwiJdbcGeneratedKeys.generatedId(ps, 1);
+                assertThat(id).isPositive();
+            }
+        }
+    }
+
+    @Nested
+    class GeneratedId_ByColumnName {
+
+        @Test
+        void shouldReturnGeneratedIdByColumnName() throws SQLException {
+            try (var ps = connection.prepareStatement(
+                    "INSERT INTO test_items (name) VALUES (?)", new String[]{"id"})) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                var id = KiwiJdbcGeneratedKeys.generatedId(ps, "id");
+                assertThat(id).isPositive();
+            }
+        }
+    }
+
+    @Nested
+    class GeneratedKey_ByColumnIndex {
+
+        @Test
+        void shouldReturnGeneratedKeyAsLong() throws SQLException {
+            try (var ps = connection.prepareStatement(
+                    "INSERT INTO test_items (name) VALUES (?)", Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                var id = KiwiJdbcGeneratedKeys.generatedKey(ps, 1, Long.class);
+                assertThat(id).isPositive();
+            }
+        }
+
+        @Test
+        void shouldThrowWhenNoGeneratedKeysRequested() throws SQLException {
+            try (var ps = connection.prepareStatement("INSERT INTO test_items (name) VALUES (?)")) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                assertThatIllegalStateException()
+                        .isThrownBy(() -> KiwiJdbcGeneratedKeys.generatedKey(ps, 1, Long.class));
+            }
+        }
+    }
+
+    @Nested
+    class GeneratedKey_ByColumnName {
+
+        @Test
+        void shouldReturnGeneratedKeyByColumnName() throws SQLException {
+            try (var ps = connection.prepareStatement(
+                    "INSERT INTO test_items (name) VALUES (?)", new String[]{"id"})) {
+                ps.setString(1, "item");
+                ps.executeUpdate();
+                var id = KiwiJdbcGeneratedKeys.generatedKey(ps, "id", Long.class);
+                assertThat(id).isPositive();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Adds `KiwiJdbcGeneratedKeys` to `org.kiwiproject.jdbc` with 5 methods for extracting generated keys from a JDBC `Statement` after an insert
- Supports both index-based (most portable) and name-based access
- Documents the requirement to request generated keys at execute time (`Statement.RETURN_GENERATED_KEYS` or column name array)
- Documents driver compatibility for name-based access (PostgreSQL, H2, SQL Server supported; MySQL/MariaDB unreliable; SQLite unsupported)
- Since `PreparedStatement` and `CallableStatement` both extend `Statement`, all methods accept those types as well
- Throws `IllegalStateException` if no generated keys were returned, with a message pointing to the likely cause

Closes #1403