### PR TITLE
Add JCE provider support to SSLContextConfiguration

### DIFF
--- a/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
@@ -28,6 +28,8 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
     private String protocol = SSLContextProtocol.TLS_1_3.getValue();
     private String keyStoreType = KeyStoreType.JKS.value;
     private String trustStoreType = KeyStoreType.JKS.value;
+    private String keyStoreProvider;
+    private String trustStoreProvider;
     private boolean verifyHostname = true;
     private boolean disableSniHostCheck;
 
@@ -106,6 +108,24 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
             return this;
         }
 
+        public Builder keyStoreProvider(String keyStoreProvider) {
+            return setKeyStoreProvider(keyStoreProvider);
+        }
+
+        public Builder setKeyStoreProvider(String keyStoreProvider) {
+            configuration.setKeyStoreProvider(keyStoreProvider);
+            return this;
+        }
+
+        public Builder trustStoreProvider(String trustStoreProvider) {
+            return setTrustStoreProvider(trustStoreProvider);
+        }
+
+        public Builder setTrustStoreProvider(String trustStoreProvider) {
+            configuration.setTrustStoreProvider(trustStoreProvider);
+            return this;
+        }
+
         public Builder verifyHostname(boolean verifyHostname) {
             return setVerifyHostname(verifyHostname);
         }
@@ -164,15 +184,27 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
      * @return a new instance
      */
     public SimpleSSLContextFactory toSimpleSSLContextFactory() {
-        return new SimpleSSLContextFactory(keyStorePath,
-                keyStorePassword,
-                keyStoreType,
-                trustStorePath,
-                trustStorePassword,
-                trustStoreType,
-                protocol,
-                verifyHostname,
-                disableSniHostCheck);
+        var builder = SimpleSSLContextFactory.builder()
+                .keyStoreType(keyStoreType)
+                .trustStorePath(trustStorePath)
+                .trustStorePassword(trustStorePassword)
+                .trustStoreType(trustStoreType)
+                .protocol(protocol)
+                .verifyHostname(verifyHostname)
+                .disableSniHostCheck(disableSniHostCheck);
+        if (keyStorePath != null) {
+            builder.keyStorePath(keyStorePath);
+        }
+        if (keyStorePassword != null) {
+            builder.keyStorePassword(keyStorePassword);
+        }
+        if (keyStoreProvider != null) {
+            builder.keyStoreProvider(keyStoreProvider);
+        }
+        if (trustStoreProvider != null) {
+            builder.trustStoreProvider(trustStoreProvider);
+        }
+        return builder.build();
     }
 
     /**
@@ -185,9 +217,11 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
                 .keyStorePath(keyStorePath)
                 .keyStorePassword(keyStorePassword)
                 .keyStoreType(keyStoreType)
+                .keyStoreProvider(keyStoreProvider)
                 .trustStorePath(trustStorePath)
                 .trustStorePassword(trustStorePassword)
                 .trustStoreType(trustStoreType)
+                .trustStoreProvider(trustStoreProvider)
                 .protocol(protocol)
                 .verifyHostname(verifyHostname)
                 .disableSniHostCheck(disableSniHostCheck)

--- a/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
@@ -9,8 +9,6 @@ import org.kiwiproject.security.KeyStoreType;
 import org.kiwiproject.security.SSLContextProtocol;
 import org.kiwiproject.security.SimpleSSLContextFactory;
 
-import static java.util.Objects.nonNull;
-
 import javax.net.ssl.SSLContext;
 
 /**
@@ -186,27 +184,19 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
      * @return a new instance
      */
     public SimpleSSLContextFactory toSimpleSSLContextFactory() {
-        var builder = SimpleSSLContextFactory.builder()
+        return SimpleSSLContextFactory.builder()
+                .keyStorePath(keyStorePath)
+                .keyStorePassword(keyStorePassword)
                 .keyStoreType(keyStoreType)
+                .keyStoreProvider(keyStoreProvider)
                 .trustStorePath(trustStorePath)
                 .trustStorePassword(trustStorePassword)
                 .trustStoreType(trustStoreType)
+                .trustStoreProvider(trustStoreProvider)
                 .protocol(protocol)
                 .verifyHostname(verifyHostname)
-                .disableSniHostCheck(disableSniHostCheck);
-        if (nonNull(keyStorePath)) {
-            builder.keyStorePath(keyStorePath);
-        }
-        if (nonNull(keyStorePassword)) {
-            builder.keyStorePassword(keyStorePassword);
-        }
-        if (nonNull(keyStoreProvider)) {
-            builder.keyStoreProvider(keyStoreProvider);
-        }
-        if (nonNull(trustStoreProvider)) {
-            builder.trustStoreProvider(trustStoreProvider);
-        }
-        return builder.build();
+                .disableSniHostCheck(disableSniHostCheck)
+                .build();
     }
 
     /**

--- a/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/SSLContextConfiguration.java
@@ -9,6 +9,8 @@ import org.kiwiproject.security.KeyStoreType;
 import org.kiwiproject.security.SSLContextProtocol;
 import org.kiwiproject.security.SimpleSSLContextFactory;
 
+import static java.util.Objects.nonNull;
+
 import javax.net.ssl.SSLContext;
 
 /**
@@ -192,16 +194,16 @@ public class SSLContextConfiguration implements KeyAndTrustStoreConfigProvider {
                 .protocol(protocol)
                 .verifyHostname(verifyHostname)
                 .disableSniHostCheck(disableSniHostCheck);
-        if (keyStorePath != null) {
+        if (nonNull(keyStorePath)) {
             builder.keyStorePath(keyStorePath);
         }
-        if (keyStorePassword != null) {
+        if (nonNull(keyStorePassword)) {
             builder.keyStorePassword(keyStorePassword);
         }
-        if (keyStoreProvider != null) {
+        if (nonNull(keyStoreProvider)) {
             builder.keyStoreProvider(keyStoreProvider);
         }
-        if (trustStoreProvider != null) {
+        if (nonNull(trustStoreProvider)) {
             builder.trustStoreProvider(trustStoreProvider);
         }
         return builder.build();

--- a/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
@@ -325,8 +325,8 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
     /**
      * Convert this configuration into a {@link SSLContextConfiguration}.
      * <p>
-     * Note that {@link SSLContextConfiguration} does not have {@code provider}, {@code keyStoreProvider},
-     * {@code trustStoreProvider}, {@code trustSelfSignedCertificates}, {@code supportedProtocols},
+     * Note that {@link SSLContextConfiguration} does not have {@code provider},
+     * {@code trustSelfSignedCertificates}, {@code supportedProtocols},
      * {@code supportedCiphers}, or {@code certAlias}. As a result, this is a "lossy" conversion since it loses
      * these values.
      *
@@ -337,9 +337,11 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
                 .keyStorePath(keyStorePath)
                 .keyStorePassword(keyStorePassword)
                 .keyStoreType(keyStoreType)
+                .keyStoreProvider(keyStoreProvider)
                 .trustStorePath(trustStorePath)
                 .trustStorePassword(trustStorePassword)
                 .trustStoreType(trustStoreType)
+                .trustStoreProvider(trustStoreProvider)
                 .protocol(protocol)
                 .verifyHostname(verifyHostname)
                 .disableSniHostCheck(disableSniHostCheck)

--- a/src/main/java/org/kiwiproject/security/SimpleSSLContextFactory.java
+++ b/src/main/java/org/kiwiproject/security/SimpleSSLContextFactory.java
@@ -229,7 +229,7 @@ public class SimpleSSLContextFactory {
         }
 
         public Builder setKeyStorePath(String keyStorePath) {
-            entries.put(KEY_STORE_PATH_PROPERTY, Optional.of(keyStorePath));
+            entries.put(KEY_STORE_PATH_PROPERTY, Optional.ofNullable(keyStorePath));
             return this;
         }
 
@@ -238,7 +238,7 @@ public class SimpleSSLContextFactory {
         }
 
         public Builder setKeyStorePassword(String keyStorePassword) {
-            entries.put(KEY_STORE_PASSWORD_PROPERTY, Optional.of(keyStorePassword));
+            entries.put(KEY_STORE_PASSWORD_PROPERTY, Optional.ofNullable(keyStorePassword));
             return this;
         }
 
@@ -256,7 +256,7 @@ public class SimpleSSLContextFactory {
         }
 
         public Builder setKeyStoreProvider(String keyStoreProvider) {
-            entries.put(KEY_STORE_PROVIDER_PROPERTY, Optional.of(keyStoreProvider));
+            entries.put(KEY_STORE_PROVIDER_PROPERTY, Optional.ofNullable(keyStoreProvider));
             return this;
         }
 
@@ -292,7 +292,7 @@ public class SimpleSSLContextFactory {
         }
 
         public Builder setTrustStoreProvider(String trustStoreProvider) {
-            entries.put(TRUST_STORE_PROVIDER_PROPERTY, Optional.of(trustStoreProvider));
+            entries.put(TRUST_STORE_PROVIDER_PROPERTY, Optional.ofNullable(trustStoreProvider));
             return this;
         }
 

--- a/src/test/java/org/kiwiproject/config/SSLContextConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/config/SSLContextConfigurationTest.java
@@ -80,13 +80,59 @@ class SSLContextConfigurationTest {
                 () -> assertThat(tlsConfig.getKeyStorePath()).isEqualTo(sslConfig.getKeyStorePath()),
                 () -> assertThat(tlsConfig.getKeyStorePassword()).isEqualTo(sslConfig.getKeyStorePassword()),
                 () -> assertThat(tlsConfig.getKeyStoreType()).isEqualTo(sslConfig.getKeyStoreType()),
+                () -> assertThat(tlsConfig.getKeyStoreProvider()).isNull(),
                 () -> assertThat(tlsConfig.getTrustStorePath()).isEqualTo(sslConfig.getTrustStorePath()),
                 () -> assertThat(tlsConfig.getTrustStorePassword()).isEqualTo(sslConfig.getTrustStorePassword()),
                 () -> assertThat(tlsConfig.getTrustStoreType()).isEqualTo(sslConfig.getTrustStoreType()),
+                () -> assertThat(tlsConfig.getTrustStoreProvider()).isNull(),
                 () -> assertThat(tlsConfig.isVerifyHostname()).isEqualTo(sslConfig.isVerifyHostname()),
                 () -> assertThat(tlsConfig.isDisableSniHostCheck()).isEqualTo(sslConfig.isDisableSniHostCheck()),
                 () -> assertThat(tlsConfig.getProtocol()).isEqualTo(sslConfig.getProtocol()),
                 () -> assertThat(tlsConfig.getSupportedProtocols()).isNull()
+        );
+    }
+
+    @Test
+    void shouldPreserveProviderPropertiesWhenConvertingToTlsContextConfiguration() {
+        var sslConfig = SSLContextConfiguration.builder()
+                .keyStorePath(path)
+                .keyStorePassword(password)
+                .keyStoreType(type)
+                .keyStoreProvider("SUN")
+                .trustStorePath(path)
+                .trustStorePassword(password)
+                .trustStoreType(type)
+                .trustStoreProvider("SUN")
+                .protocol(protocol)
+                .build();
+
+        var tlsConfig = sslConfig.toTlsContextConfiguration();
+
+        assertAll(
+                () -> assertThat(tlsConfig.getKeyStoreProvider()).isEqualTo("SUN"),
+                () -> assertThat(tlsConfig.getTrustStoreProvider()).isEqualTo("SUN")
+        );
+    }
+
+    @Test
+    void shouldPreserveProviderPropertiesWhenConvertingToSimpleSSLContextFactory() {
+        var sslConfig = SSLContextConfiguration.builder()
+                .keyStorePath(path)
+                .keyStorePassword(password)
+                .keyStoreType(KeyStoreType.JKS.value)
+                .keyStoreProvider("SUN")
+                .trustStorePath(path)
+                .trustStorePassword(password)
+                .trustStoreType(KeyStoreType.JKS.value)
+                .trustStoreProvider("SUN")
+                .protocol(protocol)
+                .build();
+
+        var factoryConfig = sslConfig.toSimpleSSLContextFactory().configuration();
+
+        assertAll(
+                () -> assertThat(factoryConfig).containsEntry("keyStoreProvider", "SUN"),
+                () -> assertThat(factoryConfig).containsEntry("trustStoreProvider", "SUN")
         );
     }
 

--- a/src/test/java/org/kiwiproject/config/TlsContextConfigurationTest.java
+++ b/src/test/java/org/kiwiproject/config/TlsContextConfigurationTest.java
@@ -510,9 +510,33 @@ class TlsContextConfigurationTest {
                         () -> assertThat(sslConfig.getKeyStorePath()).isEqualTo("/data/pki/key-store.pkcs12"),
                         () -> assertThat(sslConfig.getKeyStorePassword()).isEqualTo("myKsPassword"),
                         () -> assertThat(sslConfig.getKeyStoreType()).isEqualTo(KeyStoreType.PKCS12.value),
+                        () -> assertThat(sslConfig.getKeyStoreProvider()).isNull(),
                         () -> assertThat(sslConfig.getTrustStorePath()).isEqualTo("/data/pki/trust-store.pkcs12"),
                         () -> assertThat(sslConfig.getTrustStorePassword()).isEqualTo("myTsPassword"),
-                        () -> assertThat(sslConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value)
+                        () -> assertThat(sslConfig.getTrustStoreType()).isEqualTo(KeyStoreType.PKCS12.value),
+                        () -> assertThat(sslConfig.getTrustStoreProvider()).isNull()
+                );
+            }
+
+            @Test
+            void shouldPreserveProviderPropertiesWhenConvertingToSslContextConfiguration() {
+                var tlsContextConfig = TlsContextConfiguration.builder()
+                        .protocol(SSLContextProtocol.TLS_1_3.value)
+                        .keyStorePath("/data/pki/key-store.pkcs12")
+                        .keyStorePassword("myKsPassword")
+                        .keyStoreType(KeyStoreType.PKCS12.value)
+                        .keyStoreProvider("SUN")
+                        .trustStorePath("/data/pki/trust-store.pkcs12")
+                        .trustStorePassword("myTsPassword")
+                        .trustStoreType(KeyStoreType.PKCS12.value)
+                        .trustStoreProvider("SUN")
+                        .build();
+
+                var sslConfig = tlsContextConfig.toSslContextConfiguration();
+
+                assertAll(
+                        () -> assertThat(sslConfig.getKeyStoreProvider()).isEqualTo("SUN"),
+                        () -> assertThat(sslConfig.getTrustStoreProvider()).isEqualTo("SUN")
                 );
             }
 


### PR DESCRIPTION
Closes #1413

## Summary

- Adds `keyStoreProvider` and `trustStoreProvider` fields to `SSLContextConfiguration` (getters/setters come free from class-level Lombok `@Getter`/`@Setter`)
- Adds `keyStoreProvider`/`setKeyStoreProvider` and `trustStoreProvider`/`setTrustStoreProvider` builder methods
- Updates `toSimpleSSLContextFactory()` to use the `SimpleSSLContextFactory` builder so both providers are passed through
- Updates `toTlsContextConfiguration()` to include both providers
- Updates `TlsContextConfiguration.toSslContextConfiguration()` to pass both providers through, and revises its Javadoc to remove `keyStoreProvider` and `trustStoreProvider` from the "lossy" list

Note: the top-level `provider` field on `TlsContextConfiguration` (for the `SSLContext` itself, analogous to `SSLContext.getInstance(String, String)`) is intentionally out of scope — supporting it would require separate changes to `KiwiSecurity`.

Part of #970.