### PR TITLE
deps: Remove explicit version for com.github.mwiede:jsch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
         <kiwi-bom.version>3.3.2</kiwi-bom.version>
 
         <!-- Versions for provided dependencies -->
-        <mwiede-jsch.version>2.28.6</mwiede-jsch.version>
         <retrying-again.version>2.1.15</retrying-again.version>
 
         <!-- Versions for test dependencies -->
@@ -148,7 +147,6 @@
         <dependency>
             <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <version>${mwiede-jsch.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
This is now managed in kiwi-bom.

Closes #1458