### PR TITLE
fix: Remove keystore path from TRACE log in KiwiSecurity

### DIFF
--- a/src/main/java/org/kiwiproject/security/KiwiSecurity.java
+++ b/src/main/java/org/kiwiproject/security/KiwiSecurity.java
@@ -453,7 +453,7 @@ public class KiwiSecurity {
      * @see KeyStore#load(java.io.InputStream, char[])
      */
     public static Optional<KeyStore> getKeyStore(String keyStoreType, String path, String password, @Nullable String provider) {
-        LOG.trace("Get and load {} KeyStore/TrustStore for {} (provider: {})", keyStoreType, path, provider);
+        LOG.trace("Get and load {} KeyStore/TrustStore (provider: {})", keyStoreType, provider);
         if (isNull(path) || isNull(password)) {
             LOG.debug("No keystore specified (path and/or password is null)");
             return Optional.empty();


### PR DESCRIPTION
CodeQL reported an "Insertion of sensitive information into log files" finding
introduced in #1409. The keystore/truststore filesystem path was being logged
at TRACE level, revealing the on-disk location of security-critical files.

Removed the path from the log argument list; the keystore type and JCE provider
remain, which are sufficient for diagnostic context without leaking sensitive
path information.