### PR TITLE
Remove check-latest from setup-java to use cached JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'temurin'
-          check-latest: true
 
       # Cache all the things
       - name: Cache SonarCloud packages


### PR DESCRIPTION
Remove check-latest: true from the setup-java step. With it set, the action always resolves the newest patch version which may not be cached on the runner, causing a download on every build. Removing it allows GitHub-hosted runners to use the pre-cached Temurin LTS distributions instead.