### PR TITLE
Add JCE provider support to SSL context and keystore creation

### DIFF
--- a/src/main/java/org/kiwiproject/security/KiwiSecurity.java
+++ b/src/main/java/org/kiwiproject/security/KiwiSecurity.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.Optional;
@@ -247,6 +248,69 @@ public class KiwiSecurity {
                                               String trustStoreType,
                                               String trustManagerAlgorithm,
                                               String protocol) {
+        return createSslContext(keyStorePath,
+                keyStorePassword,
+                keyStoreType,
+                null,
+                keyManagerAlgorithm,
+                trustStorePath,
+                trustStorePassword,
+                trustStoreType,
+                null,
+                trustManagerAlgorithm,
+                protocol);
+    }
+
+    /**
+     * Create a new {@link SSLContext} instance for the given paths, passwords, key and trust store types, key and
+     * trust store providers, key and trust manager algorithms, and protocol. The key and trust store types should be
+     * one of the algorithms defined in {@link KeyStoreType}.
+     * <p>
+     * If only the trust store is necessary, supply {@code null} values for the {@code keyStorePath},
+     * {@code keyStorePassword}, {@code keyStoreType}, {@code keyStoreProvider}, and {@code keyManagerAlgorithm}.
+     * <p>
+     * If a provider is given, {@link KeyStore#getInstance(String, String)} is used; otherwise
+     * {@link KeyStore#getInstance(String)} is used.
+     * <p>
+     * WARNING: While public, this is very low-level and not generally intended for client code to call directly.
+     * We recommend using {@link #createSslContext(String, String, String, String, SSLContextProtocol)}
+     * or {@link #createSslContext(String, String, String, String, String)}. Kiwi also provides higher-level
+     * constructs in the {@link org.kiwiproject.security} package.
+     *
+     * @param keyStorePath          path to the key store
+     * @param keyStorePassword      password of the key store
+     * @param keyStoreType          the key store type
+     * @param keyStoreProvider      the JCE provider name for the key store, or {@code null} to use the default provider
+     * @param keyManagerAlgorithm   the key manager algorithm
+     * @param trustStorePath        path to the trust store
+     * @param trustStorePassword    password of the trust store
+     * @param trustStoreType        the trust store type
+     * @param trustStoreProvider    the JCE provider name for the trust store, or {@code null} to use the default provider
+     * @param trustManagerAlgorithm the trust manager algorithm
+     * @param protocol              the protocol to use
+     * @return a new {@link SSLContext} instance
+     * @throws SSLContextException if unable to create the {@link SSLContext}
+     * @see KeyStore#getInstance(String)
+     * @see KeyStore#getInstance(String, String)
+     * @see KeyManager
+     * @see KeyManagerFactory#getInstance(String)
+     * @see TrustManager
+     * @see TrustManagerFactory#getInstance(String)
+     * @see SSLContextProtocol
+     * @see KeyStoreType
+     */
+    @SuppressWarnings("java:S107")
+    public static SSLContext createSslContext(@Nullable String keyStorePath,
+                                              @Nullable String keyStorePassword,
+                                              @Nullable String keyStoreType,
+                                              @Nullable String keyStoreProvider,
+                                              @Nullable String keyManagerAlgorithm,
+                                              String trustStorePath,
+                                              String trustStorePassword,
+                                              String trustStoreType,
+                                              @Nullable String trustStoreProvider,
+                                              String trustManagerAlgorithm,
+                                              String protocol) {
 
         if (isNotBlank(keyStorePath)) {
             checkArgumentNotNull(keyStorePassword, "keyStorePassword cannot be null");
@@ -261,12 +325,12 @@ public class KiwiSecurity {
         checkArgumentNotBlank(protocol, "protocol cannot be blank");
 
         try {
-            var optionalKeyStore = getKeyStore(keyStoreType, keyStorePath, keyStorePassword);
+            var optionalKeyStore = getKeyStore(keyStoreType, keyStorePath, keyStorePassword, keyStoreProvider);
             var keyManagers = optionalKeyStore
                     .map(store -> getKeyManagers(store, keyStorePassword, keyManagerAlgorithm))
                     .orElse(null);
 
-            var trustStore = getKeyStore(trustStoreType, trustStorePath, trustStorePassword)
+            var trustStore = getKeyStore(trustStoreType, trustStorePath, trustStorePassword, trustStoreProvider)
                     .orElseThrow(IllegalArgumentException::new);
             var trustManagers = getTrustManagers(trustStore, trustManagerAlgorithm);
 
@@ -316,6 +380,34 @@ public class KiwiSecurity {
     }
 
     /**
+     * Return an {@link Optional} containing a {@link KeyStore} for the given {@link KeyStoreType}, path, password,
+     * and JCE provider, or an empty {@link Optional} if either path or password is null.
+     * <p>
+     * This method is intended to load an <em>existing</em> key store. If you need to programmatically create a new
+     * one, use the {@link KeyStore} API directly.
+     * <p>
+     * If the returned Optional contains a KeyStore, it has been successfully loaded.
+     * <p>
+     * If a provider is given, {@link KeyStore#getInstance(String, String)} is used; otherwise
+     * {@link KeyStore#getInstance(String)} is used.
+     *
+     * @param keyStoreType the type of key store
+     * @param path         the path to the key store
+     * @param password     the key store password
+     * @param provider     the JCE provider name, or {@code null} to use the default provider
+     * @return an optional with a {@link KeyStore} or an empty optional
+     * @throws IllegalArgumentException if keyStoreType is blank
+     * @throws SSLContextException      if unable to create a {@link KeyStore}
+     * @see KeyStore#getInstance(String)
+     * @see KeyStore#getInstance(String, String)
+     * @see KeyStore#load(java.io.InputStream, char[])
+     */
+    public static Optional<KeyStore> getKeyStore(KeyStoreType keyStoreType, String path, String password, @Nullable String provider) {
+        checkArgumentNotNull(keyStoreType, "keyStoreType cannot be null");
+        return getKeyStore(keyStoreType.value, path, password, provider);
+    }
+
+    /**
      * Return an {@link Optional} containing a {@link KeyStore} for the given {@link KeyStoreType}, path, and
      * password, or an empty {@link Optional} if either path or password is null.
      * <p>
@@ -334,7 +426,34 @@ public class KiwiSecurity {
      *  @see KeyStore#load(java.io.InputStream, char[])
      */
     public static Optional<KeyStore> getKeyStore(String keyStoreType, String path, String password) {
-        LOG.trace("Get and load {} KeyStore/TrustStore for {}", keyStoreType, path);
+        return getKeyStore(keyStoreType, path, password, null);
+    }
+
+    /**
+     * Return an {@link Optional} containing a {@link KeyStore} for the given key store type, path, password,
+     * and JCE provider, or an empty {@link Optional} if either path or password is null.
+     * <p>
+     * This method is intended to load an <em>existing</em> key store. If you need to programmatically create a new
+     * one, use the {@link KeyStore} API directly.
+     * <p>
+     * If the returned Optional contains a KeyStore, it has been successfully loaded.
+     * <p>
+     * If a provider is given, {@link KeyStore#getInstance(String, String)} is used; otherwise
+     * {@link KeyStore#getInstance(String)} is used.
+     *
+     * @param keyStoreType the type of key store
+     * @param path         the path to the key store
+     * @param password     the key store password
+     * @param provider     the JCE provider name, or {@code null} to use the default provider
+     * @return an optional with a {@link KeyStore} or an empty optional
+     * @throws IllegalArgumentException if keyStoreType is blank
+     * @throws SSLContextException      if unable to create a {@link KeyStore}
+     * @see KeyStore#getInstance(String)
+     * @see KeyStore#getInstance(String, String)
+     * @see KeyStore#load(java.io.InputStream, char[])
+     */
+    public static Optional<KeyStore> getKeyStore(String keyStoreType, String path, String password, @Nullable String provider) {
+        LOG.trace("Get and load {} KeyStore/TrustStore for {} (provider: {})", keyStoreType, path, provider);
         if (isNull(path) || isNull(password)) {
             LOG.debug("No keystore specified (path and/or password is null)");
             return Optional.empty();
@@ -343,13 +462,15 @@ public class KiwiSecurity {
         checkArgumentNotBlank(keyStoreType, "keyStoreType cannot be blank");
 
         try {
-            var keyStore = KeyStore.getInstance(keyStoreType);
+            var keyStore = isNotBlank(provider)
+                    ? KeyStore.getInstance(keyStoreType, provider)
+                    : KeyStore.getInstance(keyStoreType);
             var keyStoreUrl = Paths.get(path).toUri().toURL();
             try (var inputStream = keyStoreUrl.openStream()) {
                 keyStore.load(inputStream, password.toCharArray());
             }
             return Optional.of(keyStore);
-        } catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException e) {
+        } catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException | NoSuchProviderException e) {
             throw new SSLContextException("Error getting key store", e);
         }
     }

--- a/src/main/java/org/kiwiproject/security/KiwiSecurity.java
+++ b/src/main/java/org/kiwiproject/security/KiwiSecurity.java
@@ -280,12 +280,12 @@ public class KiwiSecurity {
      * @param keyStorePath          path to the key store
      * @param keyStorePassword      password of the key store
      * @param keyStoreType          the key store type
-     * @param keyStoreProvider      the JCE provider name for the key store, or {@code null} to use the default provider
+     * @param keyStoreProvider      the JCE provider name for the key store, or {@code null} or blank to use the default provider
      * @param keyManagerAlgorithm   the key manager algorithm
      * @param trustStorePath        path to the trust store
      * @param trustStorePassword    password of the trust store
      * @param trustStoreType        the trust store type
-     * @param trustStoreProvider    the JCE provider name for the trust store, or {@code null} to use the default provider
+     * @param trustStoreProvider    the JCE provider name for the trust store, or {@code null} or blank to use the default provider
      * @param trustManagerAlgorithm the trust manager algorithm
      * @param protocol              the protocol to use
      * @return a new {@link SSLContext} instance
@@ -394,7 +394,7 @@ public class KiwiSecurity {
      * @param keyStoreType the type of key store
      * @param path         the path to the key store
      * @param password     the key store password
-     * @param provider     the JCE provider name, or {@code null} to use the default provider
+     * @param provider     the JCE provider name, or {@code null} or blank to use the default provider
      * @return an optional with a {@link KeyStore} or an empty optional
      * @throws IllegalArgumentException if keyStoreType is blank
      * @throws SSLContextException      if unable to create a {@link KeyStore}
@@ -444,7 +444,7 @@ public class KiwiSecurity {
      * @param keyStoreType the type of key store
      * @param path         the path to the key store
      * @param password     the key store password
-     * @param provider     the JCE provider name, or {@code null} to use the default provider
+     * @param provider     the JCE provider name, or {@code null} or blank to use the default provider
      * @return an optional with a {@link KeyStore} or an empty optional
      * @throws IllegalArgumentException if keyStoreType is blank
      * @throws SSLContextException      if unable to create a {@link KeyStore}

--- a/src/test/java/org/kiwiproject/security/KiwiSecurityTest.java
+++ b/src/test/java/org/kiwiproject/security/KiwiSecurityTest.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.UnrecoverableKeyException;
 import java.util.Locale;
 
@@ -114,6 +115,24 @@ class KiwiSecurityTest {
                 assertThat(KiwiSecurity.createSslContext(
                         null, null, null, null,
                         path, password, "JKS", TrustManagerFactory.getDefaultAlgorithm(), "TLSv1.2"))
+                        .isNotNull();
+            }
+
+            @Test
+            void whenUsingNullProviders() {
+                assertThat(KiwiSecurity.createSslContext(
+                        path, password, type, null, KeyManagerFactory.getDefaultAlgorithm(),
+                        path, password, type, null, TrustManagerFactory.getDefaultAlgorithm(),
+                        protocol.value))
+                        .isNotNull();
+            }
+
+            @Test
+            void whenUsingValidProviders() {
+                assertThat(KiwiSecurity.createSslContext(
+                        path, password, type, "SUN", KeyManagerFactory.getDefaultAlgorithm(),
+                        path, password, type, "SUN", TrustManagerFactory.getDefaultAlgorithm(),
+                        protocol.value))
                         .isNotNull();
             }
         }
@@ -317,6 +336,30 @@ class KiwiSecurityTest {
             }
 
             @Test
+            void whenInvalidKeyStoreProvider() {
+                assertThatThrownBy(() ->
+                        KiwiSecurity.createSslContext(
+                                path, password, storeType, "NotARealProvider", keyManagerAlgorithm,
+                                path, password, storeType, null, trustManagerAlgorithm,
+                                protocol))
+                        .hasMessage("Error creating SSLContext")
+                        .isExactlyInstanceOf(SSLContextException.class)
+                        .hasCauseExactlyInstanceOf(NoSuchProviderException.class);
+            }
+
+            @Test
+            void whenInvalidTrustStoreProvider() {
+                assertThatThrownBy(() ->
+                        KiwiSecurity.createSslContext(
+                                null, null, null, null, null,
+                                path, password, storeType, "NotARealProvider", trustManagerAlgorithm,
+                                protocol))
+                        .hasMessage("Error creating SSLContext")
+                        .isExactlyInstanceOf(SSLContextException.class)
+                        .hasCauseExactlyInstanceOf(NoSuchProviderException.class);
+            }
+
+            @Test
             void whenInvalidKeyManagerAlgorithm() {
                 assertThatThrownBy(() ->
                         KiwiSecurity.createSslContext(
@@ -369,6 +412,46 @@ class KiwiSecurityTest {
             void whenGivenNullPathOrPassword(String path, String password) {
                 assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password)).isEmpty();
             }
+
+            @Test
+            void whenValidStringTypeAndPathAndCredential_withNullProvider() {
+                assertThat(KiwiSecurity.getKeyStore("JKS", path, password, null)).isPresent();
+            }
+
+            @Test
+            void whenValidStringTypeAndPathAndCredential_withBlankProvider() {
+                assertThat(KiwiSecurity.getKeyStore("JKS", path, password, "")).isPresent();
+            }
+
+            @Test
+            void whenValidStringTypeAndPathAndCredential_withExplicitProvider() {
+                assertThat(KiwiSecurity.getKeyStore("JKS", path, password, "SUN")).isPresent();
+            }
+
+            @Test
+            void whenValidKeyStoreTypeAndPathAndCredential_withNullProvider() {
+                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password, null)).isPresent();
+            }
+
+            @Test
+            void whenValidKeyStoreTypeAndPathAndCredential_withBlankProvider() {
+                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password, "")).isPresent();
+            }
+
+            @Test
+            void whenValidKeyStoreTypeAndPathAndCredential_withExplicitProvider() {
+                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password, "SUN")).isPresent();
+            }
+
+            @ParameterizedTest
+            @CsvSource(value = {
+                "null, null",
+                "/certs/my.jks, null",
+                "null, the_password!"
+            }, nullValues = "null")
+            void whenGivenNullPathOrPassword_withProvider(String path, String password) {
+                assertThat(KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password, "SUN")).isEmpty();
+            }
         }
 
         @Nested
@@ -404,6 +487,24 @@ class KiwiSecurityTest {
                         .hasMessage("Error getting key store")
                         .hasCauseExactlyInstanceOf(IOException.class)
                         .hasRootCauseExactlyInstanceOf(UnrecoverableKeyException.class);
+            }
+
+            @Test
+            void whenInvalidProvider_withStringType() {
+                assertThatThrownBy(() ->
+                        KiwiSecurity.getKeyStore("JKS", path, password, "NotARealProvider"))
+                        .isExactlyInstanceOf(SSLContextException.class)
+                        .hasMessage("Error getting key store")
+                        .hasCauseExactlyInstanceOf(NoSuchProviderException.class);
+            }
+
+            @Test
+            void whenInvalidProvider_withKeyStoreType() {
+                assertThatThrownBy(() ->
+                        KiwiSecurity.getKeyStore(KeyStoreType.JKS, path, password, "NotARealProvider"))
+                        .isExactlyInstanceOf(SSLContextException.class)
+                        .hasMessage("Error getting key store")
+                        .hasCauseExactlyInstanceOf(NoSuchProviderException.class);
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR adds support for specifying custom JCE (Java Cryptography Extension) providers when creating SSL contexts and loading keystores. This allows users to use alternative cryptographic providers beyond the default JDK providers.

## Key Changes
- Added `NoSuchProviderException` import to handle provider-related errors
- Introduced new overloaded `createSslContext()` method that accepts `keyStoreProvider` and `trustStoreProvider` parameters
- Refactored existing `createSslContext()` method to delegate to the new provider-aware version with null providers
- Added two new overloaded `getKeyStore()` methods that accept an optional `provider` parameter:
  - One accepting `KeyStoreType` enum
  - One accepting `String` keyStoreType
- Refactored existing `getKeyStore()` methods to delegate to the new provider-aware versions
- Updated `KeyStore.getInstance()` calls to conditionally use the provider-specific variant when a provider is specified
- Enhanced logging to include provider information in trace messages
- Added `NoSuchProviderException` to the caught exception types in keystore loading

## Notable Implementation Details
- The provider parameter is optional (`@Nullable`) and defaults to null, maintaining backward compatibility
- When a provider is specified, `KeyStore.getInstance(String, String)` is used; otherwise `KeyStore.getInstance(String)` is used
- The existing `createSslContext()` method now acts as a convenience wrapper that calls the new provider-aware version
- All new methods include comprehensive JavaDoc with warnings about low-level usage and recommendations to use higher-level constructs
- The `@SuppressWarnings("java:S107")` annotation is applied to the new method with many parameters to suppress SonarQube warnings about method complexity

Closes #1408 