### PR TITLE
feat: add ExecutionStrategy, ExecutionStrategies, and SystemExecutioner

### DIFF
--- a/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
@@ -104,7 +104,7 @@ public class ExecutionStrategies {
          * @return an OptionalInt containing the exit code, or empty if exit was never called
          */
         public OptionalInt exitCode() {
-            return didExit.get() ? OptionalInt.of(exitCode.get()) : OptionalInt.empty();
+            return didExit() ? OptionalInt.of(exitCode.get()) : OptionalInt.empty();
         }
     }
 }

--- a/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
@@ -1,9 +1,10 @@
 package org.kiwiproject.base.system;
 
-import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.OptionalInt;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -22,8 +23,8 @@ public class ExecutionStrategies {
     }
 
     /**
-     * Returns a strategy that "flags" when the {@code exit()} method is called, but does not actually
-     * terminate the JVM.
+     * Returns a strategy that "flags" when the {@code exit(int)} method is called, but does not actually
+     * terminate the JVM. Intended for use in integration tests where the JVM should not actually exit.
      *
      * @return an exit-flagging ExecutionStrategy
      */
@@ -34,20 +35,10 @@ public class ExecutionStrategies {
     /**
      * Returns a strategy that uses the {@link System} class to exit/terminate the JVM.
      *
-     * @return a strategy that uses {@link System#exit(int)} that sets the exit code to 1 (one)
+     * @return a strategy that uses {@link System#exit(int)}
      */
     public static SystemExitExecutionStrategy systemExit() {
         return new SystemExitExecutionStrategy();
-    }
-
-    /**
-     * Returns a strategy that uses the {@link System} class to exit/terminate the JVM.
-     *
-     * @param exitCode the exit code that will be supplied to {@link System#exit(int)}
-     * @return a strategy that uses {@link System#exit(int)} that uses the given exit code
-     */
-    public static SystemExitExecutionStrategy systemExit(int exitCode) {
-        return new SystemExitExecutionStrategy(exitCode);
     }
 
     /**
@@ -56,30 +47,13 @@ public class ExecutionStrategies {
     @Slf4j
     public static class SystemExitExecutionStrategy implements ExecutionStrategy {
 
-        @Getter
-        private final int exitCode;
-
         /**
-         * Construct an instance that will set the exit code to 1 (one).
-         */
-        public SystemExitExecutionStrategy() {
-            this(1);
-        }
-
-        /**
-         * Construct an instance that will use the given exit code.
+         * Terminates the currently running JVM with the given exit code.
          *
-         * @param exitCode the exit code for {@link System#exit(int)}
-         */
-        public SystemExitExecutionStrategy(int exitCode) {
-            this.exitCode = exitCode;
-        }
-
-        /**
-         * Terminates the currently running JVM.
+         * @param exitCode the exit code, following the same conventions as {@link System#exit(int)}
          */
         @Override
-        public void exit() {
+        public void exit(int exitCode) {
             LOG.warn("Terminating the VM!");
             System.exit(exitCode);
         }
@@ -94,31 +68,43 @@ public class ExecutionStrategies {
          * A no-op. Mainly useful in unit testing scenarios.
          */
         @Override
-        public void exit() {
+        public void exit(int exitCode) {
             // Intentionally empty
         }
     }
 
     /**
-     * Implementation of {@link ExecutionStrategy} that "flags" a call to {@link #exit()} but does not actually
-     * exit the JVM.
+     * Implementation of {@link ExecutionStrategy} that "flags" a call to {@link #exit(int)} but does not actually
+     * exit the JVM. Intended for use in integration tests where the JVM should not actually exit, but code can
+     * verify that exit would have been called and with what exit code.
      */
     public static class ExitFlaggingExecutionStrategy implements ExecutionStrategy {
 
         private final AtomicBoolean didExit = new AtomicBoolean();
+        private final AtomicInteger exitCode = new AtomicInteger();
 
         @Override
-        public void exit() {
+        public void exit(int exitCode) {
+            this.exitCode.set(exitCode);
             didExit.set(true);
         }
 
         /**
-         * Was {@link #exit()} called?
+         * Was {@link #exit(int)} called?
          *
          * @return true if exit was called, otherwise false
          */
         public boolean didExit() {
             return didExit.get();
+        }
+
+        /**
+         * Returns the exit code passed to {@link #exit(int)}, or an empty OptionalInt if exit was never called.
+         *
+         * @return an OptionalInt containing the exit code, or empty if exit was never called
+         */
+        public OptionalInt exitCode() {
+            return didExit.get() ? OptionalInt.of(exitCode.get()) : OptionalInt.empty();
         }
     }
 }

--- a/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
@@ -4,8 +4,8 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.OptionalInt;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Factory for {@link ExecutionStrategy} instances.
@@ -54,7 +54,7 @@ public class ExecutionStrategies {
          */
         @Override
         public void exit(int exitCode) {
-            LOG.warn("Terminating the VM!");
+            LOG.warn("Terminating the VM with exit code {}", exitCode);
             System.exit(exitCode);
         }
     }

--- a/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
+++ b/src/main/java/org/kiwiproject/base/system/ExecutionStrategies.java
@@ -1,0 +1,124 @@
+package org.kiwiproject.base.system;
+
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Factory for {@link ExecutionStrategy} instances.
+ */
+@UtilityClass
+public class ExecutionStrategies {
+
+    /**
+     * Returns a strategy that does nothing (is a "no-op").
+     *
+     * @return a no-op ExecutionStrategy
+     */
+    public static NoOpExecutionStrategy noOp() {
+        return new NoOpExecutionStrategy();
+    }
+
+    /**
+     * Returns a strategy that "flags" when the {@code exit()} method is called, but does not actually
+     * terminate the JVM.
+     *
+     * @return an exit-flagging ExecutionStrategy
+     */
+    public static ExitFlaggingExecutionStrategy exitFlagging() {
+        return new ExitFlaggingExecutionStrategy();
+    }
+
+    /**
+     * Returns a strategy that uses the {@link System} class to exit/terminate the JVM.
+     *
+     * @return a strategy that uses {@link System#exit(int)} that sets the exit code to 1 (one)
+     */
+    public static SystemExitExecutionStrategy systemExit() {
+        return new SystemExitExecutionStrategy();
+    }
+
+    /**
+     * Returns a strategy that uses the {@link System} class to exit/terminate the JVM.
+     *
+     * @param exitCode the exit code that will be supplied to {@link System#exit(int)}
+     * @return a strategy that uses {@link System#exit(int)} that uses the given exit code
+     */
+    public static SystemExitExecutionStrategy systemExit(int exitCode) {
+        return new SystemExitExecutionStrategy(exitCode);
+    }
+
+    /**
+     * Implementation of {@link ExecutionStrategy} that uses {@link System#exit(int)}.
+     */
+    @Slf4j
+    public static class SystemExitExecutionStrategy implements ExecutionStrategy {
+
+        @Getter
+        private final int exitCode;
+
+        /**
+         * Construct an instance that will set the exit code to 1 (one).
+         */
+        public SystemExitExecutionStrategy() {
+            this(1);
+        }
+
+        /**
+         * Construct an instance that will use the given exit code.
+         *
+         * @param exitCode the exit code for {@link System#exit(int)}
+         */
+        public SystemExitExecutionStrategy(int exitCode) {
+            this.exitCode = exitCode;
+        }
+
+        /**
+         * Terminates the currently running JVM.
+         */
+        @Override
+        public void exit() {
+            LOG.warn("Terminating the VM!");
+            System.exit(exitCode);
+        }
+    }
+
+    /**
+     * Implementation of {@link ExecutionStrategy} that does nothing.
+     */
+    public static class NoOpExecutionStrategy implements ExecutionStrategy {
+
+        /**
+         * A no-op. Mainly useful in unit testing scenarios.
+         */
+        @Override
+        public void exit() {
+            // Intentionally empty
+        }
+    }
+
+    /**
+     * Implementation of {@link ExecutionStrategy} that "flags" a call to {@link #exit()} but does not actually
+     * exit the JVM.
+     */
+    public static class ExitFlaggingExecutionStrategy implements ExecutionStrategy {
+
+        private final AtomicBoolean didExit = new AtomicBoolean();
+
+        @Override
+        public void exit() {
+            didExit.set(true);
+        }
+
+        /**
+         * Was {@link #exit()} called?
+         *
+         * @return true if exit was called, otherwise false
+         */
+        public boolean didExit() {
+            return didExit.get();
+        }
+    }
+}

--- a/src/main/java/org/kiwiproject/base/system/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/base/system/ExecutionStrategy.java
@@ -6,7 +6,9 @@ package org.kiwiproject.base.system;
 public interface ExecutionStrategy {
 
     /**
-     * Performs the exit operation.
+     * Performs the exit operation using the given exit code.
+     *
+     * @param exitCode the exit code, following the same conventions as {@link System#exit(int)}
      */
-    void exit();
+    void exit(int exitCode);
 }

--- a/src/main/java/org/kiwiproject/base/system/ExecutionStrategy.java
+++ b/src/main/java/org/kiwiproject/base/system/ExecutionStrategy.java
@@ -1,0 +1,12 @@
+package org.kiwiproject.base.system;
+
+/**
+ * Defines a strategy used in {@link SystemExecutioner} to terminate the JVM.
+ */
+public interface ExecutionStrategy {
+
+    /**
+     * Performs the exit operation.
+     */
+    void exit();
+}

--- a/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
@@ -13,7 +13,7 @@ import java.time.Duration;
  * Wrapper around {@link System#exit(int)} for situations in which the JVM must be exited. This class is mainly
  * intended for scenarios in which production code may call {@link System#exit(int)} in order to allow unit testing
  * of the exit behavior, but without actually exiting the JVM. For example, a Jetty server that cannot start due to
- * failure to obtain a port, or any other non-recoverable startup error that would otherwise result in a hung or
+ * failure to get a port or any other non-recoverable startup error that would otherwise result in a hung or
  * unresponsive server, application, resource, etc. In situations like this, you can test that the
  * {@link SystemExecutioner} would have exited when specific errors occur.
  * <p>

--- a/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
@@ -5,6 +5,7 @@ import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.DefaultEnvironment;
+import org.kiwiproject.time.KiwiDurationFormatters;
 
 import java.time.Duration;
 
@@ -65,7 +66,7 @@ public class SystemExecutioner {
      */
     public void exit(int exitCode, Duration waitTime) {
         requireNotNull(waitTime, "waitTime must not be null");
-        LOG.warn("Waiting {} before exiting", waitTime);
+        LOG.warn("Waiting {} before exiting", KiwiDurationFormatters.formatJavaDurationWords(waitTime));
         new DefaultEnvironment().sleepQuietly(waitTime);
         exit(exitCode);
     }

--- a/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.DefaultEnvironment;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 /**
  * Wrapper around {@link System#exit(int)} for situations in which the JVM must be exited. This class is mainly
@@ -19,7 +19,8 @@ import java.util.concurrent.TimeUnit;
  * The no-args constructor uses the {@link ExecutionStrategies.SystemExitExecutionStrategy}, which uses
  * {@link System#exit(int)} to terminate the JVM. You can supply your own {@link ExecutionStrategy} as well, for
  * example {@link ExecutionStrategies.NoOpExecutionStrategy} is useful in unit tests (so it doesn't actually terminate
- * the JVM).
+ * the JVM), and {@link ExecutionStrategies.ExitFlaggingExecutionStrategy} is useful in integration tests where you
+ * want to verify the exit code without terminating the JVM.
  */
 @Slf4j
 public class SystemExecutioner {
@@ -48,21 +49,23 @@ public class SystemExecutioner {
     }
 
     /**
-     * Exits immediately.
+     * Exits immediately with the given exit code.
+     *
+     * @param exitCode the exit code, following the same conventions as {@link System#exit(int)}
      */
-    public void exit() {
-        executionStrategy.exit();
+    public void exit(int exitCode) {
+        executionStrategy.exit(exitCode);
     }
 
     /**
-     * Waits the given amount of time, then exits.
+     * Waits the given duration, then exits with the given exit code.
      *
-     * @param waitTime     the wait time amount
-     * @param waitTimeUnit the wait time unit
+     * @param exitCode the exit code, following the same conventions as {@link System#exit(int)}
+     * @param waitTime the amount of time to wait before exiting
      */
-    public void exit(long waitTime, TimeUnit waitTimeUnit) {
-        LOG.warn("Waiting {} {} before exiting", waitTime, waitTimeUnit);
-        new DefaultEnvironment().sleepQuietly(waitTime, waitTimeUnit);
-        exit();
+    public void exit(int exitCode, Duration waitTime) {
+        LOG.warn("Waiting {} before exiting", waitTime);
+        new DefaultEnvironment().sleepQuietly(waitTime);
+        exit(exitCode);
     }
 }

--- a/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
@@ -64,6 +64,7 @@ public class SystemExecutioner {
      * @param waitTime the amount of time to wait before exiting
      */
     public void exit(int exitCode, Duration waitTime) {
+        requireNotNull(waitTime, "waitTime must not be null");
         LOG.warn("Waiting {} before exiting", waitTime);
         new DefaultEnvironment().sleepQuietly(waitTime);
         exit(exitCode);

--- a/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
@@ -1,11 +1,11 @@
 package org.kiwiproject.base.system;
 
 import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+import static org.kiwiproject.time.KiwiDurationFormatters.formatJavaDurationWords;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.kiwiproject.base.DefaultEnvironment;
-import org.kiwiproject.time.KiwiDurationFormatters;
 
 import java.time.Duration;
 
@@ -66,7 +66,7 @@ public class SystemExecutioner {
      */
     public void exit(int exitCode, Duration waitTime) {
         requireNotNull(waitTime, "waitTime must not be null");
-        LOG.warn("Waiting {} before exiting", KiwiDurationFormatters.formatJavaDurationWords(waitTime));
+        LOG.warn("Waiting {} before exiting", formatJavaDurationWords(waitTime));
         new DefaultEnvironment().sleepQuietly(waitTime);
         exit(exitCode);
     }

--- a/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
+++ b/src/main/java/org/kiwiproject/base/system/SystemExecutioner.java
@@ -1,0 +1,68 @@
+package org.kiwiproject.base.system;
+
+import static org.kiwiproject.base.KiwiPreconditions.requireNotNull;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.kiwiproject.base.DefaultEnvironment;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wrapper around {@link System#exit(int)} for situations in which the JVM must be exited. This class is mainly
+ * intended for scenarios in which production code may call {@link System#exit(int)} in order to allow unit testing
+ * of the exit behavior, but without actually exiting the JVM. For example, a Jetty server that cannot start due to
+ * failure to obtain a port, or any other non-recoverable startup error that would otherwise result in a hung or
+ * unresponsive server, application, resource, etc. In situations like this, you can test that the
+ * {@link SystemExecutioner} would have exited when specific errors occur.
+ * <p>
+ * The no-args constructor uses the {@link ExecutionStrategies.SystemExitExecutionStrategy}, which uses
+ * {@link System#exit(int)} to terminate the JVM. You can supply your own {@link ExecutionStrategy} as well, for
+ * example {@link ExecutionStrategies.NoOpExecutionStrategy} is useful in unit tests (so it doesn't actually terminate
+ * the JVM).
+ */
+@Slf4j
+public class SystemExecutioner {
+
+    /**
+     * The execution strategy to use when one of the {@code exit} methods is called.
+     */
+    @Getter
+    private final ExecutionStrategy executionStrategy;
+
+    /**
+     * Creates a new {@link SystemExecutioner} using the default {@link ExecutionStrategy}, which is
+     * {@link ExecutionStrategies.SystemExitExecutionStrategy}.
+     */
+    public SystemExecutioner() {
+        this(ExecutionStrategies.systemExit());
+    }
+
+    /**
+     * Creates a new {@link SystemExecutioner} using the given {@link ExecutionStrategy}.
+     *
+     * @param executionStrategy the strategy to use
+     */
+    public SystemExecutioner(ExecutionStrategy executionStrategy) {
+        this.executionStrategy = requireNotNull(executionStrategy, "executionStrategy must not be null");
+    }
+
+    /**
+     * Exits immediately.
+     */
+    public void exit() {
+        executionStrategy.exit();
+    }
+
+    /**
+     * Waits the given amount of time, then exits.
+     *
+     * @param waitTime     the wait time amount
+     * @param waitTimeUnit the wait time unit
+     */
+    public void exit(long waitTime, TimeUnit waitTimeUnit) {
+        LOG.warn("Waiting {} {} before exiting", waitTime, waitTimeUnit);
+        new DefaultEnvironment().sleepQuietly(waitTime, waitTimeUnit);
+        exit();
+    }
+}

--- a/src/test/java/org/kiwiproject/base/system/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/base/system/ExecutionStrategiesTest.java
@@ -11,10 +11,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.kiwiproject.base.process.Processes;
-import org.kiwiproject.base.system.ExecutionStrategies.SystemExitExecutionStrategy;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -29,29 +29,22 @@ class ExecutionStrategiesTest {
     }
 
     @Test
-    void shouldBuildSystemExitStrategy() {
-        var strategy = ExecutionStrategies.systemExit();
-        assertThat(strategy).isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
-        assertThat(strategy.getExitCode()).isEqualTo(1);
+    void shouldBuildExitFlaggingStrategy() {
+        assertThat(ExecutionStrategies.exitFlagging())
+                .isExactlyInstanceOf(ExecutionStrategies.ExitFlaggingExecutionStrategy.class);
     }
 
     @Test
-    void shouldBuildSystemExitStrategyWithExitCode() {
-        var strategy = ExecutionStrategies.systemExit(42);
-        assertThat(strategy).isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
-        assertThat(strategy.getExitCode()).isEqualTo(42);
+    void shouldBuildSystemExitStrategy() {
+        assertThat(ExecutionStrategies.systemExit())
+                .isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
     }
 
-    // This is silly, and is here to simply show that the return type change
-    // doesn't affect existing methods that accepts ExecutionStrategy or code
-    // that declares a field or variable as ExecutionStrategy, as 'var' using
-    // LTVI, or explicitly as the exact type. Yes, this is "just Java" and
-    // isn't really necessary, but being overly cautious anyway.
     @Test
     void shouldUseExitStrategyInMethodThatAcceptsExecutionStrategy() {
         ExecutionStrategy noOpStrategy = ExecutionStrategies.noOp();
-        var exitFlaggingStrategy = ExecutionStrategies.exitFlagging();
-        SystemExitExecutionStrategy systemExitStrategy = ExecutionStrategies.systemExit(130);
+        ExecutionStrategy exitFlaggingStrategy = ExecutionStrategies.exitFlagging();
+        ExecutionStrategy systemExitStrategy = ExecutionStrategies.systemExit();
 
         assertAll(
             () -> assertThatCode(() -> acceptStrategy(noOpStrategy)).doesNotThrowAnyException(),
@@ -59,8 +52,7 @@ class ExecutionStrategiesTest {
             () -> assertThatCode(() -> acceptStrategy(systemExitStrategy)).doesNotThrowAnyException(),
             () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.noOp())).doesNotThrowAnyException(),
             () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.exitFlagging())).doesNotThrowAnyException(),
-            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.systemExit())).doesNotThrowAnyException(),
-            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.systemExit(127))).doesNotThrowAnyException()
+            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.systemExit())).doesNotThrowAnyException()
         );
     }
 
@@ -74,7 +66,7 @@ class ExecutionStrategiesTest {
         @Test
         void shouldDoNothing() {
             var executionStrategy = ExecutionStrategies.noOp();
-            assertThatCode(executionStrategy::exit).doesNotThrowAnyException();
+            assertThatCode(() -> executionStrategy.exit(1)).doesNotThrowAnyException();
         }
     }
 
@@ -83,17 +75,28 @@ class ExecutionStrategiesTest {
 
         @Test
         void shouldFlagCallsToExit() {
-            var executionStrategy = ExecutionStrategies.exitFlagging();
-            assertThatCode(executionStrategy::exit).doesNotThrowAnyException();
+            var strategy = ExecutionStrategies.exitFlagging();
+            assertThatCode(() -> strategy.exit(1)).doesNotThrowAnyException();
 
-            assertThat(executionStrategy).isExactlyInstanceOf(ExecutionStrategies.ExitFlaggingExecutionStrategy.class);
-            assertThat(executionStrategy.didExit()).isTrue();
+            assertThat(strategy.didExit()).isTrue();
+            assertThat(strategy.exitCode()).hasValue(1);
+        }
+
+        @Test
+        void shouldCaptureExitCode() {
+            var strategy = ExecutionStrategies.exitFlagging();
+            strategy.exit(42);
+
+            assertThat(strategy.didExit()).isTrue();
+            assertThat(strategy.exitCode()).hasValue(42);
         }
 
         @Test
         void shouldNotFlagWhenExitNotCalled() {
-            var exitFlaggingStrategy = ExecutionStrategies.exitFlagging();
-            assertThat(exitFlaggingStrategy.didExit()).isFalse();
+            var strategy = ExecutionStrategies.exitFlagging();
+
+            assertThat(strategy.didExit()).isFalse();
+            assertThat(strategy.exitCode()).isEmpty();
         }
     }
 
@@ -103,7 +106,7 @@ class ExecutionStrategiesTest {
         @ParameterizedTest
         @CsvSource({
                 "1, 0",
-                "143 , 0",
+                "143, 0",
                 "127, 25",
                 "143, 50"
         })
@@ -125,8 +128,7 @@ class ExecutionStrategiesTest {
             LOG.debug("Using exitCode: {} ; exitWaitDelayMillis: {}", exitCode, exitWaitDelayMillis);
 
             // pretend some unrecoverable error occurred...
-            var executionStrategy = ExecutionStrategies.systemExit(exitCode);
-            new SystemExecutioner(executionStrategy).exit(exitWaitDelayMillis, TimeUnit.MILLISECONDS);
+            new SystemExecutioner().exit(exitCode, Duration.ofMillis(exitWaitDelayMillis));
         }
     }
 

--- a/src/test/java/org/kiwiproject/base/system/ExecutionStrategiesTest.java
+++ b/src/test/java/org/kiwiproject/base/system/ExecutionStrategiesTest.java
@@ -1,0 +1,158 @@
+package org.kiwiproject.base.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.kiwiproject.base.process.Processes;
+import org.kiwiproject.base.system.ExecutionStrategies.SystemExitExecutionStrategy;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@DisplayName("ExecutionStrategies")
+@Slf4j
+class ExecutionStrategiesTest {
+
+    @Test
+    void shouldBuildNoOpStrategy() {
+        assertThat(ExecutionStrategies.noOp())
+                .isExactlyInstanceOf(ExecutionStrategies.NoOpExecutionStrategy.class);
+    }
+
+    @Test
+    void shouldBuildSystemExitStrategy() {
+        var strategy = ExecutionStrategies.systemExit();
+        assertThat(strategy).isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
+        assertThat(strategy.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldBuildSystemExitStrategyWithExitCode() {
+        var strategy = ExecutionStrategies.systemExit(42);
+        assertThat(strategy).isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
+        assertThat(strategy.getExitCode()).isEqualTo(42);
+    }
+
+    // This is silly, and is here to simply show that the return type change
+    // doesn't affect existing methods that accepts ExecutionStrategy or code
+    // that declares a field or variable as ExecutionStrategy, as 'var' using
+    // LTVI, or explicitly as the exact type. Yes, this is "just Java" and
+    // isn't really necessary, but being overly cautious anyway.
+    @Test
+    void shouldUseExitStrategyInMethodThatAcceptsExecutionStrategy() {
+        ExecutionStrategy noOpStrategy = ExecutionStrategies.noOp();
+        var exitFlaggingStrategy = ExecutionStrategies.exitFlagging();
+        SystemExitExecutionStrategy systemExitStrategy = ExecutionStrategies.systemExit(130);
+
+        assertAll(
+            () -> assertThatCode(() -> acceptStrategy(noOpStrategy)).doesNotThrowAnyException(),
+            () -> assertThatCode(() -> acceptStrategy(exitFlaggingStrategy)).doesNotThrowAnyException(),
+            () -> assertThatCode(() -> acceptStrategy(systemExitStrategy)).doesNotThrowAnyException(),
+            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.noOp())).doesNotThrowAnyException(),
+            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.exitFlagging())).doesNotThrowAnyException(),
+            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.systemExit())).doesNotThrowAnyException(),
+            () -> assertThatCode(() -> acceptStrategy(ExecutionStrategies.systemExit(127))).doesNotThrowAnyException()
+        );
+    }
+
+    private static void acceptStrategy(ExecutionStrategy strategy) {
+        LOG.info("Accepted strategy: {}", strategy);
+    }
+
+    @Nested
+    class NoOpStrategy {
+
+        @Test
+        void shouldDoNothing() {
+            var executionStrategy = ExecutionStrategies.noOp();
+            assertThatCode(executionStrategy::exit).doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ExitFlaggingStrategy {
+
+        @Test
+        void shouldFlagCallsToExit() {
+            var executionStrategy = ExecutionStrategies.exitFlagging();
+            assertThatCode(executionStrategy::exit).doesNotThrowAnyException();
+
+            assertThat(executionStrategy).isExactlyInstanceOf(ExecutionStrategies.ExitFlaggingExecutionStrategy.class);
+            assertThat(executionStrategy.didExit()).isTrue();
+        }
+
+        @Test
+        void shouldNotFlagWhenExitNotCalled() {
+            var exitFlaggingStrategy = ExecutionStrategies.exitFlagging();
+            assertThat(exitFlaggingStrategy.didExit()).isFalse();
+        }
+    }
+
+    @Nested
+    class SystemExitStrategy {
+
+        @ParameterizedTest
+        @CsvSource({
+                "1, 0",
+                "143 , 0",
+                "127, 25",
+                "143, 50"
+        })
+        void shouldExitTheJVM(int exitCode, long exitWaitDelayMillis) throws IOException {
+            var result = execTestApplication(exitCode, exitWaitDelayMillis);
+
+            assertThat(result.pid).isPositive();
+            assertThat(result.exitValue)
+                    .describedAs("Expecting non-null exit code (null means timeout waiting for process to exit)")
+                    .isEqualTo(exitCode);
+        }
+    }
+
+    @Slf4j
+    public static class TestApplication {
+        public static void main(String[] args) {
+            int exitCode = Integer.parseInt(args[0]);
+            long exitWaitDelayMillis = Long.parseLong(args[1]);
+            LOG.debug("Using exitCode: {} ; exitWaitDelayMillis: {}", exitCode, exitWaitDelayMillis);
+
+            // pretend some unrecoverable error occurred...
+            var executionStrategy = ExecutionStrategies.systemExit(exitCode);
+            new SystemExecutioner(executionStrategy).exit(exitWaitDelayMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static ExecResult execTestApplication(int exitCode, long exitWaitDelayMillis) throws IOException {
+        var javaHome = System.getProperty("java.home");
+        var javaBin = Path.of(javaHome, "bin", "java").toString();
+        var classpath = System.getProperty("java.class.path");
+        var className = TestApplication.class.getName();
+        var command = List.of(javaBin,
+                "-cp", classpath,
+                className,
+                String.valueOf(exitCode),
+                String.valueOf(exitWaitDelayMillis));
+
+        LOG.debug("Executing TestApplication using {} with exitCode {} and exitWaitDelayMillis {}",
+                javaBin, exitCode, exitWaitDelayMillis);
+        long start = System.nanoTime();
+        var process = new ProcessBuilder(command).start();
+        var exitValueOrNull = Processes.waitForExit(process, 5, TimeUnit.SECONDS).orElse(null);
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        LOG.debug("After {} ms, received exit value {} for process {}", elapsedMillis, exitValueOrNull, process.pid());
+
+        return new ExecResult(process.pid(), exitValueOrNull);
+    }
+
+    private record ExecResult(long pid, Integer exitValue) {
+    }
+}

--- a/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
@@ -28,6 +28,14 @@ class SystemExecutionerTest {
     }
 
     @Test
+    void shouldRequireWaitTime() {
+        var executioner = new SystemExecutioner(ExecutionStrategies.noOp());
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> executioner.exit(1, null))
+                .withMessage("waitTime must not be null");
+    }
+
+    @Test
     void shouldUseSystemExitStrategyByDefault() {
         var executioner = new SystemExecutioner();
         assertThat(executioner.getExecutionStrategy())
@@ -47,82 +55,84 @@ class SystemExecutionerTest {
 
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
         LOG.info("elapsedMillis: {} (elapsedNanos: {})", elapsedMillis, elapsedNanos);
-        assertThat(elapsedMillis).isZero();
+        assertThat(elapsedMillis).isLessThan(10);
     }
 
     @RepeatedTest(3)
     void shouldExitWithWaitTime() {
         var executorService = Executors.newSingleThreadExecutor();
 
-        var waitTime = Duration.ofMillis(25);
-        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
-        var executioner = new SystemExecutioner(executionStrategy);
-        var startTime = new AtomicLong();
+        try {
+            var waitTime = Duration.ofMillis(25);
+            var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+            var executioner = new SystemExecutioner(executionStrategy);
+            var startTime = new AtomicLong();
 
-        var executionFuture = executorService.submit(() -> {
-            LOG.info("Calling executioner...");
-            startTime.set(System.nanoTime());
-            executioner.exit(1, waitTime);
-        });
+            var executionFuture = executorService.submit(() -> {
+                LOG.info("Calling executioner...");
+                startTime.set(System.nanoTime());
+                executioner.exit(1, waitTime);
+            });
 
-        await().pollInterval(5, TimeUnit.MILLISECONDS)
-                .atMost(ONE_SECOND)
-                .until(executionFuture::isDone);
+            await().pollInterval(5, TimeUnit.MILLISECONDS)
+                    .atMost(ONE_SECOND)
+                    .until(executionFuture::isDone);
 
-        long elapsedNanos = System.nanoTime() - startTime.get();
+            long elapsedNanos = System.nanoTime() - startTime.get();
 
-        assertThat(executionStrategy.didExit())
-                .describedAs("Execution strategy exit() should have been called")
-                .isTrue();
-        assertThat(executionStrategy.exitCode()).hasValue(1);
+            assertThat(executionStrategy.didExit())
+                    .describedAs("Execution strategy exit() should have been called")
+                    .isTrue();
+            assertThat(executionStrategy.exitCode()).hasValue(1);
 
-        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
-        logElapsed(elapsedNanos, elapsedMillis);
-        var fudgedWaitTimeMillis = waitTime.toMillis() - 2; // Allow for some slop in timing
-        assertThat(elapsedMillis)
-                .describedAs("Elapsed millis must be greater than or equal to %d", waitTime.toMillis())
-                .isGreaterThanOrEqualTo(fudgedWaitTimeMillis);
-
-        executorService.shutdown();
-        await().atMost(ONE_SECOND).until(executorService::isShutdown);
+            long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+            logElapsed(elapsedNanos, elapsedMillis);
+            var fudgedWaitTimeMillis = waitTime.toMillis() - 2; // Allow for some slop in timing
+            assertThat(elapsedMillis)
+                    .describedAs("Elapsed millis must be greater than or equal to %d", waitTime.toMillis())
+                    .isGreaterThanOrEqualTo(fudgedWaitTimeMillis);
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
     @RepeatedTest(3)
     void shouldExitBeforeGivenWaitTime_WhenWaitingThreadInterrupted() {
         var executorService = Executors.newFixedThreadPool(2);
 
-        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
-        var executioner = new SystemExecutioner(executionStrategy);
-        var startTime = new AtomicLong();
-        var executionFuture = executorService.submit(() -> {
-            LOG.info("Calling executioner with 5 second wait");
-            startTime.set(System.nanoTime());
-            executioner.exit(1, Duration.ofSeconds(5));
-        });
+        try {
+            var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+            var executioner = new SystemExecutioner(executionStrategy);
+            var startTime = new AtomicLong();
+            var executionFuture = executorService.submit(() -> {
+                LOG.info("Calling executioner with 5 second wait");
+                startTime.set(System.nanoTime());
+                executioner.exit(1, Duration.ofSeconds(5));
+            });
 
-        var killerSleepTimeMillis = 100;
-        var killerFuture = executorService.submit(() -> {
-            LOG.info("Sleeping for {} milliseconds...", killerSleepTimeMillis);
-            new DefaultEnvironment().sleepQuietly(killerSleepTimeMillis, TimeUnit.MILLISECONDS);
-            LOG.info("I'm awake and will now interrupt executionThread");
-            var canceled = executionFuture.cancel(true);
-            LOG.info("executionFuture was canceled? {}", canceled);
-        });
+            var killerSleepTimeMillis = 100;
+            var killerFuture = executorService.submit(() -> {
+                LOG.info("Sleeping for {} milliseconds...", killerSleepTimeMillis);
+                new DefaultEnvironment().sleepQuietly(killerSleepTimeMillis, TimeUnit.MILLISECONDS);
+                LOG.info("I'm awake and will now interrupt executionThread");
+                var canceled = executionFuture.cancel(true);
+                LOG.info("executionFuture was canceled? {}", canceled);
+            });
 
-        await().pollInterval(25, TimeUnit.MILLISECONDS)
-                .atMost(ONE_SECOND)
-                .until(() -> executionFuture.isDone() && killerFuture.isDone() && executionStrategy.didExit());
+            await().pollInterval(25, TimeUnit.MILLISECONDS)
+                    .atMost(ONE_SECOND)
+                    .until(() -> executionFuture.isDone() && killerFuture.isDone() && executionStrategy.didExit());
 
-        var elapsedNanos = System.nanoTime() - startTime.get();
-        var elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
-        logElapsed(elapsedNanos, elapsedMillis);
-        var fudgedKillerSleepTimeMillis = killerSleepTimeMillis - 2; // Allow for some slop in timing
-        assertThat(elapsedMillis)
-                .describedAs("Elapsed millis must be at least %d", fudgedKillerSleepTimeMillis)
-                .isGreaterThanOrEqualTo(fudgedKillerSleepTimeMillis);
-
-        executorService.shutdown();
-        await().atMost(ONE_SECOND).until(executorService::isShutdown);
+            var elapsedNanos = System.nanoTime() - startTime.get();
+            var elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+            logElapsed(elapsedNanos, elapsedMillis);
+            var fudgedKillerSleepTimeMillis = killerSleepTimeMillis - 2; // Allow for some slop in timing
+            assertThat(elapsedMillis)
+                    .describedAs("Elapsed millis must be at least %d", fudgedKillerSleepTimeMillis)
+                    .isGreaterThanOrEqualTo(fudgedKillerSleepTimeMillis);
+        } finally {
+            executorService.shutdownNow();
+        }
     }
 
     private static void logElapsed(long elapsedNanos, long elapsedMillis) {

--- a/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
@@ -1,0 +1,128 @@
+package org.kiwiproject.base.system;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.ONE_SECOND;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.base.DefaultEnvironment;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+@DisplayName("SystemExecutioner")
+@Slf4j
+class SystemExecutionerTest {
+
+    @Test
+    void shouldRequireExecutionStrategy() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new SystemExecutioner(null))
+                .withMessage("executionStrategy must not be null");
+    }
+
+    @Test
+    void shouldUseSystemExitStrategyByDefault() {
+        var executioner = new SystemExecutioner();
+        assertThat(executioner.getExecutionStrategy())
+                .isExactlyInstanceOf(ExecutionStrategies.SystemExitExecutionStrategy.class);
+    }
+
+    @RepeatedTest(3)
+    void shouldExitImmediately() {
+        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+        var executioner = new SystemExecutioner(executionStrategy);
+        long startTime = System.nanoTime();
+        executioner.exit();
+        var elapsedNanos = System.nanoTime() - startTime;
+
+        assertThat(executionStrategy.didExit()).isTrue();
+
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+        LOG.info("elapsedMillis: {} (elapsedNanos: {})", elapsedMillis, elapsedNanos);
+        assertThat(elapsedMillis).isZero();
+    }
+
+    @RepeatedTest(3)
+    void shouldExitWithWaitTime() {
+        var executorService = Executors.newSingleThreadExecutor();
+
+        var waitTimeMillis = 25;
+        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+        var executioner = new SystemExecutioner(executionStrategy);
+        var startTime = new AtomicLong();
+
+        var executionFuture = executorService.submit(() -> {
+            LOG.info("Calling executioner...");
+            startTime.set(System.nanoTime());
+            executioner.exit(waitTimeMillis, TimeUnit.MILLISECONDS);
+        });
+
+        await().pollInterval(5, TimeUnit.MILLISECONDS)
+                .atMost(ONE_SECOND)
+                .until(executionFuture::isDone);
+
+        long elapsedNanos = System.nanoTime() - startTime.get();
+
+        assertThat(executionStrategy.didExit())
+                .describedAs("Execution strategy exit() should have been called")
+                .isTrue();
+
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+        logElapsed(elapsedNanos, elapsedMillis);
+        var fudgedWaitTimeMillis = waitTimeMillis - 2; // Allow for some slop in timing
+        assertThat(elapsedMillis)
+                .describedAs("Elapsed millis must be greater than or equal to %d", waitTimeMillis)
+                .isGreaterThanOrEqualTo(fudgedWaitTimeMillis);
+
+        executorService.shutdown();
+        await().atMost(ONE_SECOND).until(executorService::isShutdown);
+    }
+
+    @RepeatedTest(3)
+    void shouldExitBeforeGivenWaitTime_WhenWaitingThreadInterrupted() {
+        var executorService = Executors.newFixedThreadPool(2);
+
+        var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
+        var executioner = new SystemExecutioner(executionStrategy);
+        var startTime = new AtomicLong();
+        var executionFuture = executorService.submit(() -> {
+            LOG.info("Calling executioner with 5 second wait");
+            startTime.set(System.nanoTime());
+            executioner.exit(5, TimeUnit.SECONDS);
+        });
+
+        var killerSleepTimeMillis = 100;
+        var killerFuture = executorService.submit(() -> {
+            LOG.info("Sleeping for {} milliseconds...", killerSleepTimeMillis);
+            new DefaultEnvironment().sleepQuietly(killerSleepTimeMillis, TimeUnit.MILLISECONDS);
+            LOG.info("I'm awake and will now interrupt executionThread");
+            var canceled = executionFuture.cancel(true);
+            LOG.info("executionFuture was canceled? {}", canceled);
+        });
+
+        await().pollInterval(25, TimeUnit.MILLISECONDS)
+                .atMost(ONE_SECOND)
+                .until(() -> executionFuture.isDone() && killerFuture.isDone() && executionStrategy.didExit());
+
+        var elapsedNanos = System.nanoTime() - startTime.get();
+        var elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+        logElapsed(elapsedNanos, elapsedMillis);
+        var fudgedKillerSleepTimeMillis = killerSleepTimeMillis - 2; // Allow for some slop in timing
+        assertThat(elapsedMillis)
+                .describedAs("Elapsed millis must be at least %d", fudgedKillerSleepTimeMillis)
+                .isGreaterThanOrEqualTo(fudgedKillerSleepTimeMillis);
+
+        executorService.shutdown();
+        await().atMost(ONE_SECOND).until(executorService::isShutdown);
+    }
+
+    private static void logElapsed(long elapsedNanos, long elapsedMillis) {
+        LOG.info("Actual elapsed time: {} nanoseconds ; {} milliseconds", elapsedNanos, elapsedMillis);
+    }
+}

--- a/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.base.DefaultEnvironment;
 
+import java.time.Duration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -38,10 +39,11 @@ class SystemExecutionerTest {
         var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
         var executioner = new SystemExecutioner(executionStrategy);
         long startTime = System.nanoTime();
-        executioner.exit();
+        executioner.exit(1);
         var elapsedNanos = System.nanoTime() - startTime;
 
         assertThat(executionStrategy.didExit()).isTrue();
+        assertThat(executionStrategy.exitCode()).hasValue(1);
 
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
         LOG.info("elapsedMillis: {} (elapsedNanos: {})", elapsedMillis, elapsedNanos);
@@ -52,7 +54,7 @@ class SystemExecutionerTest {
     void shouldExitWithWaitTime() {
         var executorService = Executors.newSingleThreadExecutor();
 
-        var waitTimeMillis = 25;
+        var waitTime = Duration.ofMillis(25);
         var executionStrategy = new ExecutionStrategies.ExitFlaggingExecutionStrategy();
         var executioner = new SystemExecutioner(executionStrategy);
         var startTime = new AtomicLong();
@@ -60,7 +62,7 @@ class SystemExecutionerTest {
         var executionFuture = executorService.submit(() -> {
             LOG.info("Calling executioner...");
             startTime.set(System.nanoTime());
-            executioner.exit(waitTimeMillis, TimeUnit.MILLISECONDS);
+            executioner.exit(1, waitTime);
         });
 
         await().pollInterval(5, TimeUnit.MILLISECONDS)
@@ -72,12 +74,13 @@ class SystemExecutionerTest {
         assertThat(executionStrategy.didExit())
                 .describedAs("Execution strategy exit() should have been called")
                 .isTrue();
+        assertThat(executionStrategy.exitCode()).hasValue(1);
 
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
         logElapsed(elapsedNanos, elapsedMillis);
-        var fudgedWaitTimeMillis = waitTimeMillis - 2; // Allow for some slop in timing
+        var fudgedWaitTimeMillis = waitTime.toMillis() - 2; // Allow for some slop in timing
         assertThat(elapsedMillis)
-                .describedAs("Elapsed millis must be greater than or equal to %d", waitTimeMillis)
+                .describedAs("Elapsed millis must be greater than or equal to %d", waitTime.toMillis())
                 .isGreaterThanOrEqualTo(fudgedWaitTimeMillis);
 
         executorService.shutdown();
@@ -94,7 +97,7 @@ class SystemExecutionerTest {
         var executionFuture = executorService.submit(() -> {
             LOG.info("Calling executioner with 5 second wait");
             startTime.set(System.nanoTime());
-            executioner.exit(5, TimeUnit.SECONDS);
+            executioner.exit(1, Duration.ofSeconds(5));
         });
 
         var killerSleepTimeMillis = 100;

--- a/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
+++ b/src/test/java/org/kiwiproject/base/system/SystemExecutionerTest.java
@@ -89,7 +89,7 @@ class SystemExecutionerTest {
             logElapsed(elapsedNanos, elapsedMillis);
             var fudgedWaitTimeMillis = waitTime.toMillis() - 2; // Allow for some slop in timing
             assertThat(elapsedMillis)
-                    .describedAs("Elapsed millis must be greater than or equal to %d", waitTime.toMillis())
+                    .describedAs("Elapsed millis must be greater than or equal to %d", fudgedWaitTimeMillis)
                     .isGreaterThanOrEqualTo(fudgedWaitTimeMillis);
         } finally {
             executorService.shutdownNow();


### PR DESCRIPTION
Adds ExecutionStrategy, ExecutionStrategies, and SystemExecutioner to org.kiwiproject.base.system, following the existing pattern of org.kiwiproject.base.process (which parallels java.lang.Process).

These classes were previously in dropwizard-service-utilities under org.kiwiproject.dropwizard.util.startup, but have no Dropwizard dependencies and belong in kiwi.

The first commit copies the classes as-is (package rename only). The second commit applies the new design:

- ExecutionStrategy declares a single method exit(int exitCode), mirroring System.exit(int); there is no no-arg exit() method
- SystemExitExecutionStrategy is stateless; exit(int) calls System.exit(exitCode) directly
- NoOpExecutionStrategy ignores the exit code and does nothing
- ExitFlaggingExecutionStrategy records didExit() and exitCode() (OptionalInt) for use in integration tests
- SystemExecutioner provides exit(int exitCode) and exit(int exitCode, Duration waitTime)

Closes #1421