### PR TITLE
feat: add default getNumberOfElements() method to PaginatedResultPage

### DIFF
--- a/src/main/java/org/kiwiproject/search/PaginatedResultPage.java
+++ b/src/main/java/org/kiwiproject/search/PaginatedResultPage.java
@@ -17,10 +17,10 @@ public interface PaginatedResultPage<T> extends PaginatedResult {
     List<T> getContent();
 
     /**
-     * The number of elements on this page. This may be less than {@link #getPageSize()} on the last page
-     * when the total count is not evenly divisible by the page size.
+     * Return the number of elements on this page.
      *
-     * @return the number of elements on this page
+     * @return the number of elements on this page, which may be less than {@link #getPageSize()}
+     *         when this is the last page or when this page has no content
      */
     default int getNumberOfElements() {
         return getContent().size();

--- a/src/main/java/org/kiwiproject/search/PaginatedResultPage.java
+++ b/src/main/java/org/kiwiproject/search/PaginatedResultPage.java
@@ -15,4 +15,14 @@ public interface PaginatedResultPage<T> extends PaginatedResult {
      * @return an unmodifiable list of items; must not be null
      */
     List<T> getContent();
+
+    /**
+     * The number of elements on this page. This may be less than {@link #getPageSize()} on the last page
+     * when the total count is not evenly divisible by the page size.
+     *
+     * @return the number of elements on this page
+     */
+    default int getNumberOfElements() {
+        return getContent().size();
+    }
 }

--- a/src/test/java/org/kiwiproject/search/SimplePaginatedResultPageTest.java
+++ b/src/test/java/org/kiwiproject/search/SimplePaginatedResultPageTest.java
@@ -224,6 +224,27 @@ class SimplePaginatedResultPageTest {
     }
 
     @Test
+    void shouldGetNumberOfElements_WhenFullPage() {
+        var pageSize = 10;
+        var page = new SimplePaginatedResultPage<>(0, pageSize, 50, newContentOfSize(pageSize));
+        assertThat(page.getNumberOfElements()).isEqualTo(pageSize);
+    }
+
+    @Test
+    void shouldGetNumberOfElements_WhenPartialLastPage() {
+        var pageSize = 10;
+        var lastPageSize = 3;
+        var page = new SimplePaginatedResultPage<>(4, pageSize, 43, newContentOfSize(lastPageSize));
+        assertThat(page.getNumberOfElements()).isEqualTo(lastPageSize);
+    }
+
+    @Test
+    void shouldGetNumberOfElements_WhenEmptyPage() {
+        var page = new SimplePaginatedResultPage<Item>(0, 10, 0, List.of());
+        assertThat(page.getNumberOfElements()).isZero();
+    }
+
+    @Test
     void shouldNotIncludeContentInStringRepresentation() {
         var pageSize = 10;
         var page = new SimplePaginatedResultPage<>(


### PR DESCRIPTION
Add a default getNumberOfElements() method to PaginatedResultPage that returns the number of elements actually on the page, i.e. getContent().size(). This complements getPageSize(), which is the requested maximum, since the last page is often smaller when the total count is not evenly divisible by the page size.

Tests cover a full page, a partial last page, and an empty page.

Closes #1435

---
_Generated by [Claude Code](https://claude.ai/code/session_012ozTFWAM5rZPJpW4XK421c)_