### PR TITLE
fix: replace deprecated Session.setPassword(String) with setPassword(byte[])

### DIFF
--- a/src/main/java/org/kiwiproject/jsch/SftpConnector.java
+++ b/src/main/java/org/kiwiproject/jsch/SftpConnector.java
@@ -15,6 +15,7 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 /**
@@ -185,7 +186,7 @@ public class SftpConnector {
 
         } else if (isNotBlank(config.getPassword())) {
             LOG.debug("Using password to connect");
-            session.setPassword(config.getPassword());
+            session.setPassword(config.getPassword().getBytes(StandardCharsets.UTF_8));
 
         } else {
             throw new SftpTransfersException("Missing a private key and a password; cannot authenticate to the SFTP server");

--- a/src/test/java/org/kiwiproject/jsch/SftpConnectorTest.java
+++ b/src/test/java/org/kiwiproject/jsch/SftpConnectorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 @DisplayName("SftpConnector")
@@ -194,7 +195,7 @@ class SftpConnectorTest {
             SftpConnector.addAuthToSession(config, jsch, session);
 
             verifyNoInteractions(jsch);
-            verify(session).setPassword(password);
+            verify(session).setPassword(password.getBytes(StandardCharsets.UTF_8));
             verifyNoMoreInteractions(session);
         }
 


### PR DESCRIPTION
Replace the deprecated `Session.setPassword(String)` call in `SftpConnector` with `setPassword(byte[])`, encoding the password as UTF-8. Update the corresponding Mockito `verify` in `SftpConnectorTest` to match.

Addresses the CodeQL "Deprecated method or constructor invocation" warning.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2Kuitu5wdaLWt4kJfjymn)_