### PR TITLE
Remove redundant Sonar properties from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,6 @@
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_kiwi</sonar.projectKey>
-        <sonar.organization>kiwiproject</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <!-- Exclude deser.ListToCsvStringDeserializer from CPD since it is an intentional
              copy of ser.ListToCsvStringDeserializer, which will be deprecated in 5.2.0
              and removed in 6.0.0. Remove this exclusion when ser.ListToCsvStringDeserializer


### PR DESCRIPTION
Remove the redundant sonar.organization and sonar.host.url properties from pom.xml. These properties are already defined in kiwi-parent and do not need to be redefined here.