### PR TITLE
Migrate jsch from com.jcraft:jsch to the com.github.mwiede:jsch fork

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <kiwi-bom.version>3.1.0</kiwi-bom.version>
 
         <!-- Versions for provided dependencies -->
+        <mwiede-jsch.version>2.28.2</mwiede-jsch.version>
         <retrying-again.version>2.1.14</retrying-again.version>
 
         <!-- Versions for test dependencies -->
@@ -147,8 +148,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
+            <version>${mwiede-jsch.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
The original com.jcraft library has not been maintained since late
2018. The com.github.mwiede fork is actively maintained, so this switches to use it.

Closes #1430