### PR TITLE
fix: improve Async failure diagnostics with type-specific exception messages

### DIFF
--- a/src/main/java/org/kiwiproject/concurrent/Async.java
+++ b/src/main/java/org/kiwiproject/concurrent/Async.java
@@ -397,13 +397,11 @@ public class Async {
         } else if (ex instanceof InterruptedException) {
             msg = f("Interrupted while waiting for async task after {} {}", timeout, unit);
         } else if (ex instanceof ExecutionException executionException) {
-            var cause = executionException.getCause();
-            if (nonNull(cause)) {
-                msg = f("Async task completed exceptionally while waiting up to {} {}; cause: {}: {}",
-                        timeout, unit, cause.getClass().getName(), cause.getMessage());
-            } else {
-                msg = f("Async task completed exceptionally while waiting up to {} {}", timeout, unit);
-            }
+            var cause = KiwiThrowables.nextCauseOf(executionException);
+            msg = f("Async task completed exceptionally while waiting up to {} {}; cause: {}: {}",
+                    timeout, unit,
+                    cause.map(KiwiThrowables::typeOf).orElse("unknown"),
+                    cause.flatMap(KiwiThrowables::messageOf).orElse("(none)"));
         } else {
             msg = f("{} occurred while waiting up to {} {}", ex.getClass().getSimpleName(), timeout, unit);
         }

--- a/src/main/java/org/kiwiproject/concurrent/Async.java
+++ b/src/main/java/org/kiwiproject/concurrent/Async.java
@@ -388,27 +388,21 @@ public class Async {
      * Since the side effect is benign, putting it here seems preferable to duplicating the same logic
      * everywhere this method is called.
      */
-    @VisibleForTesting
-    static AsyncException newAsyncException(long timeout, TimeUnit unit,
-                                            Exception ex,
-                                            CompletableFuture<?> future) {
+    private static AsyncException newAsyncException(long timeout, TimeUnit unit,
+                                                    Exception ex,
+                                                    CompletableFuture<?> future) {
         String msg;
         if (ex instanceof TimeoutException) {
             msg = f("Timed out waiting for async task after {} {}", timeout, unit);
         } else if (ex instanceof InterruptedException) {
             msg = f("Interrupted while waiting for async task after {} {}", timeout, unit);
-        } else if (ex instanceof ExecutionException executionException) {
+        } else {
+            var executionException = (ExecutionException) ex;
             var causeOpt = KiwiThrowables.nextCauseOf(executionException);
             msg = f("Async task completed exceptionally while waiting up to {} {}; cause: {}: {}",
                     timeout, unit,
                     causeOpt.map(KiwiThrowables::typeOf).orElse("unknown"),
                     causeOpt.flatMap(KiwiThrowables::messageOf).orElse("(none)"));
-        } else {
-            // Should never be reached: CompletableFuture.get() only throws InterruptedException,
-            // ExecutionException, and TimeoutException as checked exceptions.
-            LOG.warn("Unexpected exception type {} in newAsyncException; this should not happen",
-                    ex.getClass().getName());
-            msg = f("{} occurred while waiting up to {} {}", ex.getClass().getSimpleName(), timeout, unit);
         }
         LOG.error(msg, ex);
         return new AsyncException(msg, ex, future);

--- a/src/main/java/org/kiwiproject/concurrent/Async.java
+++ b/src/main/java/org/kiwiproject/concurrent/Async.java
@@ -388,9 +388,10 @@ public class Async {
      * Since the side effect is benign, putting it here seems preferable to duplicating the same logic
      * everywhere this method is called.
      */
-    private static AsyncException newAsyncException(long timeout, TimeUnit unit,
-                                                    Exception ex,
-                                                    CompletableFuture<?> future) {
+    @VisibleForTesting
+    static AsyncException newAsyncException(long timeout, TimeUnit unit,
+                                            Exception ex,
+                                            CompletableFuture<?> future) {
         String msg;
         if (ex instanceof TimeoutException) {
             msg = f("Timed out waiting for async task after {} {}", timeout, unit);
@@ -403,6 +404,10 @@ public class Async {
                     causeOpt.map(KiwiThrowables::typeOf).orElse("unknown"),
                     causeOpt.flatMap(KiwiThrowables::messageOf).orElse("(none)"));
         } else {
+            // Should never be reached: CompletableFuture.get() only throws InterruptedException,
+            // ExecutionException, and TimeoutException as checked exceptions.
+            LOG.warn("Unexpected exception type {} in newAsyncException; this should not happen",
+                    ex.getClass().getName());
             msg = f("{} occurred while waiting up to {} {}", ex.getClass().getSimpleName(), timeout, unit);
         }
         LOG.error(msg, ex);

--- a/src/main/java/org/kiwiproject/concurrent/Async.java
+++ b/src/main/java/org/kiwiproject/concurrent/Async.java
@@ -397,11 +397,11 @@ public class Async {
         } else if (ex instanceof InterruptedException) {
             msg = f("Interrupted while waiting for async task after {} {}", timeout, unit);
         } else if (ex instanceof ExecutionException executionException) {
-            var cause = KiwiThrowables.nextCauseOf(executionException);
+            var causeOpt = KiwiThrowables.nextCauseOf(executionException);
             msg = f("Async task completed exceptionally while waiting up to {} {}; cause: {}: {}",
                     timeout, unit,
-                    cause.map(KiwiThrowables::typeOf).orElse("unknown"),
-                    cause.flatMap(KiwiThrowables::messageOf).orElse("(none)"));
+                    causeOpt.map(KiwiThrowables::typeOf).orElse("unknown"),
+                    causeOpt.flatMap(KiwiThrowables::messageOf).orElse("(none)"));
         } else {
             msg = f("{} occurred while waiting up to {} {}", ex.getClass().getSimpleName(), timeout, unit);
         }

--- a/src/main/java/org/kiwiproject/concurrent/Async.java
+++ b/src/main/java/org/kiwiproject/concurrent/Async.java
@@ -370,10 +370,12 @@ public class Async {
                 return future.get(timeout, unit);
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
-                future.cancel(true);
+                var cancelled = future.cancel(true);
+                LOG.debug("Attempted to cancel future after interruption; cancelled={}", cancelled);
                 throw newAsyncException(timeout, unit, ex, future);
             } catch (ExecutionException | TimeoutException ex) {
-                future.cancel(true);
+                var cancelled = future.cancel(true);
+                LOG.debug("Attempted to cancel future after {}; cancelled={}", ex.getClass().getSimpleName(), cancelled);
                 throw newAsyncException(timeout, unit, ex, future);
             }
         };
@@ -389,8 +391,22 @@ public class Async {
     private static AsyncException newAsyncException(long timeout, TimeUnit unit,
                                                     Exception ex,
                                                     CompletableFuture<?> future) {
-        var msg = f("{} occurred (maximum wait was specified as {} {})",
-                ex.getClass().getSimpleName(), timeout, unit);
+        String msg;
+        if (ex instanceof TimeoutException) {
+            msg = f("Timed out waiting for async task after {} {}", timeout, unit);
+        } else if (ex instanceof InterruptedException) {
+            msg = f("Interrupted while waiting for async task after {} {}", timeout, unit);
+        } else if (ex instanceof ExecutionException executionException) {
+            var cause = executionException.getCause();
+            if (nonNull(cause)) {
+                msg = f("Async task completed exceptionally while waiting up to {} {}; cause: {}: {}",
+                        timeout, unit, cause.getClass().getName(), cause.getMessage());
+            } else {
+                msg = f("Async task completed exceptionally while waiting up to {} {}", timeout, unit);
+            }
+        } else {
+            msg = f("{} occurred while waiting up to {} {}", ex.getClass().getSimpleName(), timeout, unit);
+        }
         LOG.error(msg, ex);
         return new AsyncException(msg, ex, future);
     }

--- a/src/test/java/org/kiwiproject/concurrent/AsyncHelperTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncHelperTest.java
@@ -263,7 +263,7 @@ class AsyncHelperTest {
             try {
                 assertThatThrownBy(() -> asyncHelper.waitFor(future, 1, TimeUnit.MILLISECONDS))
                         .isExactlyInstanceOf(AsyncException.class)
-                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasMessage("Timed out waiting for async task after 1 MILLISECONDS")
                         .hasCauseInstanceOf(TimeoutException.class);
 
                 assertThat(task.getCurrentCount()).isZero();
@@ -315,7 +315,7 @@ class AsyncHelperTest {
                 var futures = List.of(future1, future2, future3);
                 assertThatThrownBy(() -> asyncHelper.waitForAll(futures, 1, TimeUnit.MILLISECONDS))
                         .isExactlyInstanceOf(AsyncException.class)
-                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasMessage("Timed out waiting for async task after 1 MILLISECONDS")
                         .hasCauseInstanceOf(TimeoutException.class);
 
                 assertThat(task1.getCurrentCount()).isZero();
@@ -373,7 +373,7 @@ class AsyncHelperTest {
                 var futures = List.of(future1, future2, future3);
                 assertThatThrownBy(() -> asyncHelper.waitForAllIgnoringType(futures, 1, TimeUnit.MILLISECONDS))
                         .isExactlyInstanceOf(AsyncException.class)
-                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasMessage("Timed out waiting for async task after 1 MILLISECONDS")
                         .hasCauseInstanceOf(TimeoutException.class);
 
                 assertThat(task1.getCurrentCount()).isZero();
@@ -417,7 +417,7 @@ class AsyncHelperTest {
             var asyncException = (AsyncException) executionException.getCause();
 
             assertThat(asyncException)
-                    .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
+                    .hasMessage("Timed out waiting for async task after 5 MILLISECONDS")
                     .hasCauseExactlyInstanceOf(TimeoutException.class);
         }
     }

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -288,12 +288,39 @@ class AsyncTest {
             try {
                 assertThatThrownBy(() -> Async.waitFor(future, 1, TimeUnit.MILLISECONDS))
                         .isExactlyInstanceOf(AsyncException.class)
-                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasMessage("Timed out waiting for async task after 1 MILLISECONDS")
                         .hasCauseInstanceOf(TimeoutException.class);
 
                 assertThat(task.getCurrentCount()).isZero();
             } finally {
                 cancel(future);
+            }
+        }
+
+        @Test
+        void shouldThrowAsyncException_WithCauseDetails_WhenFutureCompletesExceptionally() {
+            var cause = new RuntimeException("the task blew up");
+            CompletableFuture<Integer> future = CompletableFuture.failedFuture(cause);
+
+            assertThatThrownBy(() -> Async.waitFor(future, 500, TimeUnit.MILLISECONDS))
+                    .isExactlyInstanceOf(AsyncException.class)
+                    .hasMessage("Async task completed exceptionally while waiting up to 500 MILLISECONDS;" +
+                            " cause: java.lang.RuntimeException: the task blew up")
+                    .hasCauseInstanceOf(ExecutionException.class);
+        }
+
+        @Test
+        void shouldThrowAsyncException_WhenThreadIsInterrupted_WhileWaiting() {
+            CompletableFuture<Integer> future = new CompletableFuture<>();
+            try {
+                Thread.currentThread().interrupt();
+                assertThatThrownBy(() -> Async.waitFor(future, 500, TimeUnit.MILLISECONDS))
+                        .isExactlyInstanceOf(AsyncException.class)
+                        .hasMessage("Interrupted while waiting for async task after 500 MILLISECONDS")
+                        .hasCauseInstanceOf(InterruptedException.class);
+            } finally {
+                Thread.interrupted(); // clear interrupt status
+                future.cancel(true);
             }
         }
     }
@@ -340,7 +367,7 @@ class AsyncTest {
                 var futures = List.of(future1, future2, future3);
                 assertThatThrownBy(() -> Async.waitForAll(futures, 1, TimeUnit.MILLISECONDS))
                         .isExactlyInstanceOf(AsyncException.class)
-                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasMessage("Timed out waiting for async task after 1 MILLISECONDS")
                         .hasCauseInstanceOf(TimeoutException.class);
 
                 assertThat(task1.getCurrentCount()).isZero();
@@ -398,7 +425,7 @@ class AsyncTest {
                 var futures = List.of(future1, future2, future3);
                 assertThatThrownBy(() -> Async.waitForAllIgnoringType(futures, 1, TimeUnit.MILLISECONDS))
                         .isExactlyInstanceOf(AsyncException.class)
-                        .hasMessage("TimeoutException occurred (maximum wait was specified as 1 MILLISECONDS)")
+                        .hasMessage("Timed out waiting for async task after 1 MILLISECONDS")
                         .hasCauseInstanceOf(TimeoutException.class);
 
                 assertThat(task1.getCurrentCount()).isZero();
@@ -442,8 +469,27 @@ class AsyncTest {
             var asyncException = (AsyncException) executionException.getCause();
 
             assertThat(asyncException)
-                    .hasMessage("TimeoutException occurred (maximum wait was specified as 5 MILLISECONDS)")
+                    .hasMessage("Timed out waiting for async task after 5 MILLISECONDS")
                     .hasCauseExactlyInstanceOf(TimeoutException.class);
+        }
+
+        @Test
+        void shouldSurfaceCauseDetails_WhenFutureCompletesExceptionally() {
+            var cause = new IllegalStateException("downstream failure");
+            CompletableFuture<Integer> future = CompletableFuture.failedFuture(cause);
+            CompletableFuture<Integer> futureWithTimeout = Async.withMaxTimeout(future, 500, TimeUnit.MILLISECONDS);
+
+            awaitAtMost500msWith25MsPoll().until(futureWithTimeout::isCompletedExceptionally);
+
+            var thrown = catchThrowable(futureWithTimeout::get);
+            assertThat(thrown).isInstanceOf(ExecutionException.class)
+                    .hasCauseExactlyInstanceOf(AsyncException.class);
+
+            var asyncException = (AsyncException) ((ExecutionException) thrown).getCause();
+            assertThat(asyncException)
+                    .hasMessage("Async task completed exceptionally while waiting up to 500 MILLISECONDS;" +
+                            " cause: java.lang.IllegalStateException: downstream failure")
+                    .hasCauseExactlyInstanceOf(ExecutionException.class);
         }
     }
 

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -493,20 +493,6 @@ class AsyncTest {
         }
     }
 
-    @Nested
-    class NewAsyncException {
-
-        @Test
-        void shouldUseDefaultMessage_ForUnexpectedExceptionType() {
-            var ex = new RuntimeException("unexpected");
-            var asyncException = Async.newAsyncException(5, TimeUnit.SECONDS, ex, null);
-
-            assertThat(asyncException)
-                    .hasMessage("RuntimeException occurred while waiting up to 5 SECONDS")
-                    .hasCause(ex);
-        }
-    }
-
     /**
      * Cancel the given CompletableFuture. This should be called by tests that are testing timeout situations
      * such as when testing {@link Async#waitFor(CompletableFuture, long, TimeUnit)} and the other similar

--- a/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
+++ b/src/test/java/org/kiwiproject/concurrent/AsyncTest.java
@@ -493,6 +493,20 @@ class AsyncTest {
         }
     }
 
+    @Nested
+    class NewAsyncException {
+
+        @Test
+        void shouldUseDefaultMessage_ForUnexpectedExceptionType() {
+            var ex = new RuntimeException("unexpected");
+            var asyncException = Async.newAsyncException(5, TimeUnit.SECONDS, ex, null);
+
+            assertThat(asyncException)
+                    .hasMessage("RuntimeException occurred while waiting up to 5 SECONDS")
+                    .hasCause(ex);
+        }
+    }
+
     /**
      * Cancel the given CompletableFuture. This should be called by tests that are testing timeout situations
      * such as when testing {@link Async#waitFor(CompletableFuture, long, TimeUnit)} and the other similar


### PR DESCRIPTION
- Refactor `newAsyncException` to produce type-specific messages rather than a single generic format:
  - `TimeoutException` → `"Timed out waiting for async task after {n} {unit}"`
  - `InterruptedException` → `"Interrupted while waiting for async task after {n} {unit}"`
  - `ExecutionException` → `"Async task completed exceptionally while waiting up to {n} {unit}; cause: {type}: {message}"` (cause unwrapped via `KiwiThrowables`)
  - default → `"{simpleClassName} occurred while waiting up to {n} {unit}"` with a WARN log; should never be reached in practice since `CompletableFuture.get()` only throws `InterruptedException`, `ExecutionException`, and `TimeoutException`
- Make `newAsyncException` package-private and annotate with `@VisibleForTesting` to allow direct testing of the default branch
- Log the result of `future.cancel(true)` at DEBUG in `withMaxTimeout` to make clear that cancellation is best-effort
- Public API and existing behavior are unchanged
- Updated 4 existing `hasMessage(...)` assertions in `AsyncTest` and 4 in `AsyncHelperTest` to match new message format
- Added `shouldThrowAsyncException_WithCauseDetails_WhenFutureCompletesExceptionally` in `WaitFor` — verifies cause type and message surface in `AsyncException`
- Added `shouldThrowAsyncException_WhenThreadIsInterrupted_WhileWaiting` in `WaitFor` — verifies interrupted message and cleans up interrupt status
- Added `shouldSurfaceCauseDetails_WhenFutureCompletesExceptionally` in `WithMaxTimeout` — verifies cause details surface through the wrapper future
- Added `NewAsyncException` nested test class with a direct call using an unexpected exception type to cover the default branch

See also discussion #1133

Closes #1428