### PR TITLE
Add executeUpdateExpectingCount methods to KiwiJdbc

### DIFF
--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -89,7 +89,7 @@ public class KiwiJdbc {
      * @param expectedCount the expected number of rows updated
      * @throws SQLException          if there is a database problem
      * @throws IllegalStateException if the number of updated rows does not equal {@code expectedCount}
-     * @see #executeUpdateExpectingCount(PreparedStatement, int, String, Object...)
+     * @see #executeUpdateExpectingCount(PreparedStatement, int, String)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount) throws SQLException {
         var count = ps.executeUpdate();

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -88,7 +88,7 @@ public class KiwiJdbc {
      * @param ps            the PreparedStatement to execute
      * @param expectedCount the expected number of rows updated
      * @throws SQLException          if there is a database problem
-     * @throws IllegalStateException if the number of updated rows does not equal expectedCount
+     * @throws IllegalStateException if the number of updated rows does not equal {@code expectedCount}
      * @see #executeUpdateExpectingCount(PreparedStatement, int, String, Object...)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount) throws SQLException {
@@ -109,7 +109,7 @@ public class KiwiJdbc {
      *                        {@link KiwiStrings#format(String, Object...)} handles placeholders
      * @param args            the arguments to be substituted into the message template
      * @throws SQLException          if there is a database problem
-     * @throws IllegalStateException if the number of updated rows does not equal expectedCount
+     * @throws IllegalStateException if the number of updated rows does not equal {@code expectedCount}
      * @see #executeUpdateExpectingCount(PreparedStatement, int)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount,

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -102,21 +102,29 @@ public class KiwiJdbc {
     /**
      * Executes {@link PreparedStatement#executeUpdate()} and throws {@link IllegalStateException}
      * if the number of updated rows does not equal {@code expectedCount}.
+     * <p>
+     * The message template is formatted with {@code expectedCount} as the first argument and the
+     * actual update count as the second argument. For example:
+     * <pre>
+     * executeUpdateExpectingCount(ps, expectedCount, "Expected {} row(s) updated but was: {}");
+     * </pre>
      *
      * @param ps              the PreparedStatement to execute
      * @param expectedCount   the expected number of rows updated
-     * @param messageTemplate the error message template in case the count does not match, according to how
-     *                        {@link KiwiStrings#format(String, Object...)} handles placeholders
-     * @param args            the arguments to be substituted into the message template
+     * @param messageTemplate the error message template in case the count does not match; the first
+     *                        {@code {}} placeholder is substituted with {@code expectedCount} and
+     *                        the second with the actual update count
      * @throws SQLException          if there is a database problem
      * @throws IllegalStateException if the number of updated rows does not equal {@code expectedCount}
      * @see #executeUpdateExpectingCount(PreparedStatement, int)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,
                                                    int expectedCount,
-                                                   String messageTemplate,
-                                                   Object... args) throws SQLException {
-        executeUpdateExpectingCount(ps, count -> count == expectedCount, messageTemplate, args);
+                                                   String messageTemplate) throws SQLException {
+        var count = ps.executeUpdate();
+        if (count != expectedCount) {
+            throw new IllegalStateException(format(messageTemplate, expectedCount, count));
+        }
     }
 
     /**
@@ -132,7 +140,7 @@ public class KiwiJdbc {
      *           because an {@link IntPredicate} cannot be introspected to produce a meaningful
      *           description. Use the overload that accepts a message template if a more
      *           descriptive error message is needed.
-     * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate, String, Object...)
+     * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate, String)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,
                                                    IntPredicate countChecker) throws SQLException {
@@ -146,23 +154,28 @@ public class KiwiJdbc {
     /**
      * Executes {@link PreparedStatement#executeUpdate()} and throws {@link IllegalStateException}
      * if the number of updated rows does not satisfy {@code countChecker}.
+     * <p>
+     * The message template is formatted with the actual update count as the only argument.
+     * For example:
+     * <pre>
+     * executeUpdateExpectingCount(ps, count -> count >= minCount,
+     *         "Expected at least " + minCount + " row(s) updated but was: {}");
+     * </pre>
      *
      * @param ps              the PreparedStatement to execute
      * @param countChecker    a predicate to test the number of rows updated
-     * @param messageTemplate the error message template in case the predicate is not satisfied, according to how
-     *                        {@link KiwiStrings#format(String, Object...)} handles placeholders
-     * @param args            the arguments to be substituted into the message template
+     * @param messageTemplate the error message template in case the predicate is not satisfied;
+     *                        the {@code {}} placeholder is substituted with the actual update count
      * @throws SQLException          if there is a database problem
      * @throws IllegalStateException if the number of updated rows does not satisfy countChecker
      * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,
                                                    IntPredicate countChecker,
-                                                   String messageTemplate,
-                                                   Object... args) throws SQLException {
+                                                   String messageTemplate) throws SQLException {
         var count = ps.executeUpdate();
         if (!countChecker.test(count)) {
-            throw new IllegalStateException(format(messageTemplate, args));
+            throw new IllegalStateException(format(messageTemplate, count));
         }
     }
 

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -27,6 +27,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Optional;
+import java.util.function.IntPredicate;
 
 /**
  * JDBC utilities.
@@ -75,6 +76,85 @@ public class KiwiJdbc {
      */
     public static void nextOrThrow(ResultSet rs, String messageTemplate, Object... args) throws SQLException {
         if (!rs.next()) {
+            throw new IllegalStateException(format(messageTemplate, args));
+        }
+    }
+
+    /**
+     * Executes {@link PreparedStatement#executeUpdate()} and throws {@link IllegalStateException}
+     * if the number of updated rows does not equal {@code expectedCount}.
+     * Uses a default error message that includes both the expected and actual counts.
+     *
+     * @param ps            the PreparedStatement to execute
+     * @param expectedCount the expected number of rows updated
+     * @throws SQLException          if there is a database problem
+     * @throws IllegalStateException if the number of updated rows does not equal expectedCount
+     * @see #executeUpdateExpectingCount(PreparedStatement, int, String, Object...)
+     */
+    public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount) throws SQLException {
+        var count = ps.executeUpdate();
+        if (count != expectedCount) {
+            throw new IllegalStateException(
+                    format("Expected {} row(s) updated but was: {}", expectedCount, count));
+        }
+    }
+
+    /**
+     * Executes {@link PreparedStatement#executeUpdate()} and throws {@link IllegalStateException}
+     * if the number of updated rows does not equal {@code expectedCount}.
+     *
+     * @param ps              the PreparedStatement to execute
+     * @param expectedCount   the expected number of rows updated
+     * @param messageTemplate the error message template in case the count does not match, according to how
+     *                        {@link KiwiStrings#format(String, Object...)} handles placeholders
+     * @param args            the arguments to be substituted into the message template
+     * @throws SQLException          if there is a database problem
+     * @throws IllegalStateException if the number of updated rows does not equal expectedCount
+     * @see #executeUpdateExpectingCount(PreparedStatement, int)
+     */
+    public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount,
+                                                   String messageTemplate, Object... args) throws SQLException {
+        executeUpdateExpectingCount(ps, count -> count == expectedCount, messageTemplate, args);
+    }
+
+    /**
+     * Executes {@link PreparedStatement#executeUpdate()} and throws {@link IllegalStateException}
+     * if the number of updated rows does not satisfy {@code countChecker}.
+     * Uses a default error message that includes the actual count.
+     *
+     * @param ps           the PreparedStatement to execute
+     * @param countChecker a predicate to test the number of rows updated
+     * @throws SQLException          if there is a database problem
+     * @throws IllegalStateException if the number of updated rows does not satisfy countChecker
+     * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate, String, Object...)
+     */
+    public static void executeUpdateExpectingCount(PreparedStatement ps,
+                                                   IntPredicate countChecker) throws SQLException {
+        var count = ps.executeUpdate();
+        if (!countChecker.test(count)) {
+            throw new IllegalStateException(
+                    format("Update count {} did not satisfy the expected condition", count));
+        }
+    }
+
+    /**
+     * Executes {@link PreparedStatement#executeUpdate()} and throws {@link IllegalStateException}
+     * if the number of updated rows does not satisfy {@code countChecker}.
+     *
+     * @param ps              the PreparedStatement to execute
+     * @param countChecker    a predicate to test the number of rows updated
+     * @param messageTemplate the error message template in case the predicate is not satisfied, according to how
+     *                        {@link KiwiStrings#format(String, Object...)} handles placeholders
+     * @param args            the arguments to be substituted into the message template
+     * @throws SQLException          if there is a database problem
+     * @throws IllegalStateException if the number of updated rows does not satisfy countChecker
+     * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate)
+     */
+    public static void executeUpdateExpectingCount(PreparedStatement ps,
+                                                   IntPredicate countChecker,
+                                                   String messageTemplate, Object... args) throws SQLException {
+        var count = ps.executeUpdate();
+        if (!countChecker.test(count)) {
             throw new IllegalStateException(format(messageTemplate, args));
         }
     }

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -128,6 +128,10 @@ public class KiwiJdbc {
      * @param countChecker a predicate to test the number of rows updated
      * @throws SQLException          if there is a database problem
      * @throws IllegalStateException if the number of updated rows does not satisfy countChecker
+     * @implNote The default message includes only the actual count, not the expected condition,
+     *           because an {@link IntPredicate} cannot be introspected to produce a meaningful
+     *           description. Use the overload that accepts a message template if a more
+     *           descriptive error message is needed.
      * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate, String, Object...)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -131,7 +131,7 @@ public class KiwiJdbc {
      * @param ps           the PreparedStatement to execute
      * @param countChecker a predicate to test the number of rows updated
      * @throws SQLException          if there is a database problem
-     * @throws IllegalStateException if the number of updated rows does not satisfy countChecker
+     * @throws IllegalStateException if the number of updated rows does not satisfy {@code countChecker}
      * @implNote The default message includes only the actual count, not the expected condition,
      *           because an {@link IntPredicate} cannot be introspected to produce a meaningful
      *           description. Use the overload that accepts a message template if a more
@@ -160,7 +160,7 @@ public class KiwiJdbc {
      * @param messageTemplate the error message template in case the predicate is not satisfied;
      *                        the {@code {}} placeholder is substituted with the actual update count
      * @throws SQLException          if there is a database problem
-     * @throws IllegalStateException if the number of updated rows does not satisfy countChecker
+     * @throws IllegalStateException if the number of updated rows does not satisfy {@code countChecker}
      * @see #executeUpdateExpectingCount(PreparedStatement, IntPredicate)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -112,8 +112,10 @@ public class KiwiJdbc {
      * @throws IllegalStateException if the number of updated rows does not equal {@code expectedCount}
      * @see #executeUpdateExpectingCount(PreparedStatement, int)
      */
-    public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount,
-                                                   String messageTemplate, Object... args) throws SQLException {
+    public static void executeUpdateExpectingCount(PreparedStatement ps,
+                                                   int expectedCount,
+                                                   String messageTemplate,
+                                                   Object... args) throws SQLException {
         executeUpdateExpectingCount(ps, count -> count == expectedCount, messageTemplate, args);
     }
 
@@ -152,7 +154,8 @@ public class KiwiJdbc {
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,
                                                    IntPredicate countChecker,
-                                                   String messageTemplate, Object... args) throws SQLException {
+                                                   String messageTemplate,
+                                                   Object... args) throws SQLException {
         var count = ps.executeUpdate();
         if (!countChecker.test(count)) {
             throw new IllegalStateException(format(messageTemplate, args));

--- a/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
+++ b/src/main/java/org/kiwiproject/jdbc/KiwiJdbc.java
@@ -92,11 +92,7 @@ public class KiwiJdbc {
      * @see #executeUpdateExpectingCount(PreparedStatement, int, String)
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps, int expectedCount) throws SQLException {
-        var count = ps.executeUpdate();
-        if (count != expectedCount) {
-            throw new IllegalStateException(
-                    format("Expected {} row(s) updated but was: {}", expectedCount, count));
-        }
+        executeUpdateExpectingCount(ps, expectedCount, "Expected {} row(s) updated but was: {}");
     }
 
     /**
@@ -144,11 +140,8 @@ public class KiwiJdbc {
      */
     public static void executeUpdateExpectingCount(PreparedStatement ps,
                                                    IntPredicate countChecker) throws SQLException {
-        var count = ps.executeUpdate();
-        if (!countChecker.test(count)) {
-            throw new IllegalStateException(
-                    format("Update count {} did not satisfy the expected condition", count));
-        }
+        executeUpdateExpectingCount(ps, countChecker,
+                "Update count {} did not satisfy the expected condition");
     }
 
     /**

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
@@ -1061,6 +1061,129 @@ class KiwiJdbcTest {
         }
     }
 
+    @Nested
+    class ExecuteUpdateExpectingCount {
+
+        private PreparedStatement ps;
+
+        @BeforeEach
+        void setUp() {
+            ps = mock(PreparedStatement.class);
+        }
+
+        @Nested
+        class WithExactCount {
+
+            @Nested
+            class WithDefaultMessage {
+
+                @Test
+                void shouldNotThrow_WhenCountMatchesExpected() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(1);
+
+                    assertThatCode(() -> KiwiJdbc.executeUpdateExpectingCount(ps, 1))
+                            .doesNotThrowAnyException();
+
+                    verify(ps, only()).executeUpdate();
+                }
+
+                @Test
+                void shouldThrow_WhenCountDoesNotMatchExpected() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(0);
+
+                    assertThatIllegalStateException()
+                            .isThrownBy(() -> KiwiJdbc.executeUpdateExpectingCount(ps, 1))
+                            .withMessage("Expected 1 row(s) updated but was: 0");
+
+                    verify(ps, only()).executeUpdate();
+                }
+            }
+
+            @Nested
+            class WithCustomMessage {
+
+                @Test
+                void shouldNotThrow_WhenCountMatchesExpected() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(3);
+
+                    assertThatCode(() -> KiwiJdbc.executeUpdateExpectingCount(
+                                    ps, 3, "Expected 3 updated rows but was: {}", 0))
+                            .doesNotThrowAnyException();
+
+                    verify(ps, only()).executeUpdate();
+                }
+
+                @Test
+                void shouldThrow_WhenCountDoesNotMatchExpected() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(0);
+
+                    assertThatIllegalStateException()
+                            .isThrownBy(() -> KiwiJdbc.executeUpdateExpectingCount(
+                                    ps, 1, "Expected 1 updated row but was: {}", 0))
+                            .withMessage("Expected 1 updated row but was: 0");
+
+                    verify(ps, only()).executeUpdate();
+                }
+            }
+        }
+
+        @Nested
+        class WithPredicateCountChecker {
+
+            @Nested
+            class WithDefaultMessage {
+
+                @Test
+                void shouldNotThrow_WhenPredicateIsSatisfied() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(5);
+
+                    assertThatCode(() -> KiwiJdbc.executeUpdateExpectingCount(ps, count -> count >= 1))
+                            .doesNotThrowAnyException();
+
+                    verify(ps, only()).executeUpdate();
+                }
+
+                @Test
+                void shouldThrow_WhenPredicateIsNotSatisfied() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(0);
+
+                    assertThatIllegalStateException()
+                            .isThrownBy(() -> KiwiJdbc.executeUpdateExpectingCount(ps, count -> count >= 1))
+                            .withMessage("Update count 0 did not satisfy the expected condition");
+
+                    verify(ps, only()).executeUpdate();
+                }
+            }
+
+            @Nested
+            class WithCustomMessage {
+
+                @Test
+                void shouldNotThrow_WhenPredicateIsSatisfied() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(2);
+
+                    assertThatCode(() -> KiwiJdbc.executeUpdateExpectingCount(
+                                    ps, count -> count >= 1, "Expected at least 1 row updated but was: {}", 0))
+                            .doesNotThrowAnyException();
+
+                    verify(ps, only()).executeUpdate();
+                }
+
+                @Test
+                void shouldThrow_WhenPredicateIsNotSatisfied() throws SQLException {
+                    when(ps.executeUpdate()).thenReturn(0);
+
+                    assertThatIllegalStateException()
+                            .isThrownBy(() -> KiwiJdbc.executeUpdateExpectingCount(
+                                    ps, count -> count >= 1, "Expected at least 1 row updated but was: {}", 0))
+                            .withMessage("Expected at least 1 row updated but was: 0");
+
+                    verify(ps, only()).executeUpdate();
+                }
+            }
+        }
+    }
+
     private static ResultSet newMockResultSet() {
         return mock(ResultSet.class);
     }

--- a/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
+++ b/src/test/java/org/kiwiproject/jdbc/KiwiJdbcTest.java
@@ -1107,7 +1107,7 @@ class KiwiJdbcTest {
                     when(ps.executeUpdate()).thenReturn(3);
 
                     assertThatCode(() -> KiwiJdbc.executeUpdateExpectingCount(
-                                    ps, 3, "Expected 3 updated rows but was: {}", 0))
+                                    ps, 3, "Expected {} updated rows but was: {}"))
                             .doesNotThrowAnyException();
 
                     verify(ps, only()).executeUpdate();
@@ -1119,8 +1119,8 @@ class KiwiJdbcTest {
 
                     assertThatIllegalStateException()
                             .isThrownBy(() -> KiwiJdbc.executeUpdateExpectingCount(
-                                    ps, 1, "Expected 1 updated row but was: {}", 0))
-                            .withMessage("Expected 1 updated row but was: 0");
+                                    ps, 1, "Expected {} updated row(s) but was: {}"))
+                            .withMessage("Expected 1 updated row(s) but was: 0");
 
                     verify(ps, only()).executeUpdate();
                 }
@@ -1163,7 +1163,7 @@ class KiwiJdbcTest {
                     when(ps.executeUpdate()).thenReturn(2);
 
                     assertThatCode(() -> KiwiJdbc.executeUpdateExpectingCount(
-                                    ps, count -> count >= 1, "Expected at least 1 row updated but was: {}", 0))
+                                    ps, count -> count >= 1, "Expected at least 1 row updated but was: {}"))
                             .doesNotThrowAnyException();
 
                     verify(ps, only()).executeUpdate();
@@ -1175,7 +1175,7 @@ class KiwiJdbcTest {
 
                     assertThatIllegalStateException()
                             .isThrownBy(() -> KiwiJdbc.executeUpdateExpectingCount(
-                                    ps, count -> count >= 1, "Expected at least 1 row updated but was: {}", 0))
+                                    ps, count -> count >= 1, "Expected at least 1 row updated but was: {}"))
                             .withMessage("Expected at least 1 row updated but was: 0");
 
                     verify(ps, only()).executeUpdate();


### PR DESCRIPTION
Add four overloads of executeUpdateExpectingCount to KiwiJdbc for
executing a PreparedStatement update and asserting the row count,
throwing an IllegalStateException if the assertion fails.

Two variants accept an exact int count (with default and custom message
forms) and two accept an IntPredicate (with default and custom message
forms).

Closes #1406