### PR TITLE
refactor(test): replace SoftAssertions with JUnit 5 assertAll in KiwiBigDecimalsTest

### DIFF
--- a/src/test/java/org/kiwiproject/base/KiwiBigDecimalsTest.java
+++ b/src/test/java/org/kiwiproject/base/KiwiBigDecimalsTest.java
@@ -1,62 +1,72 @@
 package org.kiwiproject.base;
 
-import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.math.BigDecimal;
 
 @DisplayName("KiwiBigDecimals")
-@ExtendWith(SoftAssertionsExtension.class)
 class KiwiBigDecimalsTest {
 
     @Test
-    void shouldConvertToOptionalDouble(SoftAssertions softly) {
-        softly.assertThat(KiwiBigDecimals.toOptionalDouble(null)).isEmpty();
-        softly.assertThat(KiwiBigDecimals.toOptionalDouble(BigDecimal.ZERO)).hasValue(0.0);
-        softly.assertThat(KiwiBigDecimals.toOptionalDouble(BigDecimal.ONE)).hasValue(1.0);
-        softly.assertThat(KiwiBigDecimals.toOptionalDouble(BigDecimal.TEN)).hasValue(10.0);
-        softly.assertThat(KiwiBigDecimals.toOptionalDouble(new BigDecimal("420.4242"))).hasValue(420.4242);
+    void shouldConvertToOptionalDouble() {
+        assertAll(
+                () -> assertThat(KiwiBigDecimals.toOptionalDouble(null)).isEmpty(),
+                () -> assertThat(KiwiBigDecimals.toOptionalDouble(BigDecimal.ZERO)).hasValue(0.0),
+                () -> assertThat(KiwiBigDecimals.toOptionalDouble(BigDecimal.ONE)).hasValue(1.0),
+                () -> assertThat(KiwiBigDecimals.toOptionalDouble(BigDecimal.TEN)).hasValue(10.0),
+                () -> assertThat(KiwiBigDecimals.toOptionalDouble(new BigDecimal("420.4242"))).hasValue(420.4242)
+        );
     }
 
     @Test
-    void shouldConvertToDoubleOrReturnEmptyOptional(SoftAssertions softly) {
-        softly.assertThat(KiwiBigDecimals.toOptionalDoubleObject(null)).isEmpty();
-        softly.assertThat(KiwiBigDecimals.toOptionalDoubleObject(BigDecimal.ZERO)).hasValue(0.0);
-        softly.assertThat(KiwiBigDecimals.toOptionalDoubleObject(BigDecimal.ONE)).hasValue(1.0);
-        softly.assertThat(KiwiBigDecimals.toOptionalDoubleObject(BigDecimal.TEN)).hasValue(10.0);
-        softly.assertThat(KiwiBigDecimals.toOptionalDoubleObject(new BigDecimal("420.4242"))).hasValue(420.4242);
+    void shouldConvertToDoubleOrReturnEmptyOptional() {
+        assertAll(
+                () -> assertThat(KiwiBigDecimals.toOptionalDoubleObject(null)).isEmpty(),
+                () -> assertThat(KiwiBigDecimals.toOptionalDoubleObject(BigDecimal.ZERO)).hasValue(0.0),
+                () -> assertThat(KiwiBigDecimals.toOptionalDoubleObject(BigDecimal.ONE)).hasValue(1.0),
+                () -> assertThat(KiwiBigDecimals.toOptionalDoubleObject(BigDecimal.TEN)).hasValue(10.0),
+                () -> assertThat(KiwiBigDecimals.toOptionalDoubleObject(new BigDecimal("420.4242"))).hasValue(420.4242)
+        );
     }
 
     @Test
-    void shouldConvertToDoubleOrNull(SoftAssertions softly) {
-        softly.assertThat(KiwiBigDecimals.toDoubleOrNull(null)).isNull();
-        softly.assertThat(KiwiBigDecimals.toDoubleOrNull(BigDecimal.ZERO)).isZero();
-        softly.assertThat(KiwiBigDecimals.toDoubleOrNull(BigDecimal.ONE)).isEqualTo(1.0);
-        softly.assertThat(KiwiBigDecimals.toDoubleOrNull(BigDecimal.TEN)).isEqualTo(10.0);
-        softly.assertThat(KiwiBigDecimals.toDoubleOrNull(new BigDecimal("42000.84"))).isEqualTo(42_000.84);
+    void shouldConvertToDoubleOrNull() {
+        assertAll(
+                () -> assertThat(KiwiBigDecimals.toDoubleOrNull(null)).isNull(),
+                () -> assertThat(KiwiBigDecimals.toDoubleOrNull(BigDecimal.ZERO)).isZero(),
+                () -> assertThat(KiwiBigDecimals.toDoubleOrNull(BigDecimal.ONE)).isEqualTo(1.0),
+                () -> assertThat(KiwiBigDecimals.toDoubleOrNull(BigDecimal.TEN)).isEqualTo(10.0),
+                () -> assertThat(KiwiBigDecimals.toDoubleOrNull(new BigDecimal("42000.84"))).isEqualTo(42_000.84)
+        );
     }
 
     @Test
-    void shouldRequireDoublePrimitive(SoftAssertions softly) {
-        //noinspection DataFlowIssue
-        softly.assertThatThrownBy(() -> KiwiBigDecimals.requireDouble(null))
-                .isExactlyInstanceOf(IllegalArgumentException.class);
-        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ZERO)).isZero();
-        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ONE)).isEqualTo(1.0);
-        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.TEN)).isEqualTo(10.0);
+    void shouldRequireDoublePrimitive() {
+        assertAll(
+                //noinspection DataFlowIssue
+                () -> assertThatThrownBy(() -> KiwiBigDecimals.requireDouble(null))
+                        .isExactlyInstanceOf(IllegalArgumentException.class),
+                () -> assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ZERO)).isZero(),
+                () -> assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ONE)).isEqualTo(1.0),
+                () -> assertThat(KiwiBigDecimals.requireDouble(BigDecimal.TEN)).isEqualTo(10.0)
+        );
     }
 
     @Test
-    void shouldRequireDoublePrimitiveWithCustomMessage(SoftAssertions softly) {
-        //noinspection DataFlowIssue
-        softly.assertThatThrownBy(() -> KiwiBigDecimals.requireDouble(null, "price cannot be null"))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage("price cannot be null");
-        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ZERO, "price cannot be null")).isZero();
-        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ONE, "price cannot be null")).isEqualTo(1.0);
-        softly.assertThat(KiwiBigDecimals.requireDouble(BigDecimal.TEN, "price cannot be null")).isEqualTo(10.0);
+    void shouldRequireDoublePrimitiveWithCustomMessage() {
+        assertAll(
+                //noinspection DataFlowIssue
+                () -> assertThatThrownBy(() -> KiwiBigDecimals.requireDouble(null, "price cannot be null"))
+                        .isExactlyInstanceOf(IllegalArgumentException.class)
+                        .hasMessage("price cannot be null"),
+                () -> assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ZERO, "price cannot be null")).isZero(),
+                () -> assertThat(KiwiBigDecimals.requireDouble(BigDecimal.ONE, "price cannot be null")).isEqualTo(1.0),
+                () -> assertThat(KiwiBigDecimals.requireDouble(BigDecimal.TEN, "price cannot be null")).isEqualTo(10.0)
+        );
     }
 }


### PR DESCRIPTION
- Replace AssertJ `SoftAssertions` / `SoftAssertionsExtension` with JUnit 5's built-in `assertAll` across all tests in `KiwiBigDecimalsTest`
- Remove the `SoftAssertions softly` parameter from each test method
- Keep AssertJ `assertThat` / `assertThatThrownBy` for the individual assertions inside `assertAll` lambdas

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2Kuitu5wdaLWt4kJfjymn)_