### PR TITLE
feat: add KiwiBigDecimals#requireDouble overload with custom error message

### DIFF
--- a/src/main/java/org/kiwiproject/base/KiwiBigDecimals.java
+++ b/src/main/java/org/kiwiproject/base/KiwiBigDecimals.java
@@ -64,8 +64,7 @@ public class KiwiBigDecimals {
      * @throws IllegalArgumentException if the given value is null
      */
     public static double requireDouble(@NonNull BigDecimal value) {
-        checkArgumentNotNull(value, "value cannot be null");
-        return value.doubleValue();
+        return requireDouble(value, "value cannot be null");
     }
 
     /**

--- a/src/main/java/org/kiwiproject/base/KiwiBigDecimals.java
+++ b/src/main/java/org/kiwiproject/base/KiwiBigDecimals.java
@@ -67,4 +67,17 @@ public class KiwiBigDecimals {
         checkArgumentNotNull(value, "value cannot be null");
         return value.doubleValue();
     }
+
+    /**
+     * Converts the given {@link BigDecimal} to a primitive double.
+     *
+     * @param value   the non-null BigDecimal
+     * @param message the error message to use if the value is null
+     * @return a primitive double
+     * @throws IllegalArgumentException if the given value is null
+     */
+    public static double requireDouble(@NonNull BigDecimal value, String message) {
+        checkArgumentNotNull(value, message);
+        return value.doubleValue();
+    }
 }

--- a/src/test/java/org/kiwiproject/base/KiwiBigDecimalsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiBigDecimalsTest.java
@@ -48,4 +48,15 @@ class KiwiBigDecimalsTest {
         softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ONE)).isEqualTo(1.0);
         softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.TEN)).isEqualTo(10.0);
     }
+
+    @Test
+    void shouldRequireDoublePrimitiveWithCustomMessage(SoftAssertions softly) {
+        //noinspection DataFlowIssue
+        softly.assertThatThrownBy(() -> KiwiBigDecimals.requireDouble(null, "price cannot be null"))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage("price cannot be null");
+        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ZERO, "price cannot be null")).isZero();
+        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ONE, "price cannot be null")).isEqualTo(1.0);
+        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.TEN, "price cannot be null")).isEqualTo(10.0);
+    }
 }


### PR DESCRIPTION
- Add `requireDouble(BigDecimal value, String message)` overload to `KiwiBigDecimals`
- The existing single-arg method throws a generic `"value cannot be null"` message, making it hard to identify the source at the call site
- New overload delegates to `checkArgumentNotNull(value, message)` consistent with existing patterns in `KiwiPreconditions`

Closes #1425

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2Kuitu5wdaLWt4kJfjymn)_