### PR TITLE
docs: Add note on nullability of methods in KiwiLists, KiwiArrays

### DIFF
--- a/src/main/java/org/kiwiproject/collect/KiwiArrays.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiArrays.java
@@ -15,6 +15,14 @@ import java.util.stream.IntStream;
 
 /**
  * Utility methods for working with Array instances.
+ * <p>
+ * <strong>Note</strong>: accessor methods that return {@code T} directly (e.g. {@link #first(Object[]) first},
+ * {@link #second(Object[]) second}, {@link #third(Object[]) third}, {@link #penultimate(Object[]) penultimate})
+ * may return {@code null} if the underlying array contains {@code null} at that position, since they
+ * simply reflect the array's contents. Methods returning {@code Optional<T>} (e.g.,
+ * {@link #firstIfPresent(Object[]) firstIfPresent}, {@link #lastIfPresent(Object[]) lastIfPresent})
+ * will instead throw {@link NullPointerException} in that same situation, since {@code Optional} cannot
+ * represent a {@code null} value.
  */
 @UtilityClass
 public class KiwiArrays {
@@ -211,7 +219,7 @@ public class KiwiArrays {
      *
      * @param items the array
      * @param <T>   the type of items in the array
-     * @return Optional containing last element if exists, otherwise Optional.empty()
+     * @return Optional containing the last element if it exists, otherwise Optional.empty()
      */
     public static <T> Optional<T> lastIfPresent(T[] items) {
         return isNotNullOrEmpty(items) ? Optional.of(last(items)) : Optional.empty();

--- a/src/main/java/org/kiwiproject/collect/KiwiLists.java
+++ b/src/main/java/org/kiwiproject/collect/KiwiLists.java
@@ -19,6 +19,14 @@ import java.util.stream.IntStream;
 
 /**
  * Utility methods for working with {@link List} instances.
+ * <p>
+ * <strong>Note</strong>: accessor methods that return {@code T} directly (e.g., {@link #first(List) first},
+ * {@link #second(List) second}, {@link #third(List) third}, {@link #penultimate(List) penultimate}) may return
+ * {@code null} if the underlying list contains {@code null} at that position, since they
+ * simply reflect the list's contents. Methods returning {@code Optional<T>} (e.g.
+ * {@link #firstIfPresent(List) firstIfPresent}, {@link #lastIfPresent(List)} lastIfPresent) will instead throw
+ * {@link NullPointerException} in that same situation, since {@code Optional} cannot
+ * represent a {@code null} value.
  */
 @UtilityClass
 public class KiwiLists {
@@ -207,7 +215,7 @@ public class KiwiLists {
      *
      * @param items the list
      * @param <T>   the type of items in the list
-     * @return Optional containing last element if exists, otherwise Optional.empty()
+     * @return Optional containing the last element if it exists, otherwise Optional.empty()
      */
     public static <T> Optional<T> lastIfPresent(List<T> items) {
         return isNotNullOrEmpty(items) ? Optional.of(last(items)) : Optional.empty();


### PR DESCRIPTION
Add a top-level Javadoc note to KiwiLists and KiwiArrays explaining that while certain methods (first, second, ...) that return a "T" object may return null, methods that return Optional<T> like firstIfPresent and lastIfPresent will throw an NPE if a first (or last) element exists and is null.

Also, fix a minor grammatical error on the lastIfPresent method in both KiwiLists and KiwiArrays.