### PR TITLE
fix: Remove stale @implNote from fromDropwizardTlsConfiguration

### DIFF
--- a/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
+++ b/src/main/java/org/kiwiproject/config/TlsContextConfiguration.java
@@ -257,7 +257,6 @@ public class TlsContextConfiguration implements KeyAndTrustStoreConfigProvider {
      *
      * @param tlsConfig the Dropwizard TlsConfiguration from which to pull information
      * @return a new TlsContextConfiguration instance
-     * @implNote Currently we do not support {@code supportedCiphers} or {@code certAlias}, which Dropwizard does.
      */
     public static TlsContextConfiguration fromDropwizardTlsConfiguration(TlsConfiguration tlsConfig) {
         checkArgumentNotNull(tlsConfig, "TlsConfiguration cannot be null");


### PR DESCRIPTION
The @implNote on fromDropwizardTlsConfiguration claimed that
supportedCiphers and certAlias were not supported, but the
implementation maps both fields from the Dropwizard TlsConfiguration.
The note was never updated after those fields were added to the
conversion.